### PR TITLE
JavaDoc generation by 'mvn site'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,14 @@
                     <linkXRef>false</linkXRef>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
+            </plugin>
         </plugins>
     </reporting>
 

--- a/pom.xml
+++ b/pom.xml
@@ -586,6 +586,22 @@
                 <configuration>
                     <doclint>none</doclint>
                 </configuration>
+                <reportSets>
+                    <!-- Generate aggregated apidocs at root level only and omit testapidocs. -->
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Signed-off-by: Felix Hilgerdenaar <felix.hilgerdenaar@fokus.fraunhofer.de>

## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description
 * generation of apidocs by JavaDoc
 * generation triggered by `mvn site`
 * generate aggregated apidocs at root level only and omit testapidocs

## Issue(s) related to this PR

 * issue 37
 
## Affected parts of the online documentation

No parts are affected.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer
