### PR TITLE
fix(geomath): CartesianPolygon contains

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/CartesianPolygon.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/CartesianPolygon.java
@@ -15,8 +15,6 @@
 
 package org.eclipse.mosaic.lib.geo;
 
-import org.eclipse.mosaic.lib.math.Vector3d;
-import org.eclipse.mosaic.lib.spatial.Ray;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,25 +77,63 @@ public class CartesianPolygon implements Polygon<CartesianPoint>, CartesianArea 
 
     @Override
     public boolean contains(CartesianPoint point) {
-        final Ray rayFromPoint = new Ray();
-        point.toVector3d(rayFromPoint.origin);
-        rayFromPoint.origin.set(point.getX(), 0, -point.getY());
-        rayFromPoint.direction.set(1, 0, 0);
+        float[] verticesXValues = new float[vertices.size()];
+        float[] verticesYValues = new float[vertices.size()];
 
-        int intersections = 0;
-        final Vector3d edgeStart = new Vector3d();
-        final Vector3d edgeEnd = new Vector3d();
-        CartesianPoint prev = null;
-        for (CartesianPoint curr : getVertices()) {
-            if (prev != null) {
-                edgeStart.set(prev.getX(), 0, -prev.getY());
-                edgeEnd.set(curr.getX(), 0, -curr.getY());
-                boolean intersect = rayFromPoint.intersectsLineSegmentXZ(edgeStart, edgeEnd);
-                intersections += intersect ? 1 : 0;
-            }
-            prev = curr;
+        for (int i = 0; i < vertices.size(); i++) {
+            CartesianPoint geoPoint = vertices.get(i);
+            verticesXValues[i] = (float) geoPoint.getX();
+            verticesYValues[i] = (float) geoPoint.getY();
         }
-        return intersections % 2 != 0;
+
+        return pnpoly(vertices.size(), verticesXValues, verticesYValues, (float) point.getX(), (float) point.getY());
+    }
+
+    /** Point Inclusion in Polygon Test.
+     * Defines if a points lies within a polygon
+     * @param nvert Number of vertices in the polygon. Whether to repeat the first vertex at the end is discussed below.
+     * @param vertx Array containing the x-coordinates of the polygon's vertices.
+     * @param verty Array containing the y-coordinates of the polygon's vertices.
+     * @param testx X-coordinate of the test point.
+     * @param testy Y-coordinate of the test point.
+     * @return true if point lies within the polygon, false otherwise
+     */
+    private boolean pnpoly(int nvert, float[] vertx, float[] verty, float testx, float testy) {
+        float minXValue = getMinValue(vertx);
+        float minYValue = getMinValue(verty);
+
+        boolean c = false;
+        for (int i = 0, j = nvert - 1; i < nvert; j = i++) {
+            boolean conditionXAxis;
+            boolean conditionYAxis;
+
+            if (testx <= minXValue) {
+                conditionXAxis = testx < (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) + vertx[i];
+            } else {
+                conditionXAxis = testx <= (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) + vertx[i];
+            }
+
+            if (testy <= minYValue) {
+                conditionYAxis = verty[i] > testy != verty[j] > testy;
+            } else {
+                conditionYAxis = verty[i] >= testy != verty[j] >= testy;
+            }
+
+            if (conditionYAxis && conditionXAxis) {
+                c = !c;
+            }
+        }
+        return c;
+    }
+
+    private float getMinValue(float[] numbers) {
+        float minValue = numbers[0];
+        for (int i = 1; i < numbers.length; i++) {
+            if (numbers[i] < minValue) {
+                minValue = numbers[i];
+            }
+        }
+        return minValue;
     }
 
     public GeoPolygon toGeo() {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/CartesianPolygon.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/CartesianPolygon.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mosaic.lib.geo;
 
+import org.eclipse.mosaic.lib.math.MathUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,55 +87,9 @@ public class CartesianPolygon implements Polygon<CartesianPoint>, CartesianArea 
             verticesYValues[i] = (float) geoPoint.getY();
         }
 
-        return pnpoly(vertices.size(), verticesXValues, verticesYValues, (float) point.getX(), (float) point.getY());
+        return MathUtils.pnpoly(vertices.size(), verticesXValues, verticesYValues, (float) point.getX(), (float) point.getY());
     }
 
-    /** Point Inclusion in Polygon Test.
-     * Defines if a points lies within a polygon
-     * @param nvert Number of vertices in the polygon. Whether to repeat the first vertex at the end is discussed below.
-     * @param vertx Array containing the x-coordinates of the polygon's vertices.
-     * @param verty Array containing the y-coordinates of the polygon's vertices.
-     * @param testx X-coordinate of the test point.
-     * @param testy Y-coordinate of the test point.
-     * @return true if point lies within the polygon, false otherwise
-     */
-    private boolean pnpoly(int nvert, float[] vertx, float[] verty, float testx, float testy) {
-        float minXValue = getMinValue(vertx);
-        float minYValue = getMinValue(verty);
-
-        boolean c = false;
-        for (int i = 0, j = nvert - 1; i < nvert; j = i++) {
-            boolean conditionXAxis;
-            boolean conditionYAxis;
-
-            if (testx <= minXValue) {
-                conditionXAxis = testx < (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) + vertx[i];
-            } else {
-                conditionXAxis = testx <= (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) + vertx[i];
-            }
-
-            if (testy <= minYValue) {
-                conditionYAxis = verty[i] > testy != verty[j] > testy;
-            } else {
-                conditionYAxis = verty[i] >= testy != verty[j] >= testy;
-            }
-
-            if (conditionYAxis && conditionXAxis) {
-                c = !c;
-            }
-        }
-        return c;
-    }
-
-    private float getMinValue(float[] numbers) {
-        float minValue = numbers[0];
-        for (int i = 1; i < numbers.length; i++) {
-            if (numbers[i] < minValue) {
-                minValue = numbers[i];
-            }
-        }
-        return minValue;
-    }
 
     public GeoPolygon toGeo() {
         return new GeoPolygon(

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/GeoPolygon.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/geo/GeoPolygon.java
@@ -15,8 +15,7 @@
 
 package org.eclipse.mosaic.lib.geo;
 
-import org.eclipse.mosaic.lib.math.Vector3d;
-import org.eclipse.mosaic.lib.spatial.Ray;
+import org.eclipse.mosaic.lib.math.MathUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,25 +79,19 @@ public class GeoPolygon implements Polygon<GeoPoint>, GeoArea {
 
     @Override
     public boolean contains(GeoPoint point) {
-        final Ray rayFromPoint = new Ray();
-        point.toVector3d(rayFromPoint.origin);
-        rayFromPoint.origin.set(point.getLongitude(), 0, -point.getLatitude());
-        rayFromPoint.direction.set(1, 0, 0);
+        float[] verticesXValues = new float[vertices.size()];
+        float[] verticesYValues = new float[vertices.size()];
 
-        int intersections = 0;
-        final Vector3d edgeStart = new Vector3d();
-        final Vector3d edgeEnd = new Vector3d();
-        GeoPoint prev = null;
-        for (GeoPoint curr : getVertices()) {
-            if (prev != null) {
-                edgeStart.set(prev.getLongitude(), 0, -prev.getLatitude());
-                edgeEnd.set(curr.getLongitude(), 0, -curr.getLatitude());
-                boolean intersect = rayFromPoint.intersectsLineSegmentXZ(edgeStart, edgeEnd);
-                intersections += intersect ? 1 : 0;
-            }
-            prev = curr;
+        for (int i = 0; i < vertices.size(); i++) {
+            GeoPoint geoPoint = vertices.get(i);
+            verticesXValues[i] = (float) geoPoint.toCartesian().getX();
+            verticesYValues[i] = (float) geoPoint.toCartesian().getY();
         }
-        return intersections % 2 != 0;
+
+        return MathUtils.pnpoly(
+                vertices.size(), verticesXValues, verticesYValues,
+                (float) point.toCartesian().getX(), (float) point.toCartesian().getY()
+        );
     }
 
     public CartesianPolygon toCartesian() {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MathUtils.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MathUtils.java
@@ -167,4 +167,51 @@ public class MathUtils {
         }
     }
 
+    /** Point Inclusion in Polygon Test.
+     * Defines if a points lies within a polygon
+     * @param nvert Number of vertices in the polygon. Whether to repeat the first vertex at the end is discussed below.
+     * @param vertx Array containing the x-coordinates of the polygon's vertices.
+     * @param verty Array containing the y-coordinates of the polygon's vertices.
+     * @param testx X-coordinate of the test point.
+     * @param testy Y-coordinate of the test point.
+     * @return true if point lies within the polygon, false otherwise
+     */
+    public static boolean pnpoly(int nvert, float[] vertx, float[] verty, float testx, float testy) {
+        float minXValue = getMinValue(vertx);
+        float minYValue = getMinValue(verty);
+
+        boolean c = false;
+        for (int i = 0, j = nvert - 1; i < nvert; j = i++) {
+            boolean conditionXAxis;
+            boolean conditionYAxis;
+
+            if (testx <= minXValue) {
+                conditionXAxis = testx < (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) + vertx[i];
+            } else {
+                conditionXAxis = testx <= (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) + vertx[i];
+            }
+
+            if (testy <= minYValue) {
+                conditionYAxis = verty[i] > testy != verty[j] > testy;
+            } else {
+                conditionYAxis = verty[i] >= testy != verty[j] >= testy;
+            }
+
+            if (conditionYAxis && conditionXAxis) {
+                c = !c;
+            }
+        }
+        return c;
+    }
+
+    private static float getMinValue(float[] numbers) {
+        float minValue = numbers[0];
+        for (int i = 1; i < numbers.length; i++) {
+            if (numbers[i] < minValue) {
+                minValue = numbers[i];
+            }
+        }
+        return minValue;
+    }
+
 }

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/geo/PolygonTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/geo/PolygonTest.java
@@ -121,8 +121,10 @@ public class PolygonTest {
 
         assertTrue(polygon.contains(xy(10, 6)));
         assertTrue(polygon.contains(xy(11, 12)));
+        assertTrue(polygon.contains(xy(10, 14)));
         assertTrue(polygon.contains(xy(5, 6)));
 
+        assertFalse(polygon.contains(xy(8, 14)));
         assertFalse(polygon.contains(xy(2, 6)));
         assertFalse(polygon.contains(xy(8, 6)));
         assertFalse(polygon.contains(xy(1, 3)));
@@ -130,4 +132,39 @@ public class PolygonTest {
         assertFalse(polygon.contains(xy(9, 16)));
     }
 
+    @Test
+    public void containsPointsRectangle() {
+        CartesianPolygon polygon = new CartesianRectangle(
+                xy(3, 5),
+                xy(7, 1)
+        ).toPolygon();
+
+        // Outside x-axis
+        assertFalse(polygon.contains(xy(2, 5)));
+        assertFalse(polygon.contains(xy(2, 1)));
+        assertFalse(polygon.contains(xy(8, 1)));
+        assertFalse(polygon.contains(xy(8, 5)));
+
+        // Outside y-axis
+        assertFalse(polygon.contains(xy(7, 0)));
+        assertFalse(polygon.contains(xy(7, 6)));
+        assertFalse(polygon.contains(xy(3, 0)));
+        assertFalse(polygon.contains(xy(3, 6)));
+
+
+        // Inside polygon
+        assertTrue(polygon.contains(xy(4, 4)));
+
+        // Polygon vertices
+        assertTrue(polygon.contains(xy(3, 5)));
+        assertTrue(polygon.contains(xy(3, 1)));
+        assertTrue(polygon.contains(xy(7, 5)));
+        assertTrue(polygon.contains(xy(7, 1)));
+
+        // Polygon edges
+        assertTrue(polygon.contains(xy(6, 1))); // lower limit
+        assertTrue(polygon.contains(xy(6, 5))); // upper limit
+        assertTrue(polygon.contains(xy(3, 3))); // left limit
+        assertTrue(polygon.contains(xy(7, 3))); // right limit
+    }
 }


### PR DESCRIPTION
Signed-off-by: Pablo Osinaga <pablo.alberto.osinaga@fokus.fraunhofer.de>

## Type of this PR 

- [X] Bug fix
- [ ] Enhancement

## Description

Replace current implementation of the `contains` method in the `CartesianPolygon` class with a [PNPOLY algorithm](https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html) implementation.

## Issue(s) related to this PR

Resolves internal issue 47.

## Affected parts of the online documentation

No.

## Definition of Done

- [X] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [X] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [X] `origin/main` has been merged into your Fork.
- [X] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

