### PR TITLE
Use python3 in ns3_installer.sh

### DIFF
--- a/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
+++ b/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
@@ -45,7 +45,7 @@ arg_federate_file=""
 arg_integration_testing=false
 arg_make_parallel=""
 
-required_programs=( python2 gcc unzip tar )
+required_programs=( python3 gcc unzip tar )
 required_libraries=( "libprotobuf-dev (or equal) 3.3.0" "libxml2-dev (or equal)" "libsqlite3-dev (or equal)" )
 
 ####### configurable parameters ##########
@@ -361,7 +361,7 @@ build_ns3()
   cd "${ns3_installation_path}/ns-allinone-${ns3_version}"
 
   # ns-3 prior to 3.28.1 does not compile without warnings using g++ 10.2.0
-  CXXFLAGS="-Wno-error" python2 ./build.py --disable-netanim
+  CXXFLAGS="-Wno-error" python3 ./build.py --disable-netanim
 
   log "Build ns3-federate"
   cd ${current_dir}/federate


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix

## Description

Python2 already reached EOL in January. This PR adjusts the ns3_installer.sh script to use python3 instead of python2

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

