### PR TITLE
Upgrade to SUMO 1.8.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.7.0
+    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.8.0
     command:
     - cat
     tty: true

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For a successful build you need the following software to be installed:
 
 * **Maven 3.1.x** or higher.
 * **Java 8 or 11** - We recommend using the [Adopt OpenJDK](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot).
-* **SUMO 1.7.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
+* **SUMO 1.8.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
 
 ## Build
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/traci/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/traci/SumoVersion.java
@@ -32,6 +32,7 @@ public enum SumoVersion {
     SUMO_1_5_x("1.5.*", TraciVersion.API_20),
     SUMO_1_6_x("1.6.*", TraciVersion.API_20),
     SUMO_1_7_x("1.7.*", TraciVersion.API_20),
+    SUMO_1_8_x("1.8.*", TraciVersion.API_20),
 
     /**
      * the lowest version supported by this client.
@@ -41,7 +42,7 @@ public enum SumoVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(SUMO_1_7_x.sumoVersion, SUMO_1_7_x.traciVersion);
+    HIGHEST(SUMO_1_8_x.sumoVersion, SUMO_1_8_x.traciVersion);
 
     private final String sumoVersion;
     private final TraciVersion traciVersion;
@@ -76,7 +77,7 @@ public enum SumoVersion {
         return UNKNOWN;
     }
 
-    private final static Pattern VERSION_PATTERN = Pattern.compile("^SUMO v([0-9]\\.[0-9])\\..*$");
+    private final static Pattern VERSION_PATTERN = Pattern.compile("^SUMO v?([0-9]\\.[0-9])\\..*$");
 
     private static boolean matches(String sumoVersionString, String sumoVersionPattern) {
         final Matcher matcher = VERSION_PATTERN.matcher(sumoVersionString);

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -1,0 +1,8 @@
+FROM maven:3.6.3-adoptopenjdk-8
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --allow-unauthenticated software-properties-common && \
+    add-apt-repository ppa:sumo/stable && \
+    apt-get install -y sumo

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -1,0 +1,21 @@
+# Docker image for Jenkins build
+
+This docker image is used by the Jenkins job on https://ci.eclipse.org/mosaic/job/mosaic/ to execute maven 
+builds and to provide a SUMO executable for integration tests.
+
+The `Dockerfile` is kept very simple, which is sufficient for now. SUMO devs push pre-compiled executable to 
+https://launchpad.net/~sumo/+archive/ubuntu/stable . The dockerfile grabs the latest stable one and installs it on top
+of the `maven:3.6.3-adoptopenjdk-8` image. As a consequence we cannot define a specific version to be installed, but rather
+build and tag the docker image with the latest SUMO version. This image should be built whenever a new major version of SUMO is released
+and available in the PPA.
+
+```shell script
+docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.8.0
+docker login
+docker push eclipsemosaic/mosaic-ci
+```  
+
+Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags
+
+The image is referred in the `Jenkinsfile` in the root of this repository and should be updated too, in order to test if Eclipse MOSAIC 
+is compatible with the latest SUMO version.


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

This PR upgrades code and CI to work with new stable version of SUMO 1.8.0
  * All tests are successful, no need to adjust code to be compatible with the new version.
  * The docker image used by the Jenkins pipeline has been upgraded to use SUMO 1.8.0 as well (https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags). The Dockerfile used for this image is now part of this repository.

## Issue(s) related to this PR

 * - 
 
## Affected parts of the online documentation

Yes, will be updated asap.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

