### PR TITLE
Removed Transitive dependencies from parent POM

### DIFF
--- a/NOTICE-THIRD-PARTY.md
+++ b/NOTICE-THIRD-PARTY.md
@@ -245,10 +245,10 @@ Protocol Buffers [Core] (3.8.0)
  * Source: https://github.com/protocolbuffers/protobuf/protobuf-java
 
 
-SLF4J API Module (1.7.30)
+SLF4J API Module (1.7.25)
 
  * License: MIT License
- * Maven artifact: `org.slf4j:slf4j-api:1.7.30`
+ * Maven artifact: `org.slf4j:slf4j-api:1.7.25`
  * Project: http://www.slf4j.org
  * Source: https://github.com/qos-ch/slf4j/slf4j-api
 

--- a/lib/mosaic-docker/pom.xml
+++ b/lib/mosaic-docker/pom.xml
@@ -15,8 +15,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,28 +115,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <!-- PURPOSE: Logging API -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${version.slf4j}</version>
-        </dependency>
-
-        <dependency>
-            <!-- PURPOSE: Apache 2.0 licensed implementation of the findbugs annotations -->
-            <groupId>com.github.stephenc.findbugs</groupId>
-            <artifactId>findbugs-annotations</artifactId>
-            <version>${version.findbugs-annotations}</version>
-        </dependency>
-
-        <dependency>
-            <!-- PURPOSE: General Purpose functions -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${version.commons-lang3}</version>
-        </dependency>
-
-
         <!-- testing -->
         <dependency>
             <!-- PURPOSE: JUnit -->
@@ -169,6 +147,13 @@
                 <version>${version.logback}</version>
             </dependency>
             <dependency>
+                <!-- PURPOSE: Logging API -->
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.slf4j}</version>
+            </dependency>
+
+            <dependency>
                 <!-- PURPOSE: Required for providing variables in logback.xml -->
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>janino</artifactId>
@@ -180,6 +165,20 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${version.protobuf}</version>
+            </dependency>
+
+            <dependency>
+                <!-- PURPOSE: Apache 2.0 licensed implementation of the findbugs annotations -->
+                <groupId>com.github.stephenc.findbugs</groupId>
+                <artifactId>findbugs-annotations</artifactId>
+                <version>${version.findbugs-annotations}</version>
+            </dependency>
+
+            <dependency>
+                <!-- PURPOSE: General Purpose functions -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${version.commons-lang3}</version>
             </dependency>
 
             <dependency>
@@ -528,7 +527,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/rti/mosaic-rti-api/pom.xml
+++ b/rti/mosaic-rti-api/pom.xml
@@ -15,12 +15,24 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.findbugs</groupId>
+            <artifactId>findbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.mosaic</groupId>


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

This PR removes the depedencies for `slf4j-api`, `commons-lang3`, and `findbugs-annotations` from the parent pom.xml and adds them to the modules which requires them.

## Issue(s) related to this PR

 * Link to [Eclipse Mosaic repository](https://github.com/eclipse/mosaic/issues) issue
 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

