### PR TITLE
Use cartesian geometry in SNS to check reachability

### DIFF
--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SimulationEntities.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SimulationEntities.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.mosaic.fed.sns.ambassador;
 
-import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.geo.CartesianPoint;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +34,7 @@ enum SimulationEntities {
     /**
      * Offline nodes (may get switched on).
      */
-    private final HashMap<String, GeoPoint> offlineNodes = new HashMap<>();
+    private final HashMap<String, CartesianPoint> offlineNodes = new HashMap<>();
 
     /**
      * Gets all nodes currently known as online (initialized, Wifi enabled) in the simulation.
@@ -73,7 +73,7 @@ enum SimulationEntities {
      * @param position position of the node
      * @param radius   transmission radius of the node
      */
-    public void createOnlineNode(String nodeName, GeoPoint position, double radius) {
+    public void createOnlineNode(String nodeName, CartesianPoint position, double radius) {
         if (nodeName != null && position != null) {
             SimulationNode nodeData = new SimulationNode();
             nodeData.setPosition(position);
@@ -90,7 +90,7 @@ enum SimulationEntities {
      * @param nodeName identifier of the node to be updated
      * @param position the updated position
      */
-    public void updateOnlineNode(String nodeName, GeoPoint position) {
+    public void updateOnlineNode(String nodeName, CartesianPoint position) {
         if (nodeName != null && position != null) {
             onlineNodes.get(nodeName).setPosition(position);
         } else {
@@ -104,7 +104,7 @@ enum SimulationEntities {
      * @param nodeName identifier of the node to be updated
      * @param position the updated position
      */
-    public void createOrUpdateOfflineNode(String nodeName, GeoPoint position) {
+    public void createOrUpdateOfflineNode(String nodeName, CartesianPoint position) {
         if (nodeName != null && position != null) {
             offlineNodes.put(nodeName, position);
         } else {
@@ -148,30 +148,6 @@ enum SimulationEntities {
             offlineNodes.put(nodeName, onlineNodes.get(nodeName).getPosition());
             onlineNodes.remove(nodeName);
         }
-    }
-
-    /**
-     * Returns the position of a node from the position table.
-     * Returns null if the node is non existing.
-     *
-     * @param nodeId Name of the node.
-     * @return Position of the node, null if non existing.
-     */
-    public GeoPoint getPositionOfNode(String nodeId) {
-        SimulationNode node = onlineNodes.get(nodeId);
-        return node != null ? node.getPosition() : null;
-    }
-
-    /**
-     * Returns the communication radius (for single hop) of a node.
-     * Returns null if the node is non existing.
-     *
-     * @param nodeId Name of the node.
-     * @return Position of the node, null if non existing.
-     */
-    public double getRadiusOfNode(String nodeId) {
-        SimulationNode node = onlineNodes.get(nodeId);
-        return node != null ? node.getRadius() : 0.0;
     }
 
     /**

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SimulationNode.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SimulationNode.java
@@ -15,7 +15,7 @@
 
 package org.eclipse.mosaic.fed.sns.ambassador;
 
-import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.geo.CartesianPoint;
 
 /**
  * Aspects of an active simulation entity in SNS (position, communication radius).
@@ -25,14 +25,14 @@ public class SimulationNode {
     /**
      * Position of a node.
      */
-    private GeoPoint position;
+    private CartesianPoint position;
 
     /**
      * Transmission radius of a node.
      */
     private double radius;
 
-    public GeoPoint getPosition() {
+    public CartesianPoint getPosition() {
         return position;
     }
 
@@ -40,7 +40,7 @@ public class SimulationNode {
         return radius;
     }
 
-    void setPosition(GeoPoint position) {
+    void setPosition(CartesianPoint position) {
         this.position = position;
     }
 

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/SophisticatedAdhocTransmissionModel.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/SophisticatedAdhocTransmissionModel.java
@@ -17,9 +17,9 @@ package org.eclipse.mosaic.fed.sns.model;
 
 import org.eclipse.mosaic.fed.sns.ambassador.SimulationNode;
 import org.eclipse.mosaic.fed.sns.ambassador.TransmissionSimulator;
-import org.eclipse.mosaic.lib.geo.GeoArea;
-import org.eclipse.mosaic.lib.geo.GeoCircle;
-import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.geo.CartesianArea;
+import org.eclipse.mosaic.lib.geo.CartesianCircle;
+import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.misc.Tuple;
 import org.eclipse.mosaic.lib.model.delay.Delay;
 import org.eclipse.mosaic.lib.model.transmission.TransmissionResult;
@@ -121,7 +121,7 @@ public class SophisticatedAdhocTransmissionModel extends AdhocTransmissionModel 
 
             // do this for all of the currently sending entities
             for (Map.Entry<String, SimulationNode> floodingEntityEntry : floodingEntities.entrySet()) {
-                GeoArea singleHopReachArea = new GeoCircle(
+                CartesianArea singleHopReachArea = new CartesianCircle(
                         floodingEntityEntry.getValue().getPosition(),
                         floodingEntityEntry.getValue().getRadius()
                 );
@@ -187,7 +187,7 @@ public class SophisticatedAdhocTransmissionModel extends AdhocTransmissionModel 
             ++currentDepth;
 
             currentEntity = currentNodes.get(currentEntityName);
-            GeoCircle singleHopReach = new GeoCircle(
+            CartesianCircle singleHopReach = new CartesianCircle(
                     currentEntity.getPosition(),
                     currentEntity.getRadius()
             );
@@ -236,7 +236,7 @@ public class SophisticatedAdhocTransmissionModel extends AdhocTransmissionModel 
                                                     Map<String, SimulationNode> possibleReceivers,
                                                     Map<String, SimulationNode> currentNodes) {
         SimulationNode sender = currentNodes.get(senderName);
-        GeoPoint senderPosition = sender.getPosition();
+        CartesianPoint senderPosition = sender.getPosition();
         double senderRadius = sender.getRadius();
         for (SimulationNode receiver : possibleReceivers.values()) {
             if (senderPosition.distanceTo(receiver.getPosition()) <= senderRadius) {

--- a/fed/mosaic-sns/src/test/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModelTest.java
+++ b/fed/mosaic-sns/src/test/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModelTest.java
@@ -23,8 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.mosaic.fed.sns.ambassador.SimulationNode;
-import org.eclipse.mosaic.lib.geo.GeoArea;
-import org.eclipse.mosaic.lib.geo.GeoCircle;
+import org.eclipse.mosaic.lib.geo.CartesianArea;
+import org.eclipse.mosaic.lib.geo.CartesianCircle;
+import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.junit.GeoProjectionRule;
 import org.eclipse.mosaic.lib.math.DefaultRandomNumberGenerator;
@@ -57,7 +58,7 @@ public class AdhocTransmissionModelTest {
     private final Map<String, SimulationNode> nodesRandomlyDistributed = new HashMap<>();
 
     @Rule
-    public GeoProjectionRule coordinateTransformationRule = new GeoProjectionRule(GeoPoint.lonLat(13.3856, 52.5415));
+    public GeoProjectionRule coordinateTransformationRule = new GeoProjectionRule(GeoPoint.lonLat(15.48, 47.02));
 
     @Before
     public void setup() {
@@ -77,7 +78,7 @@ public class AdhocTransmissionModelTest {
         for (int i = 0; i < 21; ++i) {
             currentLatitude += 0.001;
             SimulationNode newNode = mock(SimulationNode.class);
-            when(newNode.getPosition()).thenReturn(GeoPoint.latLon(currentLatitude, currentLongitude));
+            when(newNode.getPosition()).thenReturn(GeoPoint.latLon(currentLatitude, currentLongitude).toCartesian());
             when(newNode.getRadius()).thenReturn(adhocRadius);
             allNodes.put("" + i, newNode);
             nodesInRow.add("" + i);
@@ -90,7 +91,7 @@ public class AdhocTransmissionModelTest {
             randomLatitude = rng.nextDouble(currentLatitude, currentLatitude + 0.005);
             randomLongitude = rng.nextDouble(currentLongitude - 0.0025, currentLongitude + 0.0025);
             SimulationNode newNode = mock(SimulationNode.class);
-            when(newNode.getPosition()).thenReturn(GeoPoint.latLon(randomLatitude, randomLongitude));
+            when(newNode.getPosition()).thenReturn(GeoPoint.latLon(randomLatitude, randomLongitude).toCartesian());
             when(newNode.getRadius()).thenReturn(adhocRadius);
             allNodes.put("" + i, newNode);
             nodesRandomlyDistributed.put("" + i, newNode);
@@ -146,10 +147,10 @@ public class AdhocTransmissionModelTest {
         // ASSERT
 
         // all entities within communication radius should receive message (units 0 to 4)
-        GeoPoint senderPosition = allNodes.get("0").getPosition();
+        CartesianPoint senderPosition = allNodes.get("0").getPosition();
         double senderRadius = allNodes.get("0").getRadius();
         for (Map.Entry<String, TransmissionResult> transmissionResultEntry : directTransmissionResults.entrySet()) {
-            GeoPoint receiverPosition = allNodes.get(transmissionResultEntry.getKey()).getPosition();
+            CartesianPoint receiverPosition = allNodes.get(transmissionResultEntry.getKey()).getPosition();
             if (senderPosition.distanceTo(receiverPosition) <= senderRadius) {
                 assertTrue(transmissionResultEntry.getValue().success);
             } else {
@@ -467,7 +468,7 @@ public class AdhocTransmissionModelTest {
 
     private Map<String, SimulationNode> getAllReceiversInRange(String senderName) {
         Map<String, SimulationNode> receivers = new HashMap<>();
-        GeoArea range = new GeoCircle(
+        CartesianArea range = new CartesianCircle(
                 allNodes.get(senderName).getPosition(),
                 allNodes.get(senderName).getRadius()
         );


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [x] Enhancement

## Description

SNS uses `GeoPoint` and `GeoArea` to check for reachability of nodes. This is highly inefficient. Using `CartesianPoint` and `CartesianArea` instead improves performance by factor 5.

## Issue(s) related to this PR

-
  
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

