### PR TITLE
Resolves "Mapping - Add Apps to all TrafficLights"

### DIFF
--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -122,10 +122,11 @@ public class SpawningFramework {
         }
         // Traffic lights
         if (mappingConfiguration.trafficLights != null) {
+            int i = 0;
             for (CTrafficLight trafficLightConfigurations : mappingConfiguration.trafficLights) {
                 if (trafficLightConfigurations != null) {
                     TrafficLightSpawner tl = new TrafficLightSpawner(trafficLightConfigurations);
-                    tls.put(tl.getTlName(), tl);
+                    tls.put(ObjectUtils.defaultIfNull(tl.getTlName(), Integer.toString(++i)), tl);
                 }
             }
         }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/TrafficLightSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/TrafficLightSpawner.java
@@ -43,7 +43,11 @@ public class TrafficLightSpawner extends UnitSpawner implements Weighted {
     public TrafficLightSpawner(CTrafficLight trafficLightConfiguration) {
         super(trafficLightConfiguration.applications, trafficLightConfiguration.name, trafficLightConfiguration.group);
         this.tlName = trafficLightConfiguration.tlGroupId;
-        this.weight = ObjectUtils.defaultIfNull(trafficLightConfiguration.weight, 0d);
+        if (this.tlName == null && trafficLightConfiguration.weight == null) {
+            this.weight = 1d;
+        } else {
+            this.weight = ObjectUtils.defaultIfNull(trafficLightConfiguration.weight, 0d);
+        }
     }
 
     public double getWeight() {

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -172,8 +172,7 @@
                 "group": { "type": "string" },
                 "weight": {
                     "type": "number",
-                    "minimum": 0,
-                    "maximum": 1
+                    "minimum": 0
                 },
                 "applications": {
                     "type": "array",

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -4,43 +4,43 @@
     "properties": {
         "prototypes": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/prototype" } ]
+            "items": { "$ref": "#/definitions/prototype" }
         },
         "typeDistributions": {
             "type": "object",
-            "items": [ { "$ref": "#/definitions/typeDistribution" } ]
+            "items": { "$ref": "#/definitions/typeDistribution" }
         },
         "rsus": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/rsu" } ]
+            "items": { "$ref": "#/definitions/rsu" }
         },
         "tmcs": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/tmc" } ]
+            "items": { "$ref": "#/definitions/tmc" }
         },
         "servers": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/server" } ]
+            "items": { "$ref": "#/definitions/server" }
         },
         "trafficLights": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/tl" } ]
+            "items": { "$ref": "#/definitions/tl" }
         },
         "vehicles": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/vehicle" } ]
+            "items": { "$ref": "#/definitions/vehicle" }
         },
         "chargingStations": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/chargingStation" } ]
+            "items": { "$ref": "#/definitions/chargingStation" }
         },
         "matrixMappers": {
             "type": "array",
-            "items": [ { "$ref": "#/definitions/matrixMapper" } ]
+            "items": { "$ref": "#/definitions/matrixMapper" }
         },
         "config": {
             "type": "object",
-            "items": [ { "$ref": "#/definitions/config" } ]
+            "items": { "$ref": "#/definitions/config" }
         }
     },
     "definitions": {

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFrameworkTrafficLightTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFrameworkTrafficLightTest.java
@@ -1,0 +1,127 @@
+package org.eclipse.mosaic.fed.mapping.ambassador;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.mosaic.fed.mapping.config.CMappingAmbassador;
+import org.eclipse.mosaic.fed.mapping.config.units.CTrafficLight;
+import org.eclipse.mosaic.interactions.mapping.TrafficLightRegistration;
+import org.eclipse.mosaic.interactions.mapping.advanced.ScenarioTrafficLightRegistration;
+import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.math.DefaultRandomNumberGenerator;
+import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
+import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLight;
+import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
+import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightProgram;
+import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightState;
+import org.eclipse.mosaic.rti.api.IllegalValueException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+import org.eclipse.mosaic.rti.api.RtiAmbassador;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link SpawningFramework}.
+ */
+public class SpawningFrameworkTrafficLightTest {
+
+    @Mock
+    public RtiAmbassador rti;
+
+    private RandomNumberGenerator rng;
+
+    @Before
+    public void setup() {
+        rng = new DefaultRandomNumberGenerator(0L);
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void initAppsWithoutWeight() throws InternalFederateException, IllegalValueException {
+        //SETUP
+        CMappingAmbassador mappingConfig = new CMappingAmbassador();
+        mappingConfig.trafficLights = new ArrayList();
+        mappingConfig.trafficLights.add(newTlConfig(null, null, "app_1"));
+        mappingConfig.trafficLights.add(newTlConfig( null, null, "app_2"));
+        ScenarioTrafficLightRegistration tlRegistration = newTlRegistration(1000);
+        ArgumentCaptor<TrafficLightRegistration> captor = ArgumentCaptor.forClass(TrafficLightRegistration.class);
+
+        //RUN
+        SpawningFramework spawningFramework = new SpawningFramework(mappingConfig, tlRegistration, rti, rng);
+        spawningFramework.timeAdvance(0, rti, rng);
+
+        //ASSERT
+        verify(rti, times(1000)).triggerInteraction(captor.capture());
+        List <TrafficLightRegistration> tlrs = captor.getAllValues();
+        Assert.assertEquals(countAppInTlr(tlrs, "app_1") / 1000d, 0.5d, 0.02d);
+        Assert.assertEquals(countAppInTlr(tlrs, "app_2") / 1000d, 0.5d, 0.02d);
+    }
+
+    @Test
+    public void initAppsWithWeightAndTlGroupId() throws InternalFederateException, IllegalValueException {
+        //SETUP
+        CMappingAmbassador mappingConfig = new CMappingAmbassador();
+        mappingConfig.trafficLights = new ArrayList();
+        mappingConfig.trafficLights.add(newTlConfig(null, 0.2, "app_1"));
+        mappingConfig.trafficLights.add(newTlConfig( null, 0.8, "app_2"));
+        mappingConfig.trafficLights.add(newTlConfig( "13", null, "app_3"));
+        ScenarioTrafficLightRegistration tlRegistration = newTlRegistration(1000);
+        ArgumentCaptor<TrafficLightRegistration> captor = ArgumentCaptor.forClass(TrafficLightRegistration.class);
+
+        //RUN
+        SpawningFramework spawningFramework = new SpawningFramework(mappingConfig, tlRegistration, rti, rng);
+        spawningFramework.timeAdvance(0, rti, rng);
+
+        //ASSERT
+        verify(rti, times(1000)).triggerInteraction(captor.capture());
+        List <TrafficLightRegistration> tlrs = captor.getAllValues();
+        Assert.assertEquals(countAppInTlr(tlrs, "app_1") / 1000d, 0.2d, 0.02d);
+        Assert.assertEquals(countAppInTlr(tlrs, "app_2") / 1000d, 0.8d, 0.02d);
+        Assert.assertEquals(tlrs.get(13).getMapping().getApplications().get(0), "app_3");
+    }
+
+    private int countAppInTlr(List <TrafficLightRegistration> tlrs, String app){
+        int app_occurences = 0;
+        for (TrafficLightRegistration tlr : tlrs) {
+            if (tlr.getMapping().getApplications().get(0).equals(app)) {
+                app_occurences += 1;
+            }
+        }
+        return app_occurences;
+    }
+
+    private CTrafficLight newTlConfig(String tlGroupId, Double weight, String application){
+        CTrafficLight trafficLightConfiguration = new CTrafficLight();
+        trafficLightConfiguration.tlGroupId = tlGroupId;
+        trafficLightConfiguration.weight = weight;
+        trafficLightConfiguration.applications = Arrays.asList(application);
+        return trafficLightConfiguration;
+    }
+
+    public static ScenarioTrafficLightRegistration newTlRegistration(int numberTlGroups) {
+        Map<String, Collection<String>> lanes = Maps.newHashMap();
+        lanes.put("0", Lists.newArrayList("0"));
+        Map<String, TrafficLightProgram> programs = new HashMap<>();
+        List<TrafficLight> trafficLights = Lists.newArrayList(new TrafficLight(0, null, null, null, null));
+        List<TrafficLightGroup> tlGroups = new ArrayList<>();
+        for(int i=0; i<numberTlGroups; i++){
+            tlGroups.add(new TrafficLightGroup(Integer.toString(i), programs , trafficLights));
+        }
+        return new ScenarioTrafficLightRegistration(0, tlGroups, lanes);
+    }
+
+}

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFrameworkTrafficLightTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFrameworkTrafficLightTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
 package org.eclipse.mosaic.fed.mapping.ambassador;
 
 import static org.mockito.Mockito.times;
@@ -7,13 +22,11 @@ import org.eclipse.mosaic.fed.mapping.config.CMappingAmbassador;
 import org.eclipse.mosaic.fed.mapping.config.units.CTrafficLight;
 import org.eclipse.mosaic.interactions.mapping.TrafficLightRegistration;
 import org.eclipse.mosaic.interactions.mapping.advanced.ScenarioTrafficLightRegistration;
-import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.math.DefaultRandomNumberGenerator;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLight;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightProgram;
-import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightState;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/DepartSpeedTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/DepartSpeedTest.java
@@ -81,16 +81,8 @@ public class DepartSpeedTest {
     }
 
     @Test
-    public void checkWrongDepartSpeedMode() {
-        CVehicle vehicle = mapping.vehicles.get(3);
-        assertNotEquals(vehicle, null);
-        assertEquals(0, vehicle.departSpeed, 0);
-        assertEquals(VehicleDeparture.DepartSpeedMode.MAXIMUM, vehicle.departSpeedMode);
-    }
-
-    @Test
     public void checkNoDepartSpeedMode() {
-        CVehicle vehicle = mapping.vehicles.get(4);
+        CVehicle vehicle = mapping.vehicles.get(3);
         assertNotEquals(vehicle, null);
         assertEquals(500, vehicle.departSpeed, 0);
         assertEquals(VehicleDeparture.DepartSpeedMode.MAXIMUM, vehicle.departSpeedMode);

--- a/fed/mosaic-mapping/src/test/resources/mapping/departspeed.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/departspeed.json
@@ -32,15 +32,6 @@
             ]
         },
         {
-            "departSpeedMode": "TOMATOJUICE",
-            "route": "1",
-            "types": [
-                {
-                    "name": "PKW"
-                }
-            ]
-        },
-        {
             "departSpeed": 500,
             "route": "1",
             "types": [


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

- It is now possible to add multiple apps distributed by weights to traffic lights. If the parameters"weight" and "tlGroupId" in the traffic light mapping, then the default value of the weight is 1. 
- The mapping schema was adapted, so that weights in the traffic light mapping can be bigger than 1

## Issue(s) related to this PR

 * Resolves issue #35
 
 
## Affected parts of the online documentation

Traffic light documentation in docs/simulators/application_simulator/

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

