### PR TITLE
Fixed issue with database which was created from Network file

### DIFF
--- a/app/tutorials/highway-management/src/main/java/org/eclipse/mosaic/app/tutorial/HighwayManagementApp.java
+++ b/app/tutorials/highway-management/src/main/java/org/eclipse/mosaic/app/tutorial/HighwayManagementApp.java
@@ -62,7 +62,7 @@ public class HighwayManagementApp extends AbstractApplication<TrafficManagementC
     private void closeEdges(Route routeToClose, int numberOfLanesToClose) {
         getLog().info("Closing {} lanes along route {}", numberOfLanesToClose, routeToClose.getId());
 
-        for (String edge : routeToClose.getEdgeIdList()) {
+        for (String edge : routeToClose.getEdgeIds()) {
             for (int lane = 0; lane < numberOfLanesToClose; lane++) {
                 getOs().changeLaneState(edge, lane).closeForAll();
             }
@@ -72,7 +72,7 @@ public class HighwayManagementApp extends AbstractApplication<TrafficManagementC
     private void openEdges(Route routeToClose, int numberOfLanesToClose) {
         getLog().info("Opening {} lanes along route {}", numberOfLanesToClose, routeToClose.getId());
 
-        for (String edge : routeToClose.getEdgeIdList()) {
+        for (String edge : routeToClose.getEdgeIds()) {
             for (int lane = 0; lane < numberOfLanesToClose; lane++) {
                 getOs().changeLaneState(edge, lane).openForAll();
             }

--- a/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/persistence/SQLiteLoader.java
+++ b/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/persistence/SQLiteLoader.java
@@ -835,7 +835,7 @@ public class SQLiteLoader extends SQLiteAccess implements DatabaseLoader {
             dbConnection.setAutoCommit(false);
             for (Route route : database.getRoutes()) {
                 sequenceNumber = 0;
-                for (Edge edge : route.getRoute()) {
+                for (Edge edge : route.getEdges()) {
                     prep.setString(1, route.getId());
                     prep.setInt(2, sequenceNumber);
                     prep.setString(3, edge.getConnection().getId());

--- a/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/route/Edge.java
+++ b/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/route/Edge.java
@@ -117,7 +117,7 @@ public class Edge {
      * @return true if the scenario is compatible
      */
     public static boolean isScenarioCompatible(@Nonnull String edgeId) {
-        return (edgeId.split("_").length >= 2);
+        return (edgeId.split("_").length == 4);
     }
 
     /**

--- a/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/route/Route.java
+++ b/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/route/Route.java
@@ -15,11 +15,11 @@
 
 package org.eclipse.mosaic.lib.database.route;
 
+import org.eclipse.mosaic.lib.database.road.Connection;
 import org.eclipse.mosaic.lib.database.road.Node;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -37,7 +37,6 @@ public class Route {
 
     /**
      * The list of edges the vehicles using this route have to drive.
-     * Each entry has the form connectionid_startnode
      */
     private final List<Edge> edgeList = new ArrayList<>();
 
@@ -63,12 +62,11 @@ public class Route {
 
     /**
      * This is the list of {@link Edge}s that form the route.
-     * The entries have the form connectionid_startnode
      *
      * @return list of edges
      */
     @Nonnull
-    public List<Edge> getRoute() {
+    public List<Edge> getEdges() {
         return Collections.unmodifiableList(edgeList);
     }
 
@@ -78,12 +76,12 @@ public class Route {
      * @return Extracted list of edge Ids.
      */
     @Nonnull
-    public List<String> getEdgeIdList() {
+    public List<String> getEdgeIds() {
         return edgeList.stream().map(Edge::getId).collect(Collectors.toList());
     }
 
     /**
-     * Add an {@link Edge} to the route. Mind the order of edges.
+     * Adds an {@link Edge} to the route.
      *
      * @param edge Edge to add.
      */
@@ -100,7 +98,7 @@ public class Route {
      * @return Extracted nodes.
      */
     @Nonnull
-    public List<Node> getNodeList() {
+    public List<Node> getNodes() {
         if (edgeList.isEmpty()) {
             return new ArrayList<>();
         } else {
@@ -110,32 +108,46 @@ public class Route {
         }
     }
 
+
+
     /**
      * This extracts a list of all node IDs this {@link Route} passes.
-     * So ALL the edges nodes, even those between intersections where a route could change!
      *
      * @return Extracted list of all node IDs.
      */
     @Nonnull
-    public List<String> getNodeIdList() {
-        return Collections.unmodifiableList(getNodeList().stream().map(Node::getId).collect(Collectors.toList()));
+    public List<String> getNodeIds() {
+        return Collections.unmodifiableList(getNodes().stream().map(Node::getId).collect(Collectors.toList()));
+    }
+
+    /**
+     * This extracts a list of {@link Connection}s that vehicles using this {@link Route} are passing. Multiple adjacent edges belonging to
+     * the same connection will result in only one occurrence of the connection.
+     *
+     * @return Extracted nodes.
+     */
+    @Nonnull
+    public List<Connection> getConnections() {
+        List<Connection> connections = new ArrayList<>();
+        Connection lastConnection = null;
+        for (Edge edge : edgeList) {
+            if (lastConnection != edge.getConnection()) {
+                connections.add(edge.getConnection());
+            }
+            lastConnection = edge.getConnection();
+        }
+        return connections;
     }
 
     /**
      * This extracts a list of connection IDs. Multiple adjacent edges belonging to
-     * the same connection will result in only one occurrence of the connection !
+     * the same connection will result in only one occurrence of the connection.
      *
      * @return Extracted list of connection Ids.
      */
     @Nonnull
-    public List<String> getConnectionIdList() {
-        final LinkedList<String> result = new LinkedList<>();
-        for (Edge edge : edgeList) {
-            if (result.isEmpty() || !result.getLast().equals(edge.getConnection().getId())) {
-                result.add(edge.getConnection().getId());
-            }
-        }
-        return result;
+    public List<String> getConnectionIds() {
+        return Collections.unmodifiableList(getConnections().stream().map(Connection::getId).collect(Collectors.toList()));
     }
 
 }

--- a/lib/mosaic-database/src/test/java/org/eclipse/mosaic/lib/database/route/RouteTest.java
+++ b/lib/mosaic-database/src/test/java/org/eclipse/mosaic/lib/database/route/RouteTest.java
@@ -50,19 +50,19 @@ public class RouteTest {
         Route route = createTestRoute();
 
         // test path
-        assertEquals("Wrong edge amount on the route", 2, route.getRoute().size());
+        assertEquals("Wrong edge amount on the route", 2, route.getEdges().size());
 
-        Edge edge = route.getRoute().get(0);
+        Edge edge = route.getEdges().get(0);
         assertEquals("Wrong edge 1 connection id", "1", edge.getConnection().getId());
         assertEquals("Wrong edge 1 start node id", "1", edge.getFromNode().getId());
         assertEquals("Wrong edge 1 end node id", "2", edge.getToNode().getId());
 
-        edge = route.getRoute().get(1);
+        edge = route.getEdges().get(1);
         assertEquals("Wrong edge 2 connection id", "1", edge.getConnection().getId());
         assertEquals("Wrong edge 2 start node id", "2", edge.getFromNode().getId());
         assertEquals("Wrong edge 2 end node id", "3", edge.getToNode().getId());
 
-        assertEquals("Route string representation wasn't generated correctly", "1_1 1_2", String.join(" ", route.getEdgeIdList()));
+        assertEquals("Route string representation wasn't generated correctly", "1_1 1_2", String.join(" ", route.getEdgeIds()));
     }
 
 
@@ -74,8 +74,8 @@ public class RouteTest {
         Route route = createTestRoute();
 
         // test
-        List<String> nodeIdList = route.getNodeIdList();
-        List<Node> nodeList = route.getNodeList();
+        List<String> nodeIdList = route.getNodeIds();
+        List<Node> nodeList = route.getNodes();
 
         // check counts
         assertEquals("Wrong node IDs amount on the route", 3, nodeIdList.size());

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/database/RouteManagerTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/database/RouteManagerTest.java
@@ -18,6 +18,8 @@ package org.eclipse.mosaic.lib.routing.database;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import org.eclipse.mosaic.lib.database.Database;
 import org.eclipse.mosaic.lib.database.route.Edge;
@@ -50,34 +52,13 @@ public class RouteManagerTest {
 
     private Database database;
 
-    private final String routeIDs = "32909782_26704482_26785753, "
-            + "25185001_26785753_26704584, "
-            + "25185007_26704584_21487146, "
-            + "25185006_21487146_21487168, "
-            + "4068038_21487168_251150126, "
-            + "4068038_251150126_428788319, "
-            + "4068038_428788319_408194194, "
-            + "4068038_408194194_423839224, "
-            + "4068038_423839224_26704448, "
-            + "36337928_26704448_27537750, "
-            + "4609244_27537750_27537749, "
-            + "4609243_27537749_252864801, "
-            + "4609243_252864801_252864802, "
-            + "32935479_252864802_21487170, "
-            + "30806885_21487170_299080425, "
-            + "30194724_299080425_21487175, "
-            + "4413638_21487175_21487174, "
-            + "4397063_21487174_26873453, "
-            + "4397063_26873453_26873454";
-
-
     @Before
     public void setUp() throws IOException {
         final File dbFileCopy = folder.newFile("tiergarten.db");
 
         FileUtils.copyInputStreamToFile(getClass().getResourceAsStream(dbFile), dbFileCopy);
 
-        database = Database.loadFromFile(dbFileCopy);
+        database = spy(Database.loadFromFile(dbFileCopy));
 
         instance = new RouteManager(database);
     }
@@ -90,18 +71,18 @@ public class RouteManagerTest {
         Route route = instance.createRouteByCandidateRoute(candidateRoute);
 
         List<String> firstNodesOfConnections = new ArrayList<>();
-        for (Edge edge : route.getRoute()) {
+        for (Edge edge : route.getEdges()) {
             if (edge.getFromNode().equals(edge.getConnection().getFrom())
                     || edge.getFromNode().equals(edge.getConnection().getTo())) {
                 firstNodesOfConnections.add(edge.getFromNode().getId());
             }
         }
         assertEquals("1", route.getId());
-        assertEquals(Arrays.asList("4609243_27537749_252864801", "4609243_252864801_252864802"), route.getConnectionIdList());
-        assertEquals(Arrays.asList("4609243_27537749_252864801_27537749", "4609243_252864801_252864802_252864801", "4609243_252864801_252864802_265786533"), route.getEdgeIdList());
+        assertEquals(Arrays.asList("4609243_27537749_252864801", "4609243_252864801_252864802"), route.getConnectionIds());
+        assertEquals(Arrays.asList("4609243_27537749_252864801_27537749", "4609243_252864801_252864802_252864801", "4609243_252864801_252864802_265786533"), route.getEdgeIds());
 
         assertEquals(Arrays.asList("27537749", "252864801"), firstNodesOfConnections);
-        assertEquals(candidateRoute.getNodeIdList(), route.getNodeIdList());
+        assertEquals(candidateRoute.getNodeIdList(), route.getNodeIds());
     }
 
     @Test
@@ -128,6 +109,24 @@ public class RouteManagerTest {
 
         assertEquals("1", rtiRoute.getId());
         assertEquals(Arrays.asList("4400154_21487169_21677261_27011311", "32935480_21677261_21668930_21677261", "32935480_21668930_27537748_21668930"), rtiRoute.getEdgeIdList());
+        assertEquals(candidateRoute.getNodeIdList(), rtiRoute.getNodeIdList());
+        assertEquals(1213.4, rtiRoute.getLength(), 0.1d);
+    }
+
+    @Test
+    public void getRouteForRTI_originSumo() throws IllegalRouteException {
+        // SETUP
+        // override behavior of getImportOrigin to simulate import origin from network file
+        doReturn(Database.IMPORT_ORIGIN_SUMO).when(database).getImportOrigin();
+
+        CandidateRoute candidateRoute = new CandidateRoute(Arrays.asList("27011311", "21677261", "21668930", "27537748"), 0, 0);
+        Route route = instance.createRouteByCandidateRoute(candidateRoute);
+
+        //RUN
+        VehicleRoute rtiRoute = instance.createRouteForRTI(route);
+
+        assertEquals("1", rtiRoute.getId());
+        assertEquals(Arrays.asList("4400154_21487169_21677261", "32935480_21677261_21668930", "32935480_21668930_27537748"), rtiRoute.getEdgeIdList());
         assertEquals(candidateRoute.getNodeIdList(), rtiRoute.getNodeIdList());
         assertEquals(1213.4, rtiRoute.getLength(), 0.1d);
     }


### PR DESCRIPTION

## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

If the scenario database was created from a Netfile, the exported rou.xml from both scenario-convert and SumoAmbassador are invalid. While importing a net.xml file, each Sumo-Edge of the network is transformed to one Connection. Points which form the geometry/shape of the edge, are added to the connection as Nodes.

When exporting Routes, however, the geometry nodes from a Connection are transformed to multiple edges (e.g. a connection with 2 additional geometry nodes would result in 3 edges). This is only valid, as long as the database was created from OSM input file. When coming from a SUMO network file, the routes must be exported in a way, that each connection results in only one corresponding edge.

This issue is fixed in this PR. When transforming the `Route` from the database into a `VehicleRoute` (which is eventually used by the SumoAmbassador to export the edges of the route), only the ids of the list of connections is used if the database originates from a SUMO network file.

Additionally, the getter methods of the `Route` class have been cleaned a bit.

## Issue(s) related to this PR

 * Internal issue 101
 
 ## Affected parts of the online documentation

No.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

