### PR TITLE
Fixed route building by clearing all lists at start

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/AStar.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/AStar.java
@@ -41,6 +41,7 @@ public class AStar<T extends AStar.Node<T, P>, P extends Point<P>> {
         CostNode destinationNode = null;
         closedList.clear();
         openList.clear();
+        openListNodes.clear();
         boolean routeFound = false;
 
         openList.add(new CostNode(from, 0));


### PR DESCRIPTION
Signed-off-by: Franziska Vogt <franziska.vogt@fokus.fraunhofer.de>

## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

This pull request fixes a bug, which caused a failure to build a route given specific vehicle spawning orders.

## Issue(s) related to this PR

 * Link to [Eclipse Mosaic Extended repository](https://gitlab.fokus.fraunhofer.de/simulation/mosaic/mosaic-extended/-/issues/149) issue 
 
 
## Affected parts of the online documentation

None

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

