### PR TITLE
Upgrade SUMO support to 1.9.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.8.0
+    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.0
     command:
     - cat
     tty: true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additional simulators and assessment features are provided by [Fraunhofer FOKUS]
 
 ## Related repositories
 
-* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.8.0`.
+* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.9.0`.
 * The coupling to [ns-3](https://www.nsnam.org) is realized by a federate implementation which can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/ns3-federate). 
   We currently support ns-3 version `3.28`. 
 * The coupling to [OMNeT++](https://omnetpp.org) is implemented in a very similar manner. The corresponding federate implementation can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/omnetpp-federate). 
@@ -56,7 +56,7 @@ For a successful build you need the following software to be installed:
 
 * **Maven 3.1.x** or higher.
 * **Java 8 or 11** - We recommend using the [Adopt OpenJDK](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot).
-* **SUMO 1.8.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
+* **SUMO 1.9.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
 
 ## Build
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/traci/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/traci/SumoVersion.java
@@ -33,6 +33,7 @@ public enum SumoVersion {
     SUMO_1_6_x("1.6.*", TraciVersion.API_20),
     SUMO_1_7_x("1.7.*", TraciVersion.API_20),
     SUMO_1_8_x("1.8.*", TraciVersion.API_20),
+    SUMO_1_9_x("1.9.*", TraciVersion.API_20),
 
     /**
      * the lowest version supported by this client.
@@ -86,8 +87,8 @@ public enum SumoVersion {
     }
 
     public boolean isGreaterOrEqualThan(SumoVersion other) {
-        return this.getApiVersion() > other.getApiVersion()
-                || this.major > other.major
-                || this.minor > other.minor;
+        return this.getApiVersion() >= other.getApiVersion()
+                || this.major >= other.major
+                || this.minor >= other.minor;
     }
 }

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/commands/TrafficLightAddProgramTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/commands/TrafficLightAddProgramTest.java
@@ -17,9 +17,9 @@ package org.eclipse.mosaic.fed.sumo.traci.commands;
 
 import static org.junit.Assert.assertEquals;
 
-import org.eclipse.mosaic.fed.sumo.traci.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.traci.SumoVersion;
 import org.eclipse.mosaic.fed.sumo.traci.complex.SumoTrafficLightLogic.Phase;
-import org.eclipse.mosaic.fed.sumo.traci.junit.SinceTraci;
+import org.eclipse.mosaic.fed.sumo.traci.junit.SinceSumo;
 import org.eclipse.mosaic.fed.sumo.traci.junit.SumoRunner;
 import org.eclipse.mosaic.rti.TIME;
 
@@ -32,7 +32,7 @@ import java.util.List;
 @RunWith(SumoRunner.class)
 public class TrafficLightAddProgramTest extends AbstractTraciCommandTest {
 
-    @SinceTraci(TraciVersion.API_20)
+    @SinceSumo(SumoVersion.SUMO_1_9_x)
     @Test
     public void execute() throws Exception {
         List<Phase> phases = Lists.newArrayList(
@@ -44,14 +44,14 @@ public class TrafficLightAddProgramTest extends AbstractTraciCommandTest {
 
         // ASSERT
         new TrafficLightSetProgram().execute(traci.getTraciConnection(), "2", "1");
-        simulateStep.execute(traci.getTraciConnection(), 10 * TIME.SECOND);
+        simulateStep.execute(traci.getTraciConnection(), 6 * TIME.SECOND);
 
         String currentState = new TrafficLightGetState().execute(traci.getTraciConnection(), "2");
-        assertEquals("ggggggggggg", currentState);
-
-        simulateStep.execute(traci.getTraciConnection(), 20 * TIME.SECOND);
-        currentState = new TrafficLightGetState().execute(traci.getTraciConnection(), "2");
         assertEquals("rrrrrrrrrrr", currentState);
+
+        simulateStep.execute(traci.getTraciConnection(), 16 * TIME.SECOND);
+        currentState = new TrafficLightGetState().execute(traci.getTraciConnection(), "2");
+        assertEquals("ggggggggggg", currentState);
     }
 
 }

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/junit/SinceSumo.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/junit/SinceSumo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.traci.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import org.eclipse.mosaic.fed.sumo.traci.SumoVersion;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark single unit tests to work only with specific versions of SUMO.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface SinceSumo {
+
+    /**
+     * Returns lowest supported SUMO version on default.
+     *
+     * @return Lowest supported SUMO version
+     */
+    SumoVersion value() default SumoVersion.LOWEST;
+}

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/junit/SumoTraciRule.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/junit/SumoTraciRule.java
@@ -28,7 +28,6 @@ import org.eclipse.mosaic.lib.util.SocketUtils;
 import org.eclipse.mosaic.rti.api.federatestarter.ExecutableFederateExecutor;
 
 import com.google.common.collect.Lists;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -49,7 +48,7 @@ import java.util.regex.Pattern;
 
 public class SumoTraciRule implements TestRule {
     // set this value to true to open the simulation with SUMO-GUI, you can also set the Environment variable GUI_DEBUG to true
-    private final static boolean GUI_DEBUG = ObjectUtils.defaultIfNull(Boolean.valueOf(System.getenv("MOSAIC_SUMO_GUI_DEBUG")), true);
+    private final static boolean GUI_DEBUG = Boolean.parseBoolean(StringUtils.defaultIfBlank(System.getenv("MOSAIC_SUMO_GUI_DEBUG"), "false"));
 
     private static final Pattern PORT_PATTERN = Pattern.compile(".*Starting server on port ([0-9]+).*");
 

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/junit/SumoTraciRule.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/traci/junit/SumoTraciRule.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
 
 public class SumoTraciRule implements TestRule {
     // set this value to true to open the simulation with SUMO-GUI, you can also set the Environment variable GUI_DEBUG to true
-    private final static boolean GUI_DEBUG = ObjectUtils.defaultIfNull(Boolean.valueOf(System.getenv("MOSAIC_SUMO_GUI_DEBUG")), false);
+    private final static boolean GUI_DEBUG = ObjectUtils.defaultIfNull(Boolean.valueOf(System.getenv("MOSAIC_SUMO_GUI_DEBUG")), true);
 
     private static final Pattern PORT_PATTERN = Pattern.compile(".*Starting server on port ([0-9]+).*");
 
@@ -92,6 +92,18 @@ public class SumoTraciRule implements TestRule {
                                         sinceTraci.value()
                                 ),
                                 currentVersion.getApiVersion() >= sinceTraci.value().getApiVersion()
+                        );
+                    }
+
+                    SinceSumo sinceSumo = description.getAnnotation(SinceSumo.class);
+                    if (sinceSumo != null) {
+                        SumoVersion currentVersion = SumoTraciRule.this.traci.getCurrentVersion();
+                        assumeTrue(
+                                String.format(
+                                        "This unit test expects SUMO version %s to be installed. Skipping.",
+                                        sinceSumo.value()
+                                ),
+                                currentVersion.isGreaterOrEqualThan(sinceSumo.value())
                         );
                     }
                     base.evaluate();

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -10,9 +10,9 @@ build and tag the docker image with the latest SUMO version. This image should b
 and available in the PPA.
 
 ```shell script
-docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.8.0
+docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.0
 docker login
-docker push eclipsemosaic/mosaic-ci
+docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.0
 ```  
 
 Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

Upgrade to SUMO 1.9.0

- Deployed new image for Eclipse CI with SUMO 1.9.0
- Added `@SinceSumo`  annotation for tests to be executed only if specific SUMO version is installed
- Fixed test `TrafficLightAddProgramTest`. Due to a fix in SUMO, traffic lights now start with the first phase defined in the program when switching to it. This was not the case in previous versions of SUMO. As a consequence, the assertion of the states of the traffic light at specific simulations times had to be adjusted to the now correct behavior.

## Issue(s) related to this PR

 * Internal issue 151 
 
## Affected parts of the online documentation

The latest supported version should be fixed in the documentation.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

