### PR TITLE
Fixed issue that Docker image could not create m2 repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.0
+    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.2
     command:
     - cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ spec:
     command:
     - cat
     tty: true
+    volumeMounts:
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
     resources:
       limits:
         memory: "2Gi"

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -1,6 +1,9 @@
 FROM maven:3.6.3-adoptopenjdk-8
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV USER_NAME=jenkins
+ENV HOME=/home/jenkins
+WORKDIR /home/jenkins
 
 RUN apt-get update && \
     apt-get install -y --allow-unauthenticated software-properties-common && \

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -10,9 +10,9 @@ build and tag the docker image with the latest SUMO version. This image should b
 and available in the PPA.
 
 ```shell script
-docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.0
+docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.2
 docker login
-docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.0
+docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.9.2
 ```  
 
 Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

The docker image which is used to run tests with Maven is now configured with a specific user, allowing the m2-repository to be created again.
