### PR TITLE
Allow CommunicationConfiguration to be received before VehicleRegistration

### DIFF
--- a/bundle/src/assembly/resources/etc/runtime.json
+++ b/bundle/src/assembly/resources/etc/runtime.json
@@ -78,7 +78,6 @@
             "deploy": false,
             "start": false,
             "subscriptions": [
-                "VehicleRegistration",
                 "RsuRegistration",
                 "TmcRegistration",
                 "ServerRegistration",
@@ -102,7 +101,6 @@
             "deploy": true,
             "start": true,
             "subscriptions": [
-                "VehicleRegistration",
                 "RsuRegistration",
                 "TrafficLightRegistration",
                 "VehicleUpdates",
@@ -123,7 +121,6 @@
             "deploy": true,
             "start": true,
             "subscriptions": [
-                "VehicleRegistration",
                 "RsuRegistration",
                 "TrafficLightRegistration",
                 "VehicleUpdates",

--- a/bundle/src/assembly/resources/etc/runtime.json
+++ b/bundle/src/assembly/resources/etc/runtime.json
@@ -102,6 +102,7 @@
             "start": true,
             "subscriptions": [
                 "RsuRegistration",
+                "ChargingStationRegistration",
                 "TrafficLightRegistration",
                 "VehicleUpdates",
                 "V2xMessageTransmission",
@@ -122,6 +123,7 @@
             "start": true,
             "subscriptions": [
                 "RsuRegistration",
+                "ChargingStationRegistration",
                 "TrafficLightRegistration",
                 "VehicleUpdates",
                 "V2xMessageTransmission",

--- a/bundle/src/assembly/resources/etc/runtime.json
+++ b/bundle/src/assembly/resources/etc/runtime.json
@@ -141,8 +141,8 @@
             "deploy": false,
             "start": false,
             "subscriptions": [
-                "VehicleRegistration",
                 "RsuRegistration",
+                "ChargingStationRegistration",
                 "TrafficLightRegistration",
                 "VehicleUpdates",
                 "V2xMessageTransmission",

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/AdHocModuleConfiguration.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/AdHocModuleConfiguration.java
@@ -38,7 +38,7 @@ import java.util.List;
  *  * </pre>
  * <br>
  * <br>
- * Single Radio Dual Channel
+ * Single Radio Dual Channel:
  * <br>
  * <pre>
  * AdHocModuleConfiguration configuration = new AdHocModuleConfiguration()

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/AdHocModuleConfiguration.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/AdHocModuleConfiguration.java
@@ -51,11 +51,6 @@ import java.util.List;
 public class AdHocModuleConfiguration implements CommunicationModuleConfiguration {
 
     /**
-     * Helper var in order to check if distance and power is not configured simultaneously.
-     */
-    private Boolean distanceConfigured = null;
-
-    /**
      * List of enabled and configured radios (usual cases operate with 1 (single) or 2 (dual) radios).
      */
     private final List<AdHocModuleRadioConfiguration> radios = new ArrayList<>();
@@ -108,15 +103,9 @@ public class AdHocModuleConfiguration implements CommunicationModuleConfiguratio
          * @return the current AdHocRadioConfiguration
          */
         public AdHocModuleRadioConfiguration power(int power) {
-            if (this.parent.distanceConfigured != null && this.parent.distanceConfigured) {
-                throw new RuntimeException(
-                        "A mixed configuration of distance and power is not allowed. Please be careful with configuring the adhoc module."
-                );
-            }
             if (power < -1) {
                 throw new RuntimeException("Negative power is not allowed within an AdHoc configuration.");
             }
-            this.parent.distanceConfigured = Boolean.FALSE;
             this.power = power;
             return this;
         }
@@ -129,15 +118,9 @@ public class AdHocModuleConfiguration implements CommunicationModuleConfiguratio
          * @return the current AdHocRadioConfiguration
          */
         public AdHocModuleRadioConfiguration distance(double distance) {
-            if (this.parent.distanceConfigured != null && !this.parent.distanceConfigured) {
-                throw new RuntimeException(
-                        "A mixed configuration of distance and power is not allowed. Please be careful with configuring the adhoc module."
-                );
-            }
             if (distance < 0) {
                 throw new RuntimeException("Negative distance is not allowed within an AdHoc configuration.");
             }
-            this.parent.distanceConfigured = Boolean.TRUE;
             this.distance = distance;
             return this;
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/AdHocModuleConfiguration.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/AdHocModuleConfiguration.java
@@ -30,9 +30,15 @@ import java.util.List;
  * AdHocModuleConfiguration configuration = new AdHocModuleConfiguration()
  *     .addRadio().power(50).channel(AdHocChannel.CCH).create();
  * </pre>
+ * Single Radio Single Channel (with distance instead of power for SNS):
+ *  * <br>
+ *  * <pre>
+ *  * AdHocModuleConfiguration configuration = new AdHocModuleConfiguration()
+ *  *     .addRadio().distance(250).channel(AdHocChannel.CCH).create();
+ *  * </pre>
  * <br>
  * <br>
- * Single Radio Dual Channel:
+ * Single Radio Dual Channel
  * <br>
  * <pre>
  * AdHocModuleConfiguration configuration = new AdHocModuleConfiguration()
@@ -40,12 +46,12 @@ import java.util.List;
  * </pre>
  * <br>
  * <br>
- * Dual Radio Single Channel (with distance instead of power for SNS):
+ * Dual Radio Single Channel:
  * <br>
  * <pre>
  * AdHocModuleConfiguration configuration = new AdHocModuleConfiguration()
- *     .addRadio().distance(250).channel(AdHocChannel.SCH1).create()
- *     .addRadio().distance(250).channel(AdHocChannel.CCH).create();
+ *     .addRadio().power(50).channel(AdHocChannel.SCH1).create()
+ *     .addRadio().power(50).channel(AdHocChannel.CCH).create();
  * </pre>
  */
 public class AdHocModuleConfiguration implements CommunicationModuleConfiguration {
@@ -83,7 +89,7 @@ public class AdHocModuleConfiguration implements CommunicationModuleConfiguratio
 
         private final AdHocModuleConfiguration parent;
 
-        private int power = -1;  // Default value 0 indicates power configuration through federate
+        private int power = -1;  // Default value -1 indicates power configuration through federate
         private Double distance = null;
 
         private AdHocChannel channel0;

--- a/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/ambassador/CellAmbassador.java
+++ b/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/ambassador/CellAmbassador.java
@@ -275,7 +275,13 @@ public class CellAmbassador extends AbstractFederateAmbassador {
             } else if (registeredServers.containsKey(nodeId)) { // handle servers
                 handleServerCellConfiguration(nodeId, cellConfiguration, interactionTime);
             } else {
-                log.warn("Could not handle unknown entity {}", nodeId);
+                if (cellConfiguration.isCellCommunicationEnabled()) {
+                    throw new InternalFederateException(
+                            "Cell Ambassador: Cannot activate Cell module for \"" + nodeId + "\" because the id is unknown"
+                    );
+                } else {
+                    log.debug("Tried to deactivate the Cell module for a node with the unknown id: {}", nodeId);
+                }
             }
         }
         handoverInfo.ifPresent((handover) -> {

--- a/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/ambassador/CellAmbassador.java
+++ b/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/ambassador/CellAmbassador.java
@@ -275,7 +275,7 @@ public class CellAmbassador extends AbstractFederateAmbassador {
             } else if (registeredServers.containsKey(nodeId)) { // handle servers
                 handleServerCellConfiguration(nodeId, cellConfiguration, interactionTime);
             } else {
-                if (cellConfiguration.isCellCommunicationEnabled()) {
+                if (cellConfiguration.isEnabled()) {
                     throw new InternalFederateException(
                             "Cell Ambassador: Cannot activate Cell module for \"" + nodeId + "\" because the id is unknown"
                     );
@@ -515,7 +515,7 @@ public class CellAmbassador extends AbstractFederateAmbassador {
         final AtomicReference<CellConfiguration> registeredVehicle = registeredVehicles.get(added.getName());
         return registeredVehicle != null
                 && registeredVehicle.get() != null
-                && registeredVehicle.get().isCellCommunicationEnabled();
+                && registeredVehicle.get().isEnabled();
     }
 
     private Optional<HandoverInfo> handleVehicleCellConfiguration(String nodeId, CellConfiguration cellConfiguration, Long interactionTime) throws InternalFederateException {

--- a/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/ambassador/CellAmbassador.java
+++ b/fed/mosaic-cell/src/main/java/org/eclipse/mosaic/fed/cell/ambassador/CellAmbassador.java
@@ -298,18 +298,11 @@ public class CellAmbassador extends AbstractFederateAmbassador {
      */
     private void process(VehicleRegistration vehicleRegistration) throws InternalFederateException {
         VehicleMapping veh = vehicleRegistration.getMapping();
-        if (veh.hasApplication()) {
-            registeredVehicles.put(veh.getName(), new AtomicReference<>(null));
-            log.debug("Registered VEH (id={}, with app(s)={}) for later adding upon VehicleUpdates, t={}",
-                    veh.getName(), veh.getApplications(),
-                    TIME.format(vehicleRegistration.getTime()));
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("VEH (id={}) has NO application and is ignored in "
-                        + "communication simulation", veh.getName());
-            }
-        }
-        for (CellularCommunicationConfiguration pendingConfiguration: new ArrayList<>(pendingConfigurations)) {
+        registeredVehicles.put(veh.getName(), new AtomicReference<>(null));
+        log.debug("Registered VEH (id={}, with app(s)={}) for later adding upon VehicleUpdates, t={}",
+                veh.getName(), veh.getApplications(),
+                TIME.format(vehicleRegistration.getTime()));
+        for (CellularCommunicationConfiguration pendingConfiguration : new ArrayList<>(pendingConfigurations)) {
             process(pendingConfiguration);
         }
     }
@@ -535,9 +528,10 @@ public class CellAmbassador extends AbstractFederateAmbassador {
      * @return True if cellular communication enabled.
      */
     private boolean isVehicleCellEnabled(VehicleData added) {
-        return registeredVehicles.containsKey(added.getName())
-                && registeredVehicles.get(added.getName()).get() != null
-                && registeredVehicles.get(added.getName()).get().isCellCommunicationEnabled();
+        final AtomicReference<CellConfiguration> registeredVehicle = registeredVehicles.get(added.getName());
+        return registeredVehicle != null
+                && registeredVehicle.get() != null
+                && registeredVehicle.get().isCellCommunicationEnabled();
     }
 
     private Optional<HandoverInfo> handleVehicleCellConfiguration(String nodeId, CellConfiguration cellConfiguration, Long interactionTime) throws InternalFederateException {

--- a/fed/mosaic-ns3/src/main/java/org/eclipse/mosaic/fed/ns3/ambassador/Ns3Ambassador.java
+++ b/fed/mosaic-ns3/src/main/java/org/eclipse/mosaic/fed/ns3/ambassador/Ns3Ambassador.java
@@ -71,7 +71,7 @@ public class Ns3Ambassador extends AbstractNetworkAmbassador {
     }
 
     @Override
-    protected synchronized void receiveTypedInteraction(AdHocCommunicationConfiguration interaction) throws InternalFederateException {
+    protected synchronized void process(AdHocCommunicationConfiguration interaction) throws InternalFederateException {
 
         AdHocConfiguration conf = interaction.getConfiguration();
         RadioMode radioMode = conf.getRadioMode();
@@ -89,6 +89,6 @@ public class Ns3Ambassador extends AbstractNetworkAmbassador {
                     + "configuration message will be discarded");
             return;
         }
-        super.receiveTypedInteraction(interaction);
+        super.process(interaction);
     }
 }

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SnsAmbassador.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SnsAmbassador.java
@@ -22,7 +22,6 @@ import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
 import org.eclipse.mosaic.interactions.mapping.ChargingStationRegistration;
 import org.eclipse.mosaic.interactions.mapping.RsuRegistration;
 import org.eclipse.mosaic.interactions.mapping.TrafficLightRegistration;
-import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
 import org.eclipse.mosaic.lib.enums.DestinationType;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
@@ -32,7 +31,6 @@ import org.eclipse.mosaic.lib.objects.communication.AdHocConfiguration;
 import org.eclipse.mosaic.lib.objects.mapping.ChargingStationMapping;
 import org.eclipse.mosaic.lib.objects.mapping.RsuMapping;
 import org.eclipse.mosaic.lib.objects.mapping.TrafficLightMapping;
-import org.eclipse.mosaic.lib.objects.mapping.VehicleMapping;
 import org.eclipse.mosaic.lib.objects.v2x.V2xReceiverInformation;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
@@ -111,9 +109,7 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
                 this.process((ChargingStationRegistration) interaction);
             } else if (interaction.getTypeId().startsWith(TrafficLightRegistration.TYPE_ID)) {
                 this.process((TrafficLightRegistration) interaction);
-            } else if (interaction.getTypeId().startsWith(VehicleRegistration.TYPE_ID)) {
-                this.process((VehicleRegistration) interaction);
-            } else if (interaction.getTypeId().startsWith(VehicleUpdates.TYPE_ID)) {
+            }  else if (interaction.getTypeId().startsWith(VehicleUpdates.TYPE_ID)) {
                 this.process((VehicleUpdates) interaction);
             } else if (interaction.getTypeId().startsWith(AdHocCommunicationConfiguration.TYPE_ID)) {
                 this.process((AdHocCommunicationConfiguration) interaction);
@@ -148,18 +144,6 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
         if (applicationTl.hasApplication()) {
             SimulationEntities.INSTANCE.createOrUpdateOfflineNode(applicationTl.getName(), applicationTl.getPosition().toCartesian());
             log.info("Added TrafficLight id={} @time={}", applicationTl.getName(), TIME.format(interaction.getTime()));
-        }
-    }
-
-    private void process(VehicleRegistration interaction) {
-        final VehicleMapping applicationVeh = interaction.getMapping();
-        if (applicationVeh.hasApplication()) {
-            registeredVehicles.put(applicationVeh.getName(), null);
-            log.debug(
-                    "Registered Vehicle (with application) for later adding id={} @time={}",
-                    applicationVeh.getName(),
-                    TIME.format(interaction.getTime())
-            );
         }
     }
 
@@ -208,11 +192,9 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
                     if (adHocConfiguration.getConf0().getRadius() != null) {
                         communicationRadius = adHocConfiguration.getConf0().getRadius();
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug(
-                                    "Node {} is configured with a power value. The SNS supposed to handle configurations using radii.",
-                                    adHocConfiguration.getNodeId());
-                        }
+                        log.warn(
+                                "Node {} is configured with a power value. The SNS supposed to handle configurations using radii.",
+                                adHocConfiguration.getNodeId());
                     }
                 }
                 if (SimulationEntities.INSTANCE.isNodeSimulated(nodeId)) {

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SnsAmbassador.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/SnsAmbassador.java
@@ -71,7 +71,7 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
     /**
      * Construct the Ambassador.
      *
-     * @param ambassadorParameter parameter.
+     * @param ambassadorParameter ambassadorId and configuration.
      */
     public SnsAmbassador(AmbassadorParameter ambassadorParameter) {
         super(ambassadorParameter);
@@ -105,10 +105,10 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
         try {
             if (interaction.getTypeId().startsWith(RsuRegistration.TYPE_ID)) {
                 this.process((RsuRegistration) interaction);
-            } else if (interaction.getTypeId().startsWith(ChargingStationRegistration.TYPE_ID)) {
-                this.process((ChargingStationRegistration) interaction);
             } else if (interaction.getTypeId().startsWith(TrafficLightRegistration.TYPE_ID)) {
                 this.process((TrafficLightRegistration) interaction);
+            } else if (interaction.getTypeId().startsWith(ChargingStationRegistration.TYPE_ID)) {
+                this.process((ChargingStationRegistration) interaction);
             }  else if (interaction.getTypeId().startsWith(VehicleUpdates.TYPE_ID)) {
                 this.process((VehicleUpdates) interaction);
             } else if (interaction.getTypeId().startsWith(AdHocCommunicationConfiguration.TYPE_ID)) {
@@ -131,19 +131,19 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
         }
     }
 
-    private void process(ChargingStationRegistration interaction) {
-        final ChargingStationMapping applicationCs = interaction.getMapping();
-        if (applicationCs.hasApplication()) {
-            SimulationEntities.INSTANCE.createOrUpdateOfflineNode(applicationCs.getName(), applicationCs.getPosition().toCartesian());
-            log.info("Added ChargingStation id={} @time={}", applicationCs.getName(), TIME.format(interaction.getTime()));
-        }
-    }
-
     private void process(TrafficLightRegistration interaction) {
         final TrafficLightMapping applicationTl = interaction.getMapping();
         if (applicationTl.hasApplication()) {
             SimulationEntities.INSTANCE.createOrUpdateOfflineNode(applicationTl.getName(), applicationTl.getPosition().toCartesian());
             log.info("Added TrafficLight id={} @time={}", applicationTl.getName(), TIME.format(interaction.getTime()));
+        }
+    }
+
+    private void process(ChargingStationRegistration interaction) {
+        final ChargingStationMapping applicationCs = interaction.getMapping();
+        if (applicationCs.hasApplication()) {
+            SimulationEntities.INSTANCE.createOrUpdateOfflineNode(applicationCs.getName(), applicationCs.getPosition().toCartesian());
+            log.info("Added ChargingStation id={} @time={}", applicationCs.getName(), TIME.format(interaction.getTime()));
         }
     }
 
@@ -179,7 +179,7 @@ public class SnsAmbassador extends AbstractFederateAmbassador {
                 }
                 break;
             case DUAL:
-                log.warn("SNS only supports single radio configuration. Ignoring configuration of second radio for node {}.", nodeId);
+                log.warn("SNS only supports single radio configuration. Configure first, while ignoring second, radio for node {}.", nodeId);
             case SINGLE:
                 double communicationRadius = this.singlehopRadius;
                 if (configuration.getConf0() != null && configuration.getConf0().getRadius() != null) {

--- a/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
+++ b/lib/mosaic-network/src/main/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassador.java
@@ -35,7 +35,7 @@ import org.eclipse.mosaic.lib.objects.addressing.SourceAddressContainer;
 import org.eclipse.mosaic.lib.objects.communication.AdHocConfiguration;
 import org.eclipse.mosaic.lib.objects.mapping.ChargingStationMapping;
 import org.eclipse.mosaic.lib.objects.mapping.RsuMapping;
-import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
+import org.eclipse.mosaic.lib.objects.mapping.TrafficLightMapping;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
 import org.eclipse.mosaic.rti.api.AbstractFederateAmbassador;
@@ -381,13 +381,13 @@ public abstract class AbstractNetworkAmbassador extends AbstractFederateAmbassad
                 interaction.getMapping().getName(),
                 interaction.getTime()
         );
-        TrafficLightGroup group = interaction.getTrafficLightGroup();
-        if (simulatedNodes.containsInternalId(group.getGroupId()) || registeredNodes.containsKey(group.getGroupId())) {
-            this.log.warn("A TL with ID {} was already added. Ignoring message.", group.getGroupId());
+        TrafficLightMapping mapping = interaction.getMapping();
+        if (simulatedNodes.containsInternalId(mapping.getName()) || registeredNodes.containsKey(mapping.getName())) {
+            this.log.warn("A TL with ID {} was already added. Ignoring message.", mapping.getName());
             return;
         }
         // Put the new TL RSU into our list of nodes to be added when AdHoc configuration is received
-        registeredNodes.put(group.getGroupId(), new RegisteredNode(null, group.getFirstPosition().toCartesian()));
+        registeredNodes.put(mapping.getName(), new RegisteredNode(null, mapping.getPosition().toCartesian()));
     }
 
     /**

--- a/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassadorTest.java
+++ b/lib/mosaic-network/src/test/java/org/eclipse/mosaic/lib/coupling/AbstractNetworkAmbassadorTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.mosaic.interactions.communication.AdHocCommunicationConfiguration;
 import org.eclipse.mosaic.interactions.mapping.RsuRegistration;
-import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
@@ -53,7 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-@SuppressWarnings({"unchecked"})
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractNetworkAmbassadorTest {
 
@@ -106,31 +104,11 @@ public class AbstractNetworkAmbassadorTest {
     }
 
     @Test
-    public void vehicleAdded_noConfigurationMessageSent() throws Exception {
+    public void vehicleMoved_noConfigurationMessageSent() throws Exception {
         // Setup
         networkAmbassador.initialize(0, 1000);
 
         // Run
-        final Interaction vehicleRegistration =
-                new VehicleRegistration(1 * TIME.SECOND, "veh_0", "vehicle", Lists.newArrayList(), null, null);
-        networkAmbassador.processInteraction(vehicleRegistration);
-
-        // Assert
-        // they can only be called when processMessage(VehicleUpdates message) is called, which we haven't done yet
-        verify(ambassadorFederateChannelMock, never()).writeAddNodeMessage(anyLong(), anyList());
-        verify(ambassadorFederateChannelMock, never()).writeConfigMessage(anyLong(), anyInt(), anyInt(), isA(AdHocConfiguration.class));
-    }
-
-    @Test
-    public void vehicleAddedAndMoved_noConfigurationMessageSent() throws Exception {
-        // Setup
-        networkAmbassador.initialize(0, 1000);
-
-        // Run
-        final Interaction vehicleRegistration =
-                new VehicleRegistration(1 * TIME.SECOND, "veh_0", "vehicle", Lists.newArrayList(), null, null);
-        networkAmbassador.processInteraction(vehicleRegistration);
-
         final Interaction vehicleUpdates = new VehicleUpdates(
                 2 * TIME.SECOND,
                 Lists.newArrayList(createVehicleInfo("veh_0")),
@@ -147,20 +125,11 @@ public class AbstractNetworkAmbassadorTest {
     }
 
     @Test
-    public void vehicleAddedMovedConfigured_configurationMessageSent() throws Exception {
+    public void vehicleMovedConfigured_configurationMessageSent() throws Exception {
         // Setup
         networkAmbassador.initialize(0, 1000);
 
         // Run
-        final Interaction vehicleRegistration = new VehicleRegistration(
-                1 * TIME.SECOND,
-                "veh_0",
-                "vehicle",
-                Lists.newArrayList(),
-                null,
-                null
-        );
-        networkAmbassador.processInteraction(vehicleRegistration); // Add vehicle
 
         final Interaction vehicleUpdates = new VehicleUpdates(
                 2 * TIME.SECOND,
@@ -181,14 +150,11 @@ public class AbstractNetworkAmbassadorTest {
     }
 
     @Test
-    public void vehicleAddedConfiguredMoved_configurationMessageSent() throws Exception {
+    public void vehicleConfiguredMoved_configurationMessageSent() throws Exception {
         // Setup
         networkAmbassador.initialize(0, 1000);
 
         // Run
-        final Interaction vehicleRegistration = new VehicleRegistration(1 * TIME.SECOND, "veh_0", "vehicle", Lists.newArrayList(), null, null);
-        networkAmbassador.processInteraction(vehicleRegistration); // Add vehicle
-
         final AdHocConfiguration adHocConfiguration = new AdHocConfiguration.Builder("veh_0").create();
         final Interaction adHocCommunicationConfiguration = new AdHocCommunicationConfiguration(2 * TIME.SECOND, adHocConfiguration);
         // Configure vehicle -> Add vehicle to simulation, send configuration to federate

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/UnitNameGenerator.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/UnitNameGenerator.java
@@ -58,6 +58,30 @@ public class UnitNameGenerator {
         return nextUnitName(UnitType.CHARGING_STATION);
     }
 
+    public static boolean isVehicle(String name) {
+        return isUnitType(UnitType.VEHICLE, name);
+    }
+
+    public static boolean isRsu(String name) {
+        return isUnitType(UnitType.ROAD_SIDE_UNIT, name);
+    }
+
+    public static boolean isTmc(String name) {
+        return isUnitType(UnitType.TRAFFIC_MANAGEMENT_CENTER, name);
+    }
+
+    public static boolean isServer(String name) {
+        return isUnitType(UnitType.SERVER, name);
+    }
+
+    public static boolean isTrafficLight(String name) {
+        return isUnitType(UnitType.TRAFFIC_LIGHT, name);
+    }
+
+    public static boolean isChargingStation(String name) {
+        return isUnitType(UnitType.CHARGING_STATION, name);
+    }
+
     public static String nextPrototypeName(String prototype) {
         if (prototype != null) {
             return prototype + "_" + prototypeCounter.getAndIncrement();
@@ -68,6 +92,10 @@ public class UnitNameGenerator {
 
     private static String nextUnitName(UnitType unitType) {
         return unitType.prefix + "_" + unitCounters.get(unitType).getAndIncrement();
+    }
+
+    private static boolean isUnitType(UnitType unitType, String name) {
+        return name.startsWith(unitType.prefix + "_");
     }
 
     /**

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/communication/CellConfiguration.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/communication/CellConfiguration.java
@@ -102,10 +102,6 @@ public class CellConfiguration implements Serializable {
         }
     }
 
-    public final boolean isCellCommunicationEnabled() {
-        return enabled;
-    }
-
     public final String getNodeId() {
         return nodeId;
     }


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

CellAmbassador and AbstractNetworkAmbassador now store the `Cell/AdhocCommunicationConfiguration` if no matching vehicle could be found. Those configuration interactions are again processed when a `VehicleRegistration` is received. This allows the `Cell/AdhocCommunicationConfiguration` interaction to be received BEFORE `VehicleRegistration`, which could happen with the improved Phabmacs Integration

## Issue(s) related to this PR

 * Internal issue 175
 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

