### PR TITLE
Release 21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,180 +1,207 @@
-# Changelog Eclipse MOSAIC 20.0 (October 2020
+# Changelog Eclipse MOSAIC 21.1 (October 2021)
 
-[M+] Moved main code to new public repository github-com/eclipse-mosaic
-[M+] Changed license to EPL 2.0
-[M+] Revised and refactored all public code.
-[M+] Significantly improved and extended the documentation, including new tutorials
-[M-] Replaced dependencies which are incompatible with EPL.
-[M+] Major overhaul of configuration files, e.g.
+* [A+] Server units are now able to access to street routing module.
+* [A+] The stop mode has been revised, allowing vehicles to park in parking areas (SUMO).
+* [M+] Made import of SUMO net files faster and more reliable in scenario-convert.
+* [M-] WebVisualizer now removes vehicles correctly and shows V2X indicators longer.
+* [M-] Fixed a bug in matrix mappers configuration in mapping.
+* [C+] Upgraded ns-3 federate to support ns3-34.
+* [C+] Major improvement of logging for SNS, OMNeT++, and ns-3.
+* [C-] Fixed a bug in polygon intersection test used by reachability check in mosaic-cell.
+* [M+] Major overhaul of battery and charging station simulation (Extended).
+* [M+] Added new consumption model for Li-Ion based batteries (Extended).
+* [T+] You can now use LibSumo as an alternative to TraCI (experimental).
+* [T+] Now supports SUMO 1.10.0
+
+# Changelog Eclipse MOSAIC 21.0 (March 2021)
+
+* [T+] It is now possible to map applications on vehicles which are defined in SUMO configurations.
+* [T+] Simplified the internal road network model for a better integration of existing SUMO scenarios.
+* [C+] Implemented much faster reachability check in SNS.
+* [A+] Added the possibility to map an application on all existing traffic lights at once.   
+* [A+] New simulation entity for Server applications.
+* [M-] Fixes a minor bug in the contains check of polygons
+* [M+] Added complete documentation for most configuration files to the website.
+* [M+] Added a new tutorial showcasing the integration of existing SUMO configurations.
+* [T+] Now supports SUMO 1.8.0
+
+# Changelog Eclipse MOSAIC 20.0 (October 2020)
+
+* [M+] Moved main code to new public repository github-com/eclipse-mosaic
+* [M+] Changed license to EPL 2.0
+* [M+] Revised and refactored all public code.
+* [M+] Significantly improved and extended the documentation, including new tutorials
+* [M-] Replaced dependencies which are incompatible with EPL.
+* [M+] Major overhaul of configuration files, e.g.
      * vsimrti/vsimrti_config.xml -> scenario_config.json
      * etc/defaults.xml -> etc/runtime.json
-[A+] Mapping configuration has been extended with new features (e.g. typeDistributions, parameter variations).
-[A+] New API for traffic light applications
-[C+] SNS supports most important Geo-Routing features for ad-hoc multihop communication
-[T+] Now supports SUMO 1.7.0
+* [A+] Mapping configuration has been extended with new features (e.g. typeDistributions, parameter variations).
+* [A+] New API for traffic light applications
+* [C+] SNS supports most important Geo-Routing features for ad-hoc multihop communication
+* [T+] Now supports SUMO 1.7.0
 
 # Changelog VSimRTI 19.1 (October 2019)
 
-[C+] The OMNeT++ federate has been migrated to OMNeT++ 5.5 and INET 4. The federate needs to be rebuild completely.
-[S+] The option "--db2vsimrti" has been extended and creates now further default configuration files.
-[A+] The collection of example applications has been extended.
-[A+] The navigation API for VSimRTI applications has been improved with new methods.
-[M+] Configuration of vehicle types now supports the emergencyDecel parameter.
-[V+] The visualizers can now be configured to visualize messages within a specific time period only.
-[V+] The websocket visualizer now centers the viewport in the browser automatically to the first simulated vehicle.
-[S-] The intersection detection in scenario-convert has been fixed.
-[V-] Several bugfixes and changes int the command line interface of VSimRTI and scenario-convert.
-[V-] The bundled LuST tutorial has been fixed to work again with VSimRTI.
-[V-] The performance GUI has been removed.
-[V+] Now supports SUMO 1.3.0
+* [C+] The OMNeT++ federate has been migrated to OMNeT++ 5.5 and INET 4. The federate needs to be rebuild completely.
+* [S+] The option "--db2vsimrti" has been extended and creates now further default configuration files.
+* [A+] The collection of example applications has been extended.
+* [A+] The navigation API for VSimRTI applications has been improved with new methods.
+* [M+] Configuration of vehicle types now supports the emergencyDecel parameter.
+* [V+] The visualizers can now be configured to visualize messages within a specific time period only.
+* [V+] The websocket visualizer now centers the viewport in the browser automatically to the first simulated vehicle.
+* [S-] The intersection detection in scenario-convert has been fixed.
+* [V-] Several bugfixes and changes int the command line interface of VSimRTI and scenario-convert.
+* [V-] The bundled LuST tutorial has been fixed to work again with VSimRTI.
+* [V-] The performance GUI has been removed.
+* [V+] Now supports SUMO 1.3.0
 
 
 # Changelog VSimRTI 19.0 (April 2019)
 
-[V+] Added support for Java 11 and OpenJDK on all operating systems.
-[V+] A new statistics visualizer collects and aggregates values from vehicles during the simulation. Find more details in the user manual.
-[V+] The web socket visualizer now uses the OpenLayers API instead of Google API.
-[V+] The configuration of vehicle spawners in the mapping configuration has been improved (e.g. depart speed, lane selection, scaling traffic).
-[A+] A model for Infrastructure to Vehicle Information (IVI) messages has been introduced.
-[A-] A bug has been fixed which led to false configuration of ad-hoc modules in application.
-[S+] The import of SUMO net and route files into scenario database has been improved.
-[S+] The new option "--db2vsimrti" has been added, which generates a simple simulation scenario from a database file.
-[V-] The Barnim tutorial scenario has been updated.
-[V-] Various performance improvements have been made.
-[V+] Now supports SUMO 1.1.0 and 1.2.0
+* [V+] Added support for Java 11 and OpenJDK on all operating systems.
+* [V+] A new statistics visualizer collects and aggregates values from vehicles during the simulation. Find more details in the user manual.
+* [V+] The web socket visualizer now uses the OpenLayers API instead of Google API.
+* [V+] The configuration of vehicle spawners in the mapping configuration has been improved (e.g. depart speed, lane selection, scaling traffic).
+* [A+] A model for Infrastructure to Vehicle Information (IVI) messages has been introduced.
+* [A-] A bug has been fixed which led to false configuration of ad-hoc modules in application.
+* [S+] The import of SUMO net and route files into scenario database has been improved.
+* [S+] The new option "--db2vsimrti" has been added, which generates a simple simulation scenario from a database file.
+* [V-] The Barnim tutorial scenario has been updated.
+* [V-] Various performance improvements have been made.
+* [V+] Now supports SUMO 1.1.0 and 1.2.0
 
 # Changelog VSimRTI 18.1 (October 2018)
 
-[A+] A new simulation entity has been added to simulate Traffic Management Center applications.
-[A+] It's now possible to parametrize applications directly in the mapping configuration.
-[C+] The Simple Network Simulator (SNS) now supports simple multi hopping.
-[C+] Cell2 now models handovers when vehicles move to another region.
-[C+] The OMNeT++ federate has been updated to support OMNeT++ 5.3 and INET 3.6
-[C+] The NS-3 federate has been updated to support ns-3 3.28
-[V+] Improved printing of exceptions to the console output.
-[V+] A new 3D visualization tool is now available in the commercial license of VSimRTI.
-[S-] The export of roundabouts for SUMO net files has been fixed.
-[T+] A vehicle class configured in the mapping configuration is now translated to a suitable SUMO vClass.
-[T+] Now supports and requires SUMO 1.0.x
+* [A+] A new simulation entity has been added to simulate Traffic Management Center applications.
+* [A+] It's now possible to parametrize applications directly in the mapping configuration.
+* [C+] The Simple Network Simulator (SNS) now supports simple multi hopping.
+* [C+] Cell2 now models handovers when vehicles move to another region.
+* [C+] The OMNeT++ federate has been updated to support OMNeT++ 5.3 and INET 3.6
+* [C+] The NS-3 federate has been updated to support ns-3 3.28
+* [V+] Improved printing of exceptions to the console output.
+* [V+] A new 3D visualization tool is now available in the commercial license of VSimRTI.
+* [S-] The export of roundabouts for SUMO net files has been fixed.
+* [T+] A vehicle class configured in the mapping configuration is now translated to a suitable SUMO vClass.
+* [T+] Now supports and requires SUMO 1.0.x
 
 # Changelog VSimRTI 18.0 (April 2018)
 
-[T+] The integration of pre-existing SUMO scenarios has been improved. However, minor limitations exist.
-[S+] It is now possible to create a scenario database from any given SUMO network file.
-[S-] The scenario database scheme has been changed slightly over the previous releases. Old databases are now unsupported. See conversion guide for details.
-[V+] The Luxembourg SUMO Traffic (LuST) scenario [1] has been integrated into VSimRTI . See user manual for details.
-[S-] Roundabouts from OSM data is now imported resulting in correct right of way behavior at roundabouts.
-[C+] Various improvements regarding Mobile Edge Computing (MEC) in the Cell2 simulator.
-[V+] The GeoTools library has been upgraded to its latest version.
-[V+] VSimRTI supports Java 9 and 10 on Linux based systems. On Windows, Java 8 is still required.
-[V-] Various performance improvements in the core of VSimRTI have been made.
-[T+] Now supports SUMO 0.32.0
+* [T+] The integration of pre-existing SUMO scenarios has been improved. However, minor limitations exist.
+* [S+] It is now possible to create a scenario database from any given SUMO network file.
+* [S-] The scenario database scheme has been changed slightly over the previous releases. Old databases are now unsupported. See conversion guide for details.
+* [V+] The Luxembourg SUMO Traffic (LuST) scenario * [1] has been integrated into VSimRTI . See user manual for details.
+* [S-] Roundabouts from OSM data is now imported resulting in correct right of way behavior at roundabouts.
+* [C+] Various improvements regarding Mobile Edge Computing (MEC) in the Cell2 simulator.
+* [V+] The GeoTools library has been upgraded to its latest version.
+* [V+] VSimRTI supports Java 9 and 10 on Linux based systems. On Windows, Java 8 is still required.
+* [V-] Various performance improvements in the core of VSimRTI have been made.
+* [T+] Now supports SUMO 0.32.0
 
-[1] https://github.com/lcodeca/LuSTScenario
+* [1] https://github.com/lcodeca/LuSTScenario
 
 # Changelog VSimRTI 17.1 (October 2017)
 
-[V-] Fixed a bug which would not preserve the order of events in rare cases.
-[A+] Ids for messages are now unique per unit, not globally.
-[A+] Introduced a simplified API for sending V2X messages from applications.
-[C+] It's now possible to define regions as polygons for the Cell2 simulator.
-[C+] The Cell2 simulator respects the maxmimum bandwidth of each vehicle.
-[C+] The OMneT++ and NS-3 federates now require protobuf3.
-[C+] The NS-3 federate experienced a major code cleanup.
-[B-] Fixed a bug in the calculation of air drag in the battery simulator.
-[T-] The SUMO TraCI Client code has been reimplemented and is now more robust.
-[T+] Now supports SUMO 0.31.0
+* [V-] Fixed a bug which would not preserve the order of events in rare cases.
+* [A+] Ids for messages are now unique per unit, not globally.
+* [A+] Introduced a simplified API for sending V2X messages from applications.
+* [C+] It's now possible to define regions as polygons for the Cell2 simulator.
+* [C+] The Cell2 simulator respects the maxmimum bandwidth of each vehicle.
+* [C+] The OMneT++ and NS-3 federates now require protobuf3.
+* [C+] The NS-3 federate experienced a major code cleanup.
+* [B-] Fixed a bug in the calculation of air drag in the battery simulator.
+* [T-] The SUMO TraCI Client code has been reimplemented and is now more robust.
+* [T+] Now supports SUMO 0.31.0
 
 # Changelog VSimRTI 17.0 (April 2017)
 
-[V+] VSimRTI supports and requires Java Runtime Environment (or JDK) Version 8.
-[V+] Now supports elevation data for nodes.
-[V+] The file visualizer optionally compresses its output file.
-[A+] Applications are provided with more information about the road the vehicle is driving on. See conversion guide for details.
-[C+] The OMNeT++ and ns-3 federate can now be executed inside a Docker container. See user manual for more details.
-[C-] The configuration of the Cell2 simulator has been revised. See conversion guide for details.
-[S+] Added the option --srtm2db for importing elevation data provided by ASC files (experimental feature).
-[T+] The slope of a vehicle is read out from SUMO via TraCI (requires SUMO > 0.27.0)
-[T-] Fixed a bug in SUMO ambassador where the vehicle signals have been read out incorrectly.
-[V-] Support of JiST/SWANS has been removed due to technical reasons.
-[A-] Fixed a bug in the application simulator where applications received events before they had been set up.
-[A-] Removed unused parameter BehaviorDataStruct from application API. See conversion guide for details.
-[T+] Now support SUMO 0.29.0
+* [V+] VSimRTI supports and requires Java Runtime Environment (or JDK) Version 8.
+* [V+] Now supports elevation data for nodes.
+* [V+] The file visualizer optionally compresses its output file.
+* [A+] Applications are provided with more information about the road the vehicle is driving on. See conversion guide for details.
+* [C+] The OMNeT++ and ns-3 federate can now be executed inside a Docker container. See user manual for more details.
+* [C-] The configuration of the Cell2 simulator has been revised. See conversion guide for details.
+* [S+] Added the option --srtm2db for importing elevation data provided by ASC files (experimental feature).
+* [T+] The slope of a vehicle is read out from SUMO via TraCI (requires SUMO > 0.27.0)
+* [T-] Fixed a bug in SUMO ambassador where the vehicle signals have been read out incorrectly.
+* [V-] Support of JiST/SWANS has been removed due to technical reasons.
+* [A-] Fixed a bug in the application simulator where applications received events before they had been set up.
+* [A-] Removed unused parameter BehaviorDataStruct from application API. See conversion guide for details.
+* [T+] Now support SUMO 0.29.0
 
 # Changelog VSimRTI 0.16.2 (October 2016)
 
-[V+] Added a new tutorial to the User Documentation regarding mapping of traffic lights.
-[V+] VSimRTI now provides a global random number generator whose seed can be set in vsimrti_config.xml
-[A+] Reworked the Application API for configuring the AdHoc and Cell modules. Please read the Conversion Guide.
-[T+] Improved performance of SUMO coupling.
-[T+] Configure SUMO specific parameters for the vehicle type, such as emissionClass or carFollowModel 
-[T+] Fuel consumption is now read out from vehicles.
-[T-] Bugfix in SUMO ambassador regarding Change Speed.
-[A-] Fixed a bug in the application simulator which did not properly simulate traffic light applications.
-[V-] Fixed a bug which occurred when the distance sensor was activated and the web visualizer was used at the same time.
-[S+] Added the option --db2shp to scenario-convert which provides a conversion of the database to shapefile format.
-[T+] Now support SUMO 0.27.1
+* [V+] Added a new tutorial to the User Documentation regarding mapping of traffic lights.
+* [V+] VSimRTI now provides a global random number generator whose seed can be set in vsimrti_config.xml
+* [A+] Reworked the Application API for configuring the AdHoc and Cell modules. Please read the Conversion Guide.
+* [T+] Improved performance of SUMO coupling.
+* [T+] Configure SUMO specific parameters for the vehicle type, such as emissionClass or carFollowModel 
+* [T+] Fuel consumption is now read out from vehicles.
+* [T-] Bugfix in SUMO ambassador regarding Change Speed.
+* [A-] Fixed a bug in the application simulator which did not properly simulate traffic light applications.
+* [V-] Fixed a bug which occurred when the distance sensor was activated and the web visualizer was used at the same time.
+* [S+] Added the option --db2shp to scenario-convert which provides a conversion of the database to shapefile format.
+* [T+] Now support SUMO 0.27.1
 
 # Changelog VSimRTI 0.16.1 (June 2016)
 
-[A+] Application API allows to change vehicle parameters, such as minimum gap or maximum speed, during the simulation
-[C+] Revised installer scripts for network simulators OMNeT++ and ns-3
-[C-] Bugfix in coupling of network simulators OMNet++ and ns-3
-[T+] SUMO coupling now provides distance sensor information for vehicles (opt-in) and the longitudal acceleration
-[T+] Now support SUMO 0.26.0
+* [A+] Application API allows to change vehicle parameters, such as minimum gap or maximum speed, during the simulation
+* [C+] Revised installer scripts for network simulators OMNeT++ and ns-3
+* [C-] Bugfix in coupling of network simulators OMNet++ and ns-3
+* [T+] SUMO coupling now provides distance sensor information for vehicles (opt-in) and the longitudal acceleration
+* [T+] Now support SUMO 0.26.0
 
 # Changelog VSimRTI 0.16.0 (April 2016)
 
-[V+] Improved User Documentation with new detailed Tutorials of Tiergarten and Barnim, and extended API-Config-Doxygen
-[A-] Application API Refactoring to allow more flexible selection of implemented functionalities (CommunicationApplication, ElectricVehicleApplication, ...)
-[A+] Introduction of new Central Navigation Component to Application to provide advanced navigation functionalities for the applications (e.g. calculate new routes with own cost functions)
-[A+] New interactions with traffic simulator (mainly SUMO) for ChangeSpeed
-[C-] Improved stability of coupling of network simulators OMNeT++ and ns-3 (based on and needs Google Protocol Buffers)
-[C+] Now support latest ns-3.25
-[C+] Introduced new built-in Simple Network Simulator (SNS), supporting various ad hoc communication modes, for quick and easy usage without further installations
-[S-] Bugfix in scenario-convert regarding SUMO rou-file import in mode --sumo2db
-[T-] Revised SUMO interfaces for compatibility with SUMO 0.25.0 (regarding headings)
-[T+] Support visualization and control of simulations directly from SUMO-GUI
+* [V+] Improved User Documentation with new detailed Tutorials of Tiergarten and Barnim, and extended API-Config-Doxygen
+* [A-] Application API Refactoring to allow more flexible selection of implemented functionalities (CommunicationApplication, ElectricVehicleApplication, ...)
+* [A+] Introduction of new Central Navigation Component to Application to provide advanced navigation functionalities for the applications (e.g. calculate new routes with own cost functions)
+* [A+] New interactions with traffic simulator (mainly SUMO) for ChangeSpeed
+* [C-] Improved stability of coupling of network simulators OMNeT++ and ns-3 (based on and needs Google Protocol Buffers)
+* [C+] Now support latest ns-3.25
+* [C+] Introduced new built-in Simple Network Simulator (SNS), supporting various ad hoc communication modes, for quick and easy usage without further installations
+* [S-] Bugfix in scenario-convert regarding SUMO rou-file import in mode --sumo2db
+* [T-] Revised SUMO interfaces for compatibility with SUMO 0.25.0 (regarding headings)
+* [T+] Support visualization and control of simulations directly from SUMO-GUI
 
 Please note, this version only delivers correct results (regarding headings) with SUMO 0.25.0 or higher
 
 # Changelog VSimRTI 0.15.1 (December 2015)
 
-[V+] A new CLI argument (--scenario) is available for vsimrti.bat/sh which lets the user pass the name of scenario instead of the full path to vsimrti_config.xml
-[A+] Support new addressing handling of tcp-like message Acknowledgment (for cellular communication)
-[A+] Enable/disable WLANmodule for ad hoc communication from applications
-[A+] Support configurable IP Address Resolver
-[B+] New configuration for the Battery Ambassador
-[C+] OMNeT++: support OMNeT++ 4.6 and INET 3.0 now
-[C-] Improved minor bugs in Cellular Simulator
-[C+] Support new schemes for geographic addressing over cellular (include MBMS/eMBMS feature)
-[N+] Major improvements in navigation simulator, which now uses GraphHopper for route calculation (e.g. routing now considers turn costs and turn restrictions).
-[S+] Several improvements in scenario-convert (now supports start with json-config).
-[T-] Fixed a bug which let SUMO crash when the navigation simulator calculated an invalid route.
-[T+] Now support SUMO 0.25.0
+* [V+] A new CLI argument (--scenario) is available for vsimrti.bat/sh which lets the user pass the name of scenario instead of the full path to vsimrti_config.xml
+* [A+] Support new addressing handling of tcp-like message Acknowledgment (for cellular communication)
+* [A+] Enable/disable WLANmodule for ad hoc communication from applications
+* [A+] Support configurable IP Address Resolver
+* [B+] New configuration for the Battery Ambassador
+* [C+] OMNeT++: support OMNeT++ 4.6 and INET 3.0 now
+* [C-] Improved minor bugs in Cellular Simulator
+* [C+] Support new schemes for geographic addressing over cellular (include MBMS/eMBMS feature)
+* [N+] Major improvements in navigation simulator, which now uses GraphHopper for route calculation (e.g. routing now considers turn costs and turn restrictions).
+* [S+] Several improvements in scenario-convert (now supports start with json-config).
+* [T-] Fixed a bug which let SUMO crash when the navigation simulator calculated an invalid route.
+* [T+] Now support SUMO 0.25.0
 
 
 # Changelog VSimRTI 0.15.0 (September 2015)
 
-[INTERNAL] new versioning system: every module of the aggregate has now the same version
+* [INTERNAL] new versioning system: every module of the aggregate has now the same version
 
-[V-] Several minor bugfixes for the general framework
-[A+] Slight improvements of interfaces of VSimRTI_App
-[B+] Extended modeling in the Battery simulator (improved handling and switching of discharging/charging)
-[C+] New generation of the VSimRTI_Cell cellular simulator with additional features (separated up/downlink, improved region definition with kml-visualization)
-[C-] Stability improvements for ns-3 and OMNeT++ (now support OMNeT++ 4.4.1)
-[T+] Enhanced SUMO integration regarding navigation interactions (ChangeRoute, ChangeTarget), now support SUMO 0.24.0
+* [V-] Several minor bugfixes for the general framework
+* [A+] Slight improvements of interfaces of VSimRTI_App
+* [B+] Extended modeling in the Battery simulator (improved handling and switching of discharging/charging)
+* [C+] New generation of the VSimRTI_Cell cellular simulator with additional features (separated up/downlink, improved region definition with kml-visualization)
+* [C-] Stability improvements for ns-3 and OMNeT++ (now support OMNeT++ 4.4.1)
+* [T+] Enhanced SUMO integration regarding navigation interactions (ChangeRoute, ChangeTarget), now support SUMO 0.24.0
 Please note, this version only works with sumo v0.21.0 or higher
 
 
 # Changelog VSimRTI 0.14.0
 
-[V+] General performance improvements
-[V+] Improved SimRunner configuration
-[A+] Completely Revised Application simulator with new features and improved performance
-[C+] Additional Features for cellular simulator VSimRTI_Cell
-[C-] Stability Improvements for ns-3 and OMNeT++
+* [V+] General performance improvements
+* [V+] Improved SimRunner configuration
+* [A+] Completely Revised Application simulator with new features and improved performance
+* [C+] Additional Features for cellular simulator VSimRTI_Cell
+* [C-] Stability Improvements for ns-3 and OMNeT++
 Please note, this version only works with sumo v0.21.0 or higher
 
 Changelog (Features and Bugfixes) Legend:
-[M] MOSAIC [V] VSimRTI [A] Application simulator [B] Battery simulator [C] Communication simulator [E] Environment simulator [N] Navigation component [S] Scenario-convert [T] Traffic simulator [+/-] new Feature/Bugfix
+* [M] MOSAIC * [V] VSimRTI * [A] Application simulator * [B] Battery simulator * [C] Communication simulator * [E] Environment simulator * [N] Navigation component * [S] Scenario-convert * [T] Traffic simulator * [+/-] new Feature/Bugfix

--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
@@ -66,8 +66,8 @@ public class WeatherServerApp extends AbstractApplication<RoadSideUnitOperatingS
     }
 
     /**
-     * This method is called by VSimRTI when a previously triggered event is handed over to the
-     * application by VSimRTI for processing.
+     * This method is called by mosaic-application when a previously triggered event is handed over to the
+     * application for processing.
      * Events can be triggered be this application itself, e.g. to run a routine periodically.
      *
      * @param event The event to be processed
@@ -81,7 +81,7 @@ public class WeatherServerApp extends AbstractApplication<RoadSideUnitOperatingS
      * Method to let the WeatherServer send a DEN message periodically.
      * <p>
      * This method sends a DEN message and generates a new event during each call.
-     * When said event is triggered (via VSimRTI), processEvent() is called, which in turn calls sample().
+     * When said event is triggered, processEvent() is called, which in turn calls sample().
      * This way, sample() is called periodically at a given interval (given by the generated event time)
      * and thus the DENM is sent periodically at this interval.
      */
@@ -127,9 +127,7 @@ public class WeatherServerApp extends AbstractApplication<RoadSideUnitOperatingS
     }
 
     /**
-     * This method is called by VSimRTI when the vehicle that has been equipped with this application
-     * leaves the simulation.
-     * It is the last method called of this class during a simulation.
+     * This method is called by mosaic-application when the simulation has finished.
      */
     @Override
     public void onShutdown() {

--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherWarningApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherWarningApp.java
@@ -66,8 +66,7 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
 
 
     /**
-     * This method is called by VSimRTI when the vehicle that has been equipped with this application
-     * enters the simulation.
+     * This method is called by mosaic-application when the vehicle enters the simulation.
      * It is the first method called of this class during a simulation.
      */
     @Override
@@ -91,8 +90,7 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
     }
 
     /**
-     * This method is called by VSimRTI when the vehicle that has been equipped with this application
-     * leaves the simulation.
+     * This method is called by mosaic-application when the vehicle leaves the simulation.
      * It is the last method called of this class during a simulation.
      */
     @Override
@@ -218,9 +216,9 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
         }
 
         /*
-         * We want to send a DENM (Decentralized Environment Notification Message). A DENM, as a subclass of
-         * V2XMessage, requires a MessageRouting (so VSimRTI knows source and destination of the message),
-         * and a payload in the form of a DENMContent object. It contains fields such as the current timestamp
+         * We want to send a DENM (Decentralized Environment Notification Message). A Denm, as a subclass of
+         * V2xMessage, requires a MessageRouting (so the communication simulator knows source and destination of the message),
+         * and a payload in the form of a DenmContent object. It contains fields such as the current timestamp
          * of the sending node, the geo position of the sending node, warning type and event strength.
          */
         Denm denm = new Denm(mr, new DenmContent(getOs().getSimulationTime(), vehicleLongLat, roadId, type, strength, SPEED, 0.0f, vehicleLongLat, null, null));
@@ -238,14 +236,6 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
     }
 
     private void reactUponDENMessageChangeRoute(Denm denm) {
-        /*
-         * NOTE: The route change happens only once. Further rerouting is not
-         * possible at the moment. The route information which could be used for
-         * rerouting is static. It was requested only once by VSimRTI from
-         * the traffic simulator. Otherwise the traffic simulator performance
-         * would decrease dramatically. This may change in the future.
-         * Until this, the routeChanged variable is used.
-         */
         final String affectedConnectionId = denm.getEventRoadId();
         final VehicleRoute routeInfo = Objects.requireNonNull(getOs().getNavigationModule().getCurrentRoute());
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatter.java
@@ -47,7 +47,7 @@ public class InteractionFormatter {
         this.methodManagers = new HashMap<>();
 
         Map<String, Class<?>> interactionClasses = InteractionUtils.getAllSupportedInteractions(
-                "com.dcaiti.vsimrti", "com.dcaiti.mosaic"
+                "com.dcaiti.mosaic"
         );
 
         for (Entry<String, List<List<String>>> e : interactionDefinitions.entrySet()) {

--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerClient.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerClient.java
@@ -16,6 +16,7 @@
 package org.eclipse.mosaic.lib.docker;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +84,7 @@ public class DockerClient {
         }
 
         final Process p;
-        if ("true".equals(System.getProperty("mosaic.docker.no-detach"))) {
+        if ("true".equals(System.getProperty("mosaic.docker.no-detach", SystemUtils.IS_OS_WINDOWS ? "true" : "false"))) {
             logger.info("Starting container without detaching.");
             p = docker.run(image, options);
         } else {

--- a/lib/mosaic-docker/src/test/java/org/eclipse/mosaic/lib/docker/DockerClientTest.java
+++ b/lib/mosaic-docker/src/test/java/org/eclipse/mosaic/lib/docker/DockerClientTest.java
@@ -59,6 +59,8 @@ public class DockerClientTest {
 
         when(commandLine.status(anyString())).thenReturn("", "", "Up 2 seconds");
         when(commandLine.port(anyString())).thenReturn("1337/tcp -> 0.0.0.0:7331\n");
+
+        System.setProperty("mosaic.docker.no-detach", "false");
     }
 
     @Test


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [ ] Enhancement

## Description

* [x] Add Changelog
* [ ] Merge all commits from `main`
* [ ] Update download links in `ns3_installer.sh` and `omnet_installer.sh`
* [ ] Update versions in pom.xml

Further changes:

* Removed some left-overs of "VSimRTI" from comments in weather-warning applications
* Remover package `com.dcaiti.vsimrti` from list of allowed interaction classes
* On windows, use "mosaic.docker.no-detach=true" if not set explicitly. I also added documentation for this flag on our website. 
  *  If this flag is on `false`, the docker container is started in "detached" mode and MOSAIC attaches to the container right after. This was in early stages the only way to make the thing work. However, now on Windows it seems that some log messages in the container are missed between running and attaching to the container. This is fixed by having the flag on `true`: 
  * With this flag on `true`, the container is directly started in attached mode. This works very well with docker on Windows.

What is this PR about?

## Affected parts of the online documentation

Yes, release news is added to the website

## Definition of Done

- [ ] You have read CONTRIBUTING.md carefully.
- [ ] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [ ] `origin/main` has been merged into your Fork.
- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] There are no new SpotBugs warnings. 
- [ ] Coding guidelines have been observed (see CONTRIBUTING.md).
- [ ] All tests pass.

## Special notes to reviewer

