### PR TITLE
Add interface for data classes to be serialized with Protobuf

### DIFF
--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/ProtobufConversion.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/ProtobufConversion.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.objects;
+
+public interface ProtobufConversion<ProtobufT> {
+
+    ProtobufT toProto();
+
+    interface Builder<ProtobufT> {
+        Builder fromProto(ProtobufT protobufType);
+    }
+}

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/ProtobufConversion.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/ProtobufConversion.java
@@ -20,6 +20,6 @@ public interface ProtobufConversion<ProtobufT> {
     ProtobufT toProto();
 
     interface Builder<ProtobufT> {
-        Builder fromProto(ProtobufT protobufType);
+        Builder<ProtobufT> fromProto(ProtobufT protobufType);
     }
 }


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* This PR adds an Interface for data-classes that are to be serialized with Protobuf
* Not certain if this is the best way to realize this

## Issue(s) related to this PR

 * related to internal issue 266
 

## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

