### PR TITLE
Extending BatteryData by consumption information

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
@@ -72,6 +72,7 @@
                     <entry>"VEHICLE_REGISTRATION"</entry>
                     <entry>Time</entry>
                     <entry>Mapping.Name</entry>
+                    <entry>Mapping.Applications</entry>
                     <entry>Mapping.VehicleType.VehicleClass</entry>
                     <entry>Mapping.VehicleType.Color</entry>
                     <entry>Mapping.Group</entry>

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -392,7 +392,7 @@ public class SimulationFacade {
                                     new Consumptions(0d), lastVehicleData.getVehicleConsumptions().getAllConsumptions())
                             )
                             .emissions(new VehicleEmissions(
-                                    new Emissions(0d,0d,0d,0d,0d), lastVehicleData.getVehicleEmissions().getAllEmissions())
+                                    new Emissions(0d, 0d, 0d, 0d, 0d), lastVehicleData.getVehicleEmissions().getAllEmissions())
                             )
                             .sensors(createSensorData(veh.id, veh.leadingVehicle, veh.minGap, followerDistances.get(veh.id)))
                             .laneArea(vehicleSegmentInfo.get(veh.id))
@@ -577,7 +577,7 @@ public class SimulationFacade {
     /**
      * Creates an immutable object holding front and rear distance sensor data based on leading vehicle information.
      *
-     * @param vehicleId         The id of the vehicle the VehicleSensors object should be created for
+     * @param vehicleId        The id of the vehicle the VehicleSensors object should be created for
      * @param leadingVehicle   Information of the leading vehicle.
      * @param minGap           The minimum gap of the current vehicle.
      * @param followerDistance The distance to the follower of the current vehicle

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -654,10 +654,7 @@ public class SimulationFacade {
      * @return The vehicle consumption.
      */
     private VehicleConsumptions calculateConsumptions(VehicleSubscriptionResult veh, VehicleData lastVehicleData) {
-        final Consumptions currentConsumptions = new Consumptions(
-                fixConsumptionValue(veh.fuel),
-                fixConsumptionValue(veh.electricity)
-        );
+        final Consumptions currentConsumptions = new Consumptions(fixConsumptionValue(veh.fuel));
         if (lastVehicleData != null && lastVehicleData.getVehicleConsumptions() != null) {
             return new VehicleConsumptions(
                     currentConsumptions,

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -384,7 +384,13 @@ public class SimulationFacade {
                     vehicleData = new VehicleData.Builder(time, lastVehicleData.getName())
                             .copyFrom(lastVehicleData)
                             .position(veh.position.getGeographicPosition(), veh.position.getProjectedPosition())
-                            .stopped(vehicleStopMode).create();
+                            .stopped(vehicleStopMode)
+                            .route(veh.routeId)
+                            .movement(veh.speed, veh.acceleration, fixDistanceDriven(veh.distanceDriven, lastVehicleData))
+                            .orientation(DriveDirection.UNAVAILABLE, veh.heading, veh.slope)
+                            .consumptions(calculateConsumptions(veh, lastVehicleData))
+                            .emissions(calculateEmissions(veh, lastVehicleData))
+                            .create();
                 } else if (veh.position == null || !veh.position.isValid()) {
                     /* if a vehicle has not yet been simulated but loaded by SUMO, the vehicle's position will be invalid.
                      * Therefore we just continue however, if it has already been in the simulation (remove(id) returns true),

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -382,12 +382,20 @@ public class SimulationFacade {
                         log.info("Vehicle {} has parked at {} (edge: {})", veh.id, veh.position, veh.edgeId);
                     }
                     vehicleData = new VehicleData.Builder(time, lastVehicleData.getName())
-                            .copyFrom(lastVehicleData)
                             .position(veh.position.getGeographicPosition(), veh.position.getProjectedPosition())
-                            .stopped(vehicleStopMode)
-                            .route(veh.routeId)
+                            .road(lastVehicleData.getRoadPosition())
                             .movement(veh.speed, veh.acceleration, fixDistanceDriven(veh.distanceDriven, lastVehicleData))
                             .orientation(DriveDirection.UNAVAILABLE, veh.heading, veh.slope)
+                            .route(veh.routeId)
+                            .stopped(vehicleStopMode)
+                            .consumptions(new VehicleConsumptions(
+                                    new Consumptions(0d), lastVehicleData.getVehicleConsumptions().getAllConsumptions())
+                            )
+                            .emissions(new VehicleEmissions(
+                                    new Emissions(0d,0d,0d,0d,0d), lastVehicleData.getVehicleEmissions().getAllEmissions())
+                            )
+                            .sensors(createSensorData(veh.id, veh.leadingVehicle, veh.minGap, followerDistances.get(veh.id)))
+                            .laneArea(vehicleSegmentInfo.get(veh.id))
                             .create();
                 } else if (veh.position == null || !veh.position.isValid()) {
                     /* if a vehicle has not yet been simulated but loaded by SUMO, the vehicle's position will be invalid.

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -388,8 +388,6 @@ public class SimulationFacade {
                             .route(veh.routeId)
                             .movement(veh.speed, veh.acceleration, fixDistanceDriven(veh.distanceDriven, lastVehicleData))
                             .orientation(DriveDirection.UNAVAILABLE, veh.heading, veh.slope)
-                            .consumptions(calculateConsumptions(veh, lastVehicleData))
-                            .emissions(calculateEmissions(veh, lastVehicleData))
                             .create();
                 } else if (veh.position == null || !veh.position.isValid()) {
                     /* if a vehicle has not yet been simulated but loaded by SUMO, the vehicle's position will be invalid.

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/BatteryData.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/BatteryData.java
@@ -61,6 +61,16 @@ public class BatteryData implements Serializable {
     private final boolean charging;
 
     /**
+     * The energy consumption of the vehicle in this simulation step. [Ws]
+     */
+    private final double currentConsumption;
+
+    /**
+     * The cumulative energy consumption of the vehicle. [Ws]
+     */
+    private final double allConsumption;
+
+    /**
      * Creates a new {@link BatteryData} for an added vehicle.
      *
      * @param time    timestamp of the data
@@ -72,23 +82,30 @@ public class BatteryData implements Serializable {
         this.stateOfCharge = -1.0;
         this.capacity = -1.0;
         this.charging = false;
+        this.currentConsumption = -1.0;
+        this.allConsumption = -1.0;
     }
 
     /**
      * Creates a new {@link BatteryData} for an added vehicle.
      *
-     * @param time          timestamp of the data
-     * @param ownerId       id of the vehicle that the data belongs to
-     * @param stateOfCharge state of charge of the battery [0,1]
-     * @param capacity      current capacity of the battery
-     * @param charging      flag indicating whether battery is charging
+     * @param time               timestamp of the data
+     * @param ownerId            id of the vehicle that the data belongs to
+     * @param stateOfCharge      state of charge of the battery [0,1]
+     * @param capacity           current capacity of the battery
+     * @param charging           flag indicating whether battery is charging
+     * @param currentConsumption the current energy consumption of the vehicle
+     * @param allConsumption     the cumulative energy consumption of the vehicle
      */
-    private BatteryData(long time, String ownerId, double stateOfCharge, double capacity, boolean charging) {
+    private BatteryData(long time, String ownerId, double stateOfCharge, double capacity,
+                        boolean charging, double currentConsumption, double allConsumption) {
         this.ownerId = ownerId;
         this.time = time;
         this.stateOfCharge = stateOfCharge;
         this.capacity = capacity;
         this.charging = charging;
+        this.currentConsumption = currentConsumption;
+        this.allConsumption = allConsumption;
     }
 
     public String getOwnerId() {
@@ -136,12 +153,22 @@ public class BatteryData implements Serializable {
         return charging;
     }
 
+    public double getCurrentConsumption() {
+        return currentConsumption;
+    }
+
+    public double getAllConsumption() {
+        return allConsumption;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder(3, 53)
                 .append(stateOfCharge)
                 .append(capacity)
                 .append(charging)
+                .append(currentConsumption)
+                .append(allConsumption)
                 .toHashCode();
     }
 
@@ -162,6 +189,8 @@ public class BatteryData implements Serializable {
                 .append(this.stateOfCharge, other.stateOfCharge)
                 .append(this.capacity, other.capacity)
                 .append(this.charging, other.charging)
+                .append(this.currentConsumption, other.currentConsumption)
+                .append(this.allConsumption, other.allConsumption)
                 .isEquals();
     }
 
@@ -172,6 +201,8 @@ public class BatteryData implements Serializable {
                 .append("stateOfCharge", stateOfCharge)
                 .append("capacity", capacity)
                 .append("charging", charging)
+                .append("currentConsumption", currentConsumption)
+                .append("allConsumption", allConsumption)
                 .build();
     }
 
@@ -181,6 +212,8 @@ public class BatteryData implements Serializable {
         private double stateOfCharge;
         private double capacity;
         private boolean charging;
+        private double currentConsumption;
+        private double allConsumption;
 
         public Builder(long time, String ownerId) {
             this.time = time;
@@ -198,6 +231,12 @@ public class BatteryData implements Serializable {
             return this;
         }
 
+        public Builder consumption(double currentConsumption, double allConsumption) {
+            this.currentConsumption = currentConsumption;
+            this.allConsumption = allConsumption;
+            return this;
+        }
+
         /**
          * Copies relevant data from a given {@link BatteryData} object.
          *
@@ -208,12 +247,13 @@ public class BatteryData implements Serializable {
             stateOfCharge = batteryData.stateOfCharge;
             capacity = batteryData.capacity;
             charging = batteryData.charging;
+            currentConsumption = batteryData.currentConsumption;
+            allConsumption = batteryData.allConsumption;
             return this;
         }
 
         public BatteryData build() {
-            return new BatteryData(time, ownerId, stateOfCharge, capacity, charging);
-
+            return new BatteryData(time, ownerId, stateOfCharge, capacity, charging, currentConsumption, allConsumption);
         }
     }
 }

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/Consumptions.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/Consumptions.java
@@ -15,8 +15,11 @@
 
 package org.eclipse.mosaic.lib.objects.vehicle;
 
+import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.Serializable;
 import javax.annotation.concurrent.Immutable;
@@ -34,14 +37,8 @@ public class Consumptions implements Serializable {
      */
     private final double fuel;
 
-    /**
-     * Electrical power consumption in Wh.
-     */
-    private final double electricalPower;
-
-    public Consumptions(double fuel, double electricalPower) {
+    public Consumptions(double fuel) {
         this.fuel = fuel;
-        this.electricalPower = electricalPower;
     }
 
     /**
@@ -52,30 +49,19 @@ public class Consumptions implements Serializable {
     }
 
     /**
-     * Returns the electrical power in Watt.
-     */
-    public double getElectricalPower() {
-        return electricalPower;
-    }
-
-    /**
      * Return a new Consumptions object containing the total consumption.
      *
      * @param consumptions the previous total consumptions
      * @return a new Consumptions object containing the total consumption
      */
     public Consumptions addConsumptions(Consumptions consumptions) {
-        return new Consumptions(
-                this.getFuel() + consumptions.getFuel(),
-                this.getElectricalPower() + consumptions.getElectricalPower()
-        );
+        return new Consumptions(this.getFuel() + consumptions.getFuel());
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(5, 17)
                 .append(this.fuel)
-                .append(this.electricalPower)
                 .toHashCode();
     }
 
@@ -94,13 +80,14 @@ public class Consumptions implements Serializable {
         Consumptions other = (Consumptions) obj;
         return new EqualsBuilder()
                 .append(this.fuel, other.fuel)
-                .append(this.electricalPower, other.electricalPower)
                 .isEquals();
     }
 
     @Override
     public String toString() {
-        return "Consumptions{" + "fuel=" + this.fuel + ", electricalPower=" + this.electricalPower + '}';
+        return new ToStringBuilder(this, SHORT_PREFIX_STYLE)
+                .append("fuel", fuel)
+                .toString();
     }
 
 }


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

What is this PR about?

This PR extends the `BatteryData`-class with additional information about energy "consumption" the BatterySimulator
was adjusted to update this information accordingly.

## Issue(s) related to this PR

 * relates to internal issue 254
 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x]  Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

