### PR TITLE
Upgrade to SUMO 1.11.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.10.0
+    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.11.0
     command:
     - cat
     tty: true

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
@@ -35,6 +35,7 @@ public enum SumoVersion {
     SUMO_1_8_x("1.8.*", TraciVersion.API_20),
     SUMO_1_9_x("1.9.*", TraciVersion.API_20),
     SUMO_1_10_x("1.10.*", TraciVersion.API_20),
+    SUMO_1_11_x("1.11.*", TraciVersion.API_20),
 
     /**
      * the lowest version supported by this client.
@@ -44,7 +45,7 @@ public enum SumoVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(SUMO_1_10_x.sumoVersion, SUMO_1_10_x.traciVersion);
+    HIGHEST(SUMO_1_11_x.sumoVersion, SUMO_1_11_x.traciVersion);
 
     private final String sumoVersion;
     private final TraciVersion traciVersion;

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/util/TrafficLightStateDecoder.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/util/TrafficLightStateDecoder.java
@@ -41,17 +41,21 @@ public class TrafficLightStateDecoder {
      */
     public static TrafficLightState createStateFromCharacter(Character stateChar) {
         switch (stateChar) {
-            case 'G':
-            case 'g':
+            case 'g': // green, but yield for foe streams with `G`
+            case 'G': // green, no yield for others
                 return new TrafficLightState(false, true, false);
-            case 'r':
+            case 'r': // red
+            case 'R': // red
+            case 's': // green right-turn arrow on red light
                 return new TrafficLightState(true, false, false);
-            case 'y':
-            case 'Y':
+            case 'y': // yellow
+            case 'Y': // yellow
                 return new TrafficLightState(false, false, true);
-            case 'u':
+            case 'u': // red + yellow
+            case 'U': // red + yellow
                 return new TrafficLightState(true, false, true);
-            case 'O': //off - no signal
+            case 'o': // off - yellow blinking indicates yield
+            case 'O': // off - no signal
                 return new TrafficLightState(false, false, false);
             default:
                 throw new IllegalArgumentException("Could not create a TrafficLightState from a phase definitions character " + stateChar);

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -8,6 +8,6 @@ WORKDIR /home/jenkins
 RUN apt-get update &&  \
     apt-get install -y --allow-unauthenticated software-properties-common && \
     # adjust this output string to bypass potentiall caches
-    echo "Installing SUMO 1.10.0" && \
+    echo "Installing SUMO 1.11.0" && \
     add-apt-repository ppa:sumo/stable && \
     apt-get install -y sumo

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -10,9 +10,9 @@ build and tag the docker image with the latest SUMO version. This image should b
 and available in the PPA.
 
 ```shell script
-docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.10.0
+docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.11.0
 docker login
-docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.10.0
+docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.11.0
 ```  
 
 Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* Introduced `1.11.0` as valid SUMO version in mosaic-sumo
* Pushed new docker image for testing with SUMO 1.11.0
* Adjusted Jenkinsfile

## Issue(s) related to this PR

 * internal issue 276 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

