### PR TITLE
Cleaned up Matrix implementations and aligned method set

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
@@ -110,7 +110,7 @@ public class Matrix3d implements Serializable {
      */
     public Matrix3d add(Matrix3d mat, Matrix3d result) {
         for (int i = 0; i < 16; i++) {
-            result.m[i] += mat.m[i];
+            result.m[i] = m[i] + mat.m[i];
         }
         return result;
     }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
@@ -16,75 +16,108 @@
 package org.eclipse.mosaic.lib.math;
 
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.Locale;
 
 public class Matrix3d implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final DecimalFormat FORMAT = new DecimalFormat("0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
-    public final double m[] = new double[9];
+    /**
+     * Array holding value of the matrix. Values are stored column-wise, that is, the first 3 values
+     * represent the first column, the second 3 values the second column, and so on.<br>
+     * Do NOT use this array directly, unless it is from crucial importance (e.g. during physics simulation)
+     */
+    public final double[] m = new double[9];
 
+    /**
+     * Creates a new 3x3 matrix, with all values being zero.
+     */
+    public Matrix3d() {
+        setZero();
+    }
+
+    /**
+     * Creates a new 3x3 matrix, with the values being copied from the given matrix.
+     */
+    public Matrix3d(Matrix3d copyFrom) {
+        set(copyFrom);
+    }
+
+    /**
+     * Creates a new identity matrix in 3x3 format.
+     */
     public static Matrix3d identityMatrix() {
-        return new Matrix3d().loadIdentity();
+        return new Matrix3d().setIdentity();
     }
 
-    public static Matrix3d copy(Matrix3d m) {
-        return new Matrix3d().set(m.m);
-    }
-
-    public Matrix3d loadIdentity() {
-        m[0] = 1;
-        m[1] = 0;
-        m[2] = 0;
-
-        m[3] = 0;
-        m[4] = 1;
-        m[5] = 0;
-
-        m[6] = 0;
-        m[7] = 0;
-        m[8] = 1;
+    /**
+     * Sets all values to match identity matrix.
+     */
+    public Matrix3d setIdentity() {
+        for (int i = 0; i < 9; i++) {
+            m[i] = i % 4 == 0 ? 1 : 0;
+        }
         return this;
     }
 
+    /**
+     * Sets all values to zero.
+     */
+    public Matrix3d setZero() {
+        for (int i = 0; i < 9; i++) {
+            m[i] = 0;
+        }
+        return this;
+    }
+
+    /**
+     * Copies the values from the given matrix to this matrix.
+     */
     public Matrix3d set(Matrix3d m) {
-        set(m.m);
+        System.arraycopy(m.m, 0, this.m, 0, 9);
         return this;
     }
 
-    public Matrix3d set(double[] data) {
-        System.arraycopy(data, 0, m, 0, 9);
+    /**
+     * Get a specific value from the matrix by row and column index
+     */
+    public double get(int row, int col) {
+        return m[col * 3 + row];
+    }
+
+    /**
+     * Sets a specific value in the matrix by row and column index
+     */
+    public Matrix3d set(int row, int col, double value) {
+        m[col * 3 + row] = value;
         return this;
     }
 
-    public Matrix3d transpose() {
-        double d;
-        d = m[1];
-        m[1] = m[3];
-        m[3] = d;
-        d = m[2];
-        m[2] = m[6];
-        m[6] = d;
-        d = m[5];
-        m[5] = m[7];
-        m[7] = d;
-        return this;
+
+    /**
+     * Adds a matrix to this matrix.
+     */
+    public Matrix3d add(Matrix3d mat) {
+        return add(mat, this);
     }
 
-    public Matrix3d transpose(Matrix3d result) {
-        result.m[0] = m[0];
-        result.m[1] = m[3];
-        result.m[2] = m[6];
-
-        result.m[3] = m[1];
-        result.m[4] = m[4];
-        result.m[5] = m[7];
-
-        result.m[6] = m[2];
-        result.m[7] = m[5];
-        result.m[8] = m[8];
+    /**
+     * Adds a matrix to this matrix and writes the result into the result matrix.
+     */
+    public Matrix3d add(Matrix3d mat, Matrix3d result) {
+        for (int i = 0; i < 16; i++) {
+            result.m[i] += mat.m[i];
+        }
         return result;
     }
 
+    /**
+     * Multiplies this matrix with another matrix and writes the result into the result matrix.
+     */
     public Matrix3d multiply(Matrix3d mat, Matrix3d result) {
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -98,6 +131,9 @@ public class Matrix3d implements Serializable {
         return result;
     }
 
+    /**
+     * Multiplies this matrix with a 3-dimensional vector.
+     */
     public Vector3d multiply(Vector3d v) {
         double x = v.x * m[0] + v.y * m[1] + v.z * m[2];
         double y = v.x * m[3] + v.y * m[4] + v.z * m[5];
@@ -106,6 +142,9 @@ public class Matrix3d implements Serializable {
         return v;
     }
 
+    /**
+     * Multiplies this matrix with a 3-dimensional vector and writes the result into the given vector.
+     */
     public Vector3d multiply(Vector3d v, Vector3d result) {
         result.x = v.x * m[0] + v.y * m[1] + v.z * m[2];
         result.y = v.x * m[3] + v.y * m[4] + v.z * m[5];
@@ -113,25 +152,138 @@ public class Matrix3d implements Serializable {
         return result;
     }
 
-//    public void orthonormalize() {
-//        Vector3d x = new Vector3d(m[0], m[3], m[6]);
-//        Vector3d y = new Vector3d(m[1], m[4], m[7]);
-//        Vector3d z = new Vector3d();
-//
-//        x.norm();
-//        x.cross(y, z);
-//        z.norm();
-//        z.cross(x, y);
-//        y.norm();
-//
-//        m[0] = x.x;
-//        m[3] = x.y;
-//        m[6] = x.z;
-//        m[1] = y.x;
-//        m[4] = y.y;
-//        m[7] = y.z;
-//        m[2] = z.x;
-//        m[5] = z.y;
-//        m[8] = z.z;
-//    }
+    /**
+     * Transposes this matrix.
+     */
+    public Matrix3d transpose() {
+        return transpose(this);
+    }
+
+    /**
+     * Writes a transposed version of this matrix into the result matrix.
+     */
+    public Matrix3d transpose(Matrix3d result) {
+        result.set(this);
+        for (int r = 0; r < 3; r++) {
+            for (int c = r + 1; c < 3; c++) {
+                result.swap(c * 3 + r, r * 3 + c);
+            }
+        }
+        return result;
+    }
+
+    private void swap(int i, int j) {
+        double d = m[i];
+        m[i] = m[j];
+        m[j] = d;
+    }
+
+    /**
+     * Inverts this matrix.
+     *
+     * @return <code>true</code>, if the inverse could be created.
+     */
+    public boolean invert() {
+        return inverse(this);
+    }
+
+    /**
+     * Writes a inverted version of this matrix into the result matrix.
+     *
+     * @return <code>true</code>, if the inverse could be created.
+     */
+    public boolean inverse(Matrix3d result) {
+        // Invert a 3 x 3 matrix
+
+        double m00 = m[0];
+        double m01 = m[3];
+        double m02 = m[6];
+        double m10 = m[1];
+        double m11 = m[4];
+        double m12 = m[7];
+        double m20 = m[2];
+        double m21 = m[5];
+        double m22 = m[8];
+
+        double det = m00 * (m11 * m22 - m21 * m12) -
+                m01 * (m10 * m22 - m12 * m20) +
+                m02 * (m10 * m21 - m11 * m20);
+
+        if (det == 0.0f) {
+            return false;
+        }
+
+        double invdet = 1 / det;
+
+        double r00 = (m11 * m22 - m21 * m12) * invdet;
+        double r01 = (m02 * m21 - m01 * m22) * invdet;
+        double r02 = (m01 * m12 - m02 * m11) * invdet;
+        double r10 = (m12 * m20 - m10 * m22) * invdet;
+        double r11 = (m00 * m22 - m02 * m20) * invdet;
+        double r12 = (m10 * m02 - m00 * m12) * invdet;
+        double r20 = (m10 * m21 - m20 * m11) * invdet;
+        double r21 = (m20 * m01 - m00 * m21) * invdet;
+        double r22 = (m00 * m11 - m10 * m01) * invdet;
+
+        result.m[0] = r00;
+        result.m[3] = r01;
+        result.m[6] = r02;
+        result.m[1] = r10;
+        result.m[4] = r11;
+        result.m[7] = r12;
+        result.m[2] = r20;
+        result.m[5] = r21;
+        result.m[8] = r22;
+
+        return true;
+    }
+
+    /**
+     * Creates copy of this matrix.
+     */
+    public Matrix3d copy() {
+        return new Matrix3d(this);
+    }
+
+    public boolean isFuzzyEqual(Matrix3d other) {
+        for (int i = 0; i < m.length; i++) {
+            if (!MathUtils.isFuzzyEqual(m[i], other.m[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final Matrix3d other = (Matrix3d) o;
+        return Arrays.equals(m, other.m);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(m);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder out = new StringBuilder(this.getClass().getSimpleName()).append("([");
+        for (int r = 0; r < 3; r++) {
+            out.append("[");
+            for (int c = 0; c < 3; c++) {
+                out.append(FORMAT.format(get(r, c)));
+                if (c < 2) {
+                    out.append(", ");
+                }
+            }
+            out.append("]");
+            if (r < 2) {
+                out.append(", ");
+            }
+        }
+        return out.append("])").toString();
+    }
 }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
@@ -27,8 +27,9 @@ public class Matrix3d implements Serializable {
     private static final DecimalFormat FORMAT = new DecimalFormat("0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     /**
-     * Array holding value of the matrix. Values are stored column-wise, that is, the first 3 values
-     * represent the first column, the second 3 values the second column, and so on.<br>
+     * Array holding value of the matrix. Values are stored in column-major order.
+     *
+     * @see MatrixAlignment#COLUMNS
      */
     protected final double[] m = new double[9];
 

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
@@ -29,9 +29,8 @@ public class Matrix3d implements Serializable {
     /**
      * Array holding value of the matrix. Values are stored column-wise, that is, the first 3 values
      * represent the first column, the second 3 values the second column, and so on.<br>
-     * Do NOT use this array directly, unless it is from crucial importance (e.g. during physics simulation)
      */
-    public final double[] m = new double[9];
+    protected final double[] m = new double[9];
 
     /**
      * Creates a new 3x3 matrix, with all values being zero.
@@ -78,8 +77,69 @@ public class Matrix3d implements Serializable {
      * Copies the values from the given matrix to this matrix.
      */
     public Matrix3d set(Matrix3d m) {
-        System.arraycopy(m.m, 0, this.m, 0, 9);
+        set(m.m, MatrixAlignment.COLUMNS);
         return this;
+    }
+
+    /**
+     * Sets the values of the matrix by the given double array. The alignment
+     * parameter defines how the values in the given array are arranged
+     * (either column or row-wise).
+     */
+    public Matrix3d set(double[] values, MatrixAlignment alignment) {
+        System.arraycopy(values, 0, this.m, 0, 9);
+        if (alignment == MatrixAlignment.ROWS) {
+            transpose();
+        }
+        return this;
+    }
+
+    /**
+     * Sets the values of the matrix by the given float array. The alignment
+     * parameter defines how the values in the given array are arranged
+     * (either column or row-wise).
+     */
+    public Matrix3d set(float[] values, MatrixAlignment alignment) {
+        for (int r = 0; r < 3; r++) {
+            for (int c = 0; c < 3; c++) {
+                m[c * 3 + r] = alignment == MatrixAlignment.COLUMNS
+                        ? values[c * 3 + r]
+                        : values[r * 3 + c];
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Returns the values of the matrix and writes it into the the given double array.
+     * The alignment parameter defines how the values in the given array will be arranged
+     * (either column or row-wise).
+     */
+    public double[] getAsDoubleArray(double[] result, MatrixAlignment alignment) {
+        for (int r = 0; r < 3; r++) {
+            for (int c = 0; c < 3; c++) {
+                result[c * 3 + r] = alignment == MatrixAlignment.COLUMNS
+                        ? m[c * 3 + r]
+                        : m[r * 3 + c];
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the values of the matrix and writes it into the the given float array.
+     * The alignment parameter defines how the values in the given array will be arranged
+     * (either column or row-wise).
+     */
+    public float[] getAsFloatArray(float[] result, MatrixAlignment alignment) {
+        for (int r = 0; r < 3; r++) {
+            for (int c = 0; c < 3; c++) {
+                result[c * 3 + r] = alignment == MatrixAlignment.COLUMNS
+                        ? (float) m[c * 3 + r]
+                        : (float) m[r * 3 + c];
+            }
+        }
+        return result;
     }
 
     /**
@@ -97,7 +157,6 @@ public class Matrix3d implements Serializable {
         return this;
     }
 
-
     /**
      * Adds a matrix to this matrix.
      */
@@ -111,6 +170,23 @@ public class Matrix3d implements Serializable {
     public Matrix3d add(Matrix3d mat, Matrix3d result) {
         for (int i = 0; i < 16; i++) {
             result.m[i] = m[i] + mat.m[i];
+        }
+        return result;
+    }
+
+    /**
+     * Subtracts a matrix from this matrix.
+     */
+    public Matrix3d subtract(Matrix3d mat) {
+        return subtract(mat, this);
+    }
+
+    /**
+     * Subtracts a matrix from this matrix and writes the result into the result matrix.
+     */
+    public Matrix3d subtract(Matrix3d mat, Matrix3d result) {
+        for (int i = 0; i < 9; i++) {
+            result.m[i] = m[i] - mat.m[i];
         }
         return result;
     }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
@@ -27,8 +27,9 @@ public class Matrix4d implements Serializable {
     private static final DecimalFormat FORMAT = new DecimalFormat("0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     /**
-     * Array holding value of the matrix. Values are stored column-wise, that is, the first 4 values
-     * represent the first column, the second 4 values the second column, and so on.<br>
+     * Array holding value of the matrix. Values are stored in column-major order.
+     *
+     * @see MatrixAlignment#COLUMNS
      */
     protected final double[] m = new double[16];
 

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
@@ -27,11 +27,10 @@ public class Matrix4d implements Serializable {
     private static final DecimalFormat FORMAT = new DecimalFormat("0.000", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     /**
-     * Array holding value of the matrix. Values are stored row-wise, that is, the first 4 values
-     * represent the first row, the second 4 values the second row, and so on.<br>
-     * Do NOT use this array directly, unless it is from crucial importance (e.g. during physics simulation)
+     * Array holding value of the matrix. Values are stored column-wise, that is, the first 4 values
+     * represent the first column, the second 4 values the second column, and so on.<br>
      */
-    public final double[] m = new double[16];
+    protected final double[] m = new double[16];
 
     /**
      * Creates a new 4x4 matrix, with all values being zero.
@@ -83,17 +82,78 @@ public class Matrix4d implements Serializable {
     }
 
     /**
+     * Sets the values of the matrix by the given double array. The alignment
+     * parameter defines how the values in the given array are arranged
+     * (either column or row-wise).
+     */
+    public Matrix4d set(double[] values, MatrixAlignment alignment) {
+        System.arraycopy(values, 0, this.m, 0, 16);
+        if (alignment == MatrixAlignment.ROWS) {
+            transpose();
+        }
+        return this;
+    }
+
+    /**
+     * Sets the values of the matrix by the given float array. The alignment
+     * parameter defines how the values in the given array are arranged
+     * (either column or row-wise).
+     */
+    public Matrix4d set(float[] values, MatrixAlignment alignment) {
+        for (int r = 0; r < 4; r++) {
+            for (int c = 0; c < 4; c++) {
+                m[c * 4 + r] = alignment == MatrixAlignment.COLUMNS
+                        ? values[c * 4 + r]
+                        : values[r * 4 + c];
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Returns the values of the matrix and writes it into the the given double array.
+     * The alignment parameter defines how the values in the given array will be arranged
+     * (either column or row-wise).
+     */
+    public double[] getAsDoubleArray(double[] result, MatrixAlignment alignment) {
+        for (int r = 0; r < 4; r++) {
+            for (int c = 0; c < 4; c++) {
+                result[c * 4 + r] = alignment == MatrixAlignment.COLUMNS
+                        ? m[c * 4 + r]
+                        : m[r * 4 + c];
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the values of the matrix and writes it into the the given float array.
+     * The alignment parameter defines how the values in the given array will be arranged
+     * (either column or row-wise).
+     */
+    public float[] getAsFloatArray(float[] result, MatrixAlignment alignment) {
+        for (int r = 0; r < 4; r++) {
+            for (int c = 0; c < 4; c++) {
+                result[c * 4 + r] = alignment == MatrixAlignment.COLUMNS
+                        ? (float) m[c * 4 + r]
+                        : (float) m[r * 4 + c];
+            }
+        }
+        return result;
+    }
+
+    /**
      * Get a specific value from the matrix by row and column index
      */
     public double get(int row, int col) {
-        return m[row * 4 + col];
+        return m[col * 4 + row];
     }
 
     /**
      * Sets a specific value in the matrix by row and column index
      */
     public Matrix4d set(int row, int col, double value) {
-        m[row * 4 + col] = value;
+        m[col * 4 + row] = value;
         return this;
     }
 
@@ -110,6 +170,23 @@ public class Matrix4d implements Serializable {
     public Matrix4d add(Matrix4d mat, Matrix4d result) {
         for (int i = 0; i < 16; i++) {
             result.m[i] = m[i] + mat.m[i];
+        }
+        return result;
+    }
+
+    /**
+     * Subtracts a matrix from this matrix.
+     */
+    public Matrix4d subtract(Matrix4d mat) {
+        return subtract(mat, this);
+    }
+
+    /**
+     * Subtracts a matrix from this matrix and writes the result into the result matrix.
+     */
+    public Matrix4d subtract(Matrix4d mat, Matrix4d result) {
+        for (int i = 0; i < 16; i++) {
+            result.m[i] = m[i] - mat.m[i];
         }
         return result;
     }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
@@ -109,7 +109,7 @@ public class Matrix4d implements Serializable {
      */
     public Matrix4d add(Matrix4d mat, Matrix4d result) {
         for (int i = 0; i < 16; i++) {
-            result.m[i] += mat.m[i];
+            result.m[i] = m[i] + mat.m[i];
         }
         return result;
     }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MatrixAlignment.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MatrixAlignment.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.math;
+
+public enum MatrixAlignment {
+
+    /**
+     * Values are stored in a way, that subsequent values belong
+     * to the same row. That is, in a 3x3 matrix, the first 3 values
+     * belong to the first row, the second 3 values to the second row, and so on.
+     */
+    ROWS,
+    /**
+     * Values are stored in a way, that subsequent values
+     * to the same column. That is, in a 3x3 matrix, the first 3 values
+     * belong to the first column, the second 3 values to the second column, and so on.
+     */
+    COLUMNS
+}

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MatrixAlignment.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MatrixAlignment.java
@@ -18,14 +18,12 @@ package org.eclipse.mosaic.lib.math;
 public enum MatrixAlignment {
 
     /**
-     * Values are stored in a way, that subsequent values belong
-     * to the same row. That is, in a 3x3 matrix, the first 3 values
+     * Values are stored row-major order. That is, in a 3x3 matrix, the first 3 values
      * belong to the first row, the second 3 values to the second row, and so on.
      */
     ROWS,
     /**
-     * Values are stored in a way, that subsequent values
-     * to the same column. That is, in a 3x3 matrix, the first 3 values
+     * Values are stored in column-major order. That is, in a 3x3 matrix, the first 3 values
      * belong to the first column, the second 3 values to the second column, and so on.
      */
     COLUMNS

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/RotationMatrix.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/RotationMatrix.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.spatial;
+
+import org.eclipse.mosaic.lib.math.MathUtils;
+import org.eclipse.mosaic.lib.math.Matrix3d;
+import org.eclipse.mosaic.lib.math.MatrixAlignment;
+import org.eclipse.mosaic.lib.math.Vector3d;
+
+public class RotationMatrix extends Matrix3d {
+
+
+    private static final RotationMatrix tmpRotA = new RotationMatrix();
+    private static final RotationMatrix tmpRotB = new RotationMatrix();
+
+    /**
+     * Creates a new transformation matrix. The initial values match the identity matrix.
+     */
+    public RotationMatrix() {
+        setIdentity();
+    }
+
+    /**
+     * Creates a new transformation matrix with values from the given TransformationMatrix.
+     */
+    public RotationMatrix(RotationMatrix copyFrom) {
+        set(copyFrom);
+    }
+
+    /**
+     * Adds rotation to this transformation matrix.
+     */
+    public RotationMatrix rotate(double angleDeg, Vector3d axis) {
+        return rotate(angleDeg, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Adds rotation to this transformation matrix.
+     */
+    public RotationMatrix rotate(double angleDeg, double axX, double axY, double axZ) {
+        synchronized (tmpRotA) {
+            tmpRotA.setRotation(angleDeg, axX, axY, axZ);
+            set(multiply(tmpRotA, tmpRotB));
+        }
+        return this;
+    }
+
+    private void setRotation(double angleDeg, double axX, double axY, double axZ) {
+        double a = Math.toRadians(angleDeg);
+        double x = axX;
+        double y = axY;
+        double z = axZ;
+        double s = Math.sin(a);
+        double c = Math.cos(a);
+        if (1.0f == x && 0.0f == y && 0.0f == z) {
+            m[4] = c;
+            m[8] = c;
+            m[5] = s;
+            m[7] = -s;
+            m[1] = 0f;
+            m[2] = 0f;
+            m[3] = 0f;
+            m[6] = 0f;
+            m[0] = 1f;
+        } else if (0.0f == x && 1.0f == y && 0.0f == z) {
+            m[0] = c;
+            m[8] = c;
+            m[6] = s;
+            m[2] = -s;
+            m[1] = 0f;
+            m[3] = 0f;
+            m[5] = 0f;
+            m[7] = 0f;
+            m[4] = 1f;
+        } else if (0.0f == x && 0.0f == y && 1.0f == z) {
+            m[0] = c;
+            m[4] = c;
+            m[1] = s;
+            m[3] = -s;
+            m[2] = 0f;
+            m[5] = 0f;
+            m[6] = 0f;
+            m[7] = 0f;
+            m[8] = 1f;
+        } else {
+            double len = Math.sqrt(x * x + y * y + z * z);
+            if (!MathUtils.isFuzzyEqual(len, 1f)) {
+                double recipLen = 1.0 / len;
+                x *= recipLen;
+                y *= recipLen;
+                z *= recipLen;
+            }
+            double nc = 1.0f - c;
+            double xy = x * y;
+            double yz = y * z;
+            double zx = z * x;
+            double xs = x * s;
+            double ys = y * s;
+            double zs = z * s;
+            m[0] = x * x * nc + c;
+            m[3] = xy * nc - zs;
+            m[6] = zx * nc + ys;
+            m[1] = xy * nc + zs;
+            m[4] = y * y * nc + c;
+            m[7] = yz * nc - xs;
+            m[2] = zx * nc - ys;
+            m[5] = yz * nc + xs;
+            m[8] = z * z * nc + c;
+        }
+    }
+
+    @Override
+    public RotationMatrix copy() {
+        return new RotationMatrix(this);
+    }
+
+    @Override
+    public RotationMatrix set(Matrix3d mat) {
+        return (RotationMatrix) super.set(mat);
+    }
+
+    @Override
+    public RotationMatrix setIdentity() {
+        return (RotationMatrix) super.setIdentity();
+    }
+
+    @Override
+    public RotationMatrix setZero() {
+        return (RotationMatrix) super.setZero();
+    }
+
+    @Override
+    public RotationMatrix set(double[] values, MatrixAlignment alignment) {
+        return (RotationMatrix) super.set(values, alignment);
+    }
+
+    @Override
+    public RotationMatrix set(float[] values, MatrixAlignment alignment) {
+        return (RotationMatrix) super.set(values, alignment);
+    }
+
+    @Override
+    public RotationMatrix set(int row, int col, double value) {
+        return (RotationMatrix) super.set(row, col, value);
+    }
+
+    @Override
+    public RotationMatrix transpose() {
+        return (RotationMatrix) super.transpose();
+    }
+
+    public RotationMatrix transpose(RotationMatrix result) {
+        return (RotationMatrix) super.transpose(result);
+    }
+
+    @Override
+    public RotationMatrix add(Matrix3d mat) {
+        return (RotationMatrix) super.add(mat);
+    }
+
+    public RotationMatrix add(Matrix3d mat, RotationMatrix result) {
+        return (RotationMatrix) super.add(mat, result);
+    }
+
+    @Override
+    public RotationMatrix subtract(Matrix3d mat) {
+        return (RotationMatrix) super.subtract(mat);
+    }
+
+    public RotationMatrix subtract(Matrix3d mat, RotationMatrix result) {
+        return (RotationMatrix) super.subtract(mat, result);
+    }
+
+    public RotationMatrix multiply(Matrix3d mat, RotationMatrix result) {
+        return (RotationMatrix) super.multiply(mat, result);
+    }
+}

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
@@ -15,9 +15,8 @@
 
 package org.eclipse.mosaic.lib.spatial;
 
-import org.eclipse.mosaic.lib.math.MathUtils;
-import org.eclipse.mosaic.lib.math.Matrix3d;
 import org.eclipse.mosaic.lib.math.Matrix4d;
+import org.eclipse.mosaic.lib.math.MatrixAlignment;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 /**
@@ -28,8 +27,7 @@ public class TransformationMatrix extends Matrix4d {
 
     private static final long serialVersionUID = 1L;
 
-    private static final TransformationMatrix tmpMatA = new TransformationMatrix();
-    private static final TransformationMatrix tmpMatB = new TransformationMatrix();
+    private static final RotationMatrix tmpRot = new RotationMatrix();
 
     /**
      * Creates a new transformation matrix. The initial values match the identity matrix.
@@ -52,30 +50,36 @@ public class TransformationMatrix extends Matrix4d {
         return new TransformationMatrix();
     }
 
-    public void toGlTransform(float[] glTransform) {
-        for (int i = 0; i < 16; i++) {
-            glTransform[i] = (float) m[i];
-        }
-    }
-
     /**
      * Extracts a 3x3 sub-matrix containing rotation+scale from this transformation matrix.
      */
-    public Matrix3d getRotation() {
-        return getRotation(new Matrix3d());
+    public RotationMatrix getRotation() {
+        return getRotation(new RotationMatrix());
     }
 
     /**
      * Extracts a 3x3 sub-matrix containing rotation+scale from this transformation matrix. The
      * result is written into the result matrix.
      */
-    public Matrix3d getRotation(Matrix3d result) {
+    public RotationMatrix getRotation(RotationMatrix result) {
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 3; col++) {
                 result.set(row, col, get(row, col));
             }
         }
         return result;
+    }
+
+    /**
+     * Replaces the 3x3 sub-matrix containing the rotation+scale for this transformation matrix.
+     */
+    public TransformationMatrix setRotation(RotationMatrix rotation) {
+        for (int row = 0; row < 3; row++) {
+            for (int col = 0; col < 3; col++) {
+                set(row, col, rotation.get(row, col));
+            }
+        }
+        return this;
     }
 
     /**
@@ -153,83 +157,12 @@ public class TransformationMatrix extends Matrix4d {
      * Adds rotation to this transformation matrix.
      */
     public TransformationMatrix rotate(double angleDeg, double axX, double axY, double axZ) {
-        synchronized (tmpMatA) {
-            tmpMatA.setRotation(angleDeg, axX, axY, axZ);
-            set(multiply(tmpMatA, tmpMatB));
+        synchronized (tmpRot) {
+            setRotation(getRotation(tmpRot).rotate(angleDeg, axX, axY, axZ));
         }
         return this;
     }
 
-    private void setRotation(double angleDeg, double axX, double axY, double axZ) {
-        double a = Math.toRadians(angleDeg);
-        double x = axX;
-        double y = axY;
-        double z = axZ;
-        m[3] = 0.0;
-        m[7] = 0.0;
-        m[11] = 0.0;
-        m[12] = 0.0;
-        m[13] = 0.0;
-        m[14] = 0.0;
-        m[15] = 1.0;
-        double s = Math.sin(a);
-        double c = Math.cos(a);
-        if (1.0f == x && 0.0f == y && 0.0f == z) {
-            m[5] = c;
-            m[10] = c;
-            m[6] = s;
-            m[9] = -s;
-            m[1] = 0f;
-            m[2] = 0f;
-            m[4] = 0f;
-            m[8] = 0f;
-            m[0] = 1f;
-        } else if (0.0f == x && 1.0f == y && 0.0f == z) {
-            m[0] = c;
-            m[10] = c;
-            m[8] = s;
-            m[2] = -s;
-            m[1] = 0f;
-            m[4] = 0f;
-            m[6] = 0f;
-            m[9] = 0f;
-            m[5] = 1f;
-        } else if (0.0f == x && 0.0f == y && 1.0f == z) {
-            m[0] = c;
-            m[5] = c;
-            m[1] = s;
-            m[4] = -s;
-            m[2] = 0f;
-            m[6] = 0f;
-            m[8] = 0f;
-            m[9] = 0f;
-            m[10] = 1f;
-        } else {
-            double len = Math.sqrt(x * x + y * y + z * z);
-            if (!MathUtils.isFuzzyEqual(len, 1f)) {
-                double recipLen = 1.0 / len;
-                x *= recipLen;
-                y *= recipLen;
-                z *= recipLen;
-            }
-            double nc = 1.0f - c;
-            double xy = x * y;
-            double yz = y * z;
-            double zx = z * x;
-            double xs = x * s;
-            double ys = y * s;
-            double zs = z * s;
-            m[0] = x * x * nc + c;
-            m[4] = xy * nc - zs;
-            m[8] = zx * nc + ys;
-            m[1] = xy * nc + zs;
-            m[5] = y * y * nc + c;
-            m[9] = yz * nc - xs;
-            m[2] = zx * nc - ys;
-            m[6] = yz * nc + xs;
-            m[10] = z * z * nc + c;
-        }
-    }
 
     @Override
     public TransformationMatrix copy() {
@@ -249,6 +182,16 @@ public class TransformationMatrix extends Matrix4d {
     @Override
     public TransformationMatrix setZero() {
         return (TransformationMatrix) super.setZero();
+    }
+
+    @Override
+    public TransformationMatrix set(float[] values, MatrixAlignment alignment) {
+        return (TransformationMatrix) super.set(values, alignment);
+    }
+
+    @Override
+    public TransformationMatrix set(double[] values, MatrixAlignment alignment) {
+        return (TransformationMatrix) super.set(values, alignment);
     }
 
     @Override
@@ -272,6 +215,15 @@ public class TransformationMatrix extends Matrix4d {
 
     public TransformationMatrix add(Matrix4d mat, TransformationMatrix result) {
         return (TransformationMatrix) super.add(mat, result);
+    }
+
+    @Override
+    public TransformationMatrix subtract(Matrix4d mat) {
+        return (TransformationMatrix) super.subtract(mat);
+    }
+
+    public TransformationMatrix subtract(Matrix4d mat, TransformationMatrix result) {
+        return (TransformationMatrix) super.subtract(mat, result);
     }
 
     public TransformationMatrix multiply(Matrix4d mat, TransformationMatrix result) {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.spatial;
+
+import org.eclipse.mosaic.lib.math.MathUtils;
+import org.eclipse.mosaic.lib.math.Matrix3d;
+import org.eclipse.mosaic.lib.math.Matrix4d;
+import org.eclipse.mosaic.lib.math.Vector3d;
+
+/**
+ * An special version of the {@link Matrix4d} providing further methods to
+ * describe scaling, rotation, and translation in the 3-dimensional space.
+ */
+public class TransformationMatrix extends Matrix4d {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final TransformationMatrix tmpMatA = new TransformationMatrix();
+    private static final TransformationMatrix tmpMatB = new TransformationMatrix();
+
+    /**
+     * Creates a new transformation matrix. The initial values match the identity matrix.
+     */
+    public TransformationMatrix() {
+        setIdentity();
+    }
+
+    /**
+     * Creates a new transformation matrix with values from the given TransformationMatrix.
+     */
+    public TransformationMatrix(TransformationMatrix copyFrom) {
+        set(copyFrom);
+    }
+
+    /**
+     * Creates a new transformation matrix. The initial values match the identity matrix.
+     */
+    public static TransformationMatrix identityMatrix() {
+        return new TransformationMatrix();
+    }
+
+    public void toGlTransform(float[] glTransform) {
+        for (int i = 0; i < 16; i++) {
+            glTransform[i] = (float) m[i];
+        }
+    }
+
+    /**
+     * Extracts a 3x3 sub-matrix containing rotation+scale from this transformation matrix.
+     */
+    public Matrix3d getRotation() {
+        return getRotation(new Matrix3d());
+    }
+
+    /**
+     * Extracts a 3x3 sub-matrix containing rotation+scale from this transformation matrix. The
+     * result is written into the result matrix.
+     */
+    public Matrix3d getRotation(Matrix3d result) {
+        for (int row = 0; row < 3; row++) {
+            for (int col = 0; col < 3; col++) {
+                result.set(row, col, get(row, col));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Extracts a 3 dimensional vector containing translation part from this transformation matrix.
+     */
+    public Vector3d getTranslation() {
+        return getTranslation(new Vector3d());
+    }
+
+    /**
+     * Extracts a 3 dimensional vector containing translation part from this transformation matrix. The
+     * result is written into the result vector.
+     */
+    public Vector3d getTranslation(Vector3d result) {
+        result.x = get(0,3);
+        result.y = get(1,3);
+        result.z = get(2,3);
+        return result;
+    }
+
+    /**
+     * Applies this transformation matrix to the given vector.
+     */
+    public Vector3d transform(Vector3d vec) {
+        return transform(vec, 1d);
+    }
+
+    /**
+     * Applies this transformation matrix to the given vector.
+     */
+    public Vector3d transform(Vector3d vec3, double w) {
+        double x = vec3.x * m[0] + vec3.y * m[4] + vec3.z * m[8] + w * m[12];
+        double y = vec3.x * m[1] + vec3.y * m[5] + vec3.z * m[9] + w * m[13];
+        double z = vec3.x * m[2] + vec3.y * m[6] + vec3.z * m[10] + w * m[14];
+        return vec3.set(x, y, z);
+    }
+
+    /**
+     * Adds translation to this transformation matrix.
+     */
+    public TransformationMatrix translate(Vector3d t) {
+        return translate(t.x, t.y, t.z);
+    }
+
+    /**
+     * Adds translation to this transformation matrix.
+     */
+    public TransformationMatrix translate(double x, double y, double z) {
+        for (int i = 0; i < 4; i++) {
+            m[12 + i] += m[i] * x + m[4 + i] * y + m[8 + i] * z;
+        }
+        return this;
+    }
+
+    /**
+     * Adds scaling to this transformation matrix.
+     */
+    public TransformationMatrix scale(double sx, double sy, double sz) {
+        for (int i = 0; i < 4; i++) {
+            m[i] *= sx;
+            m[4 + i] *= sy;
+            m[8 + i] *= sz;
+        }
+        return this;
+    }
+
+    /**
+     * Adds rotation to this transformation matrix.
+     */
+    public TransformationMatrix rotate(double angleDeg, Vector3d axis) {
+        return rotate(angleDeg, axis.x, axis.y, axis.z);
+    }
+
+    /**
+     * Adds rotation to this transformation matrix.
+     */
+    public TransformationMatrix rotate(double angleDeg, double axX, double axY, double axZ) {
+        synchronized (tmpMatA) {
+            tmpMatA.setRotation(angleDeg, axX, axY, axZ);
+            set(multiply(tmpMatA, tmpMatB));
+        }
+        return this;
+    }
+
+    private void setRotation(double angleDeg, double axX, double axY, double axZ) {
+        double a = Math.toRadians(angleDeg);
+        double x = axX;
+        double y = axY;
+        double z = axZ;
+        m[3] = 0.0;
+        m[7] = 0.0;
+        m[11] = 0.0;
+        m[12] = 0.0;
+        m[13] = 0.0;
+        m[14] = 0.0;
+        m[15] = 1.0;
+        double s = Math.sin(a);
+        double c = Math.cos(a);
+        if (1.0f == x && 0.0f == y && 0.0f == z) {
+            m[5] = c;
+            m[10] = c;
+            m[6] = s;
+            m[9] = -s;
+            m[1] = 0f;
+            m[2] = 0f;
+            m[4] = 0f;
+            m[8] = 0f;
+            m[0] = 1f;
+        } else if (0.0f == x && 1.0f == y && 0.0f == z) {
+            m[0] = c;
+            m[10] = c;
+            m[8] = s;
+            m[2] = -s;
+            m[1] = 0f;
+            m[4] = 0f;
+            m[6] = 0f;
+            m[9] = 0f;
+            m[5] = 1f;
+        } else if (0.0f == x && 0.0f == y && 1.0f == z) {
+            m[0] = c;
+            m[5] = c;
+            m[1] = s;
+            m[4] = -s;
+            m[2] = 0f;
+            m[6] = 0f;
+            m[8] = 0f;
+            m[9] = 0f;
+            m[10] = 1f;
+        } else {
+            double len = Math.sqrt(x * x + y * y + z * z);
+            if (!MathUtils.isFuzzyEqual(len, 1f)) {
+                double recipLen = 1.0 / len;
+                x *= recipLen;
+                y *= recipLen;
+                z *= recipLen;
+            }
+            double nc = 1.0f - c;
+            double xy = x * y;
+            double yz = y * z;
+            double zx = z * x;
+            double xs = x * s;
+            double ys = y * s;
+            double zs = z * s;
+            m[0] = x * x * nc + c;
+            m[4] = xy * nc - zs;
+            m[8] = zx * nc + ys;
+            m[1] = xy * nc + zs;
+            m[5] = y * y * nc + c;
+            m[9] = yz * nc - xs;
+            m[2] = zx * nc - ys;
+            m[6] = yz * nc + xs;
+            m[10] = z * z * nc + c;
+        }
+    }
+
+    @Override
+    public TransformationMatrix copy() {
+        return new TransformationMatrix(this);
+    }
+
+    @Override
+    public TransformationMatrix set(Matrix4d mat) {
+        return (TransformationMatrix) super.set(mat);
+    }
+
+    @Override
+    public TransformationMatrix setIdentity() {
+        return (TransformationMatrix) super.setIdentity();
+    }
+
+    @Override
+    public TransformationMatrix setZero() {
+        return (TransformationMatrix) super.setZero();
+    }
+
+    @Override
+    public TransformationMatrix set(int row, int col, double value) {
+        return (TransformationMatrix) super.set(row, col, value);
+    }
+
+    @Override
+    public TransformationMatrix transpose() {
+        return (TransformationMatrix) super.transpose();
+    }
+
+    public TransformationMatrix transpose(TransformationMatrix result) {
+        return (TransformationMatrix) super.transpose(result);
+    }
+
+    @Override
+    public TransformationMatrix add(Matrix4d mat) {
+        return (TransformationMatrix) super.add(mat);
+    }
+
+    public TransformationMatrix add(Matrix4d mat, TransformationMatrix result) {
+        return (TransformationMatrix) super.add(mat, result);
+    }
+
+    public TransformationMatrix multiply(Matrix4d mat, TransformationMatrix result) {
+        return (TransformationMatrix) super.multiply(mat, result);
+    }
+
+}

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix3dTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix3dTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.math;
+
+import static org.junit.Assert.fail;
+
+import org.eclipse.mosaic.lib.spatial.TransformationMatrix;
+
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Matrix3dTest {
+
+    @Test
+    public void transpose() {
+        final Matrix3d mExpected = new Matrix3d().setIdentity();
+        set(mExpected, "[1, 2, 3], [8, 6, 7], [-9, -4, 5]");
+
+        final Matrix3d mTransposedExpected = new Matrix3d();
+        set(mTransposedExpected, "[1, 8, -9], [2, 6, -4], [3, 7, 5]");
+
+        Matrix3d m = new Matrix3d(mExpected);
+
+        Matrix3d mTransposed = m.transpose(new Matrix3d());
+        assertEquals(mTransposed, mTransposedExpected);
+        assertEquals(m, mExpected); //m remains untouched
+
+        Matrix3d mTransposedTransposed = mTransposed.transpose(new Matrix3d());
+        assertEquals(mExpected, mTransposedTransposed); //double transpose results in original matrix
+
+        m.transpose();
+        assertEquals(m, mTransposedExpected); //m
+    }
+
+    @Test
+    public void inverse() {
+        final Matrix3d m = new Matrix3d();
+        set(m, "[1, 2, 3], [8, 6, 7], [-9, -4, 5]");
+
+        final Matrix3d mInvExpected = new Matrix3d();
+        set(mInvExpected, "[-0.707317073, 0.268292683, 0.048780488], [1.256097561, -0.390243902, -0.207317073], [-0.268292683, 0.170731707, 0.121951220]");
+
+        final Matrix3d mInverted = new Matrix3d();
+        m.inverse(mInverted);
+        assertEquals(mInverted, mInvExpected);
+
+        final Matrix3d multiplied = m.multiply(mInverted, new Matrix3d());
+        assertEquals(Matrix3d.identityMatrix(), multiplied);
+    }
+
+    @Test
+    public void transposeRotationMatrix() {
+        final TransformationMatrix m = new TransformationMatrix();
+        m.rotate(37, new Vector3d(0,1,0));
+
+
+        Matrix3d rotation = m.getRotation();
+        System.out.println(rotation);
+        Matrix3d inverse = new Matrix3d();
+        rotation.inverse(inverse);
+        Matrix3d transposed = new Matrix3d();
+        rotation.transpose(transposed);
+
+        assertEquals(inverse, transposed);
+    }
+
+    private void set(Matrix3d m, String matrix) {
+        Matcher matcher = Pattern.compile("([0-9\\-.]+)").matcher(matrix);
+        for (int r = 0; r < 3; r++) {
+            for (int c = 0; c < 3; c++) {
+                if (matcher.find()) {
+                    m.set(r, c, Double.parseDouble(matcher.group(1)));
+                }
+            }
+        }
+    }
+
+    private static void assertEquals(Matrix3d expected, Matrix3d actual) {
+        if(!expected.isFuzzyEqual(actual)) {
+            fail(String.format("Matrix not fuzzy equal.%nExpected: %s%nActual: %s", expected, actual));
+        }
+    }
+
+}

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix3dTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix3dTest.java
@@ -15,12 +15,12 @@
 
 package org.eclipse.mosaic.lib.math;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import org.eclipse.mosaic.lib.spatial.TransformationMatrix;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -64,19 +64,40 @@ public class Matrix3dTest {
     }
 
     @Test
-    public void transposeRotationMatrix() {
-        final TransformationMatrix m = new TransformationMatrix();
-        m.rotate(37, new Vector3d(0,1,0));
+    public void getAsArray() {
+        final Matrix3d m = new Matrix3d();
+        set(m, "[1, 2, 3], [8, 6, 7], [-9, -4, 5]");
 
+        float[] resultf = m.getAsFloatArray(new float[9], MatrixAlignment.ROWS);
+        assertTrue(Arrays.equals(new float[] {1f, 2f, 3f, 8f, 6f, 7f, -9f, -4f, 5f}, resultf));
 
-        Matrix3d rotation = m.getRotation();
-        System.out.println(rotation);
-        Matrix3d inverse = new Matrix3d();
-        rotation.inverse(inverse);
-        Matrix3d transposed = new Matrix3d();
-        rotation.transpose(transposed);
+        resultf = m.getAsFloatArray(new float[9], MatrixAlignment.COLUMNS);
+        assertTrue(Arrays.equals(new float[] {1f, 8f, -9f, 2f, 6f, -4f, 3f, 7f, 5f}, resultf));
 
-        assertEquals(inverse, transposed);
+        double[] resultd = m.getAsDoubleArray(new double[9], MatrixAlignment.ROWS);
+        assertTrue(Arrays.equals(new double[] {1d, 2d, 3d, 8d, 6d, 7d, -9d, -4d, 5d}, resultd));
+
+        resultd = m.getAsDoubleArray(new double[9], MatrixAlignment.COLUMNS);
+        assertTrue(Arrays.equals(new double[] {1d, 8d, -9d, 2d, 6d, -4d, 3d, 7d, 5d}, resultd));
+    }
+
+    @Test
+    public void setArray() {
+        final Matrix3d expected = new Matrix3d();
+        set(expected, "[1, 2, 3], [8, 6, 7], [-9, -4, 5]");
+
+        Matrix3d m = new Matrix3d();
+        m.set(new float[] {1f, 2f, 3f, 8f, 6f, 7f, -9f, -4f, 5f}, MatrixAlignment.ROWS);
+        assertEquals(expected, m);
+
+        m.set(new double[] {1d, 2d, 3d, 8d, 6d, 7d, -9d, -4d, 5d}, MatrixAlignment.ROWS);
+        assertEquals(expected, m);
+
+        m.set(new float[] {1f, 8f, -9f, 2f, 6f, -4f, 3f, 7f, 5f}, MatrixAlignment.COLUMNS);
+        assertEquals(expected, m);
+
+        m.set(new double[] {1d, 8d, -9d, 2d, 6d, -4d, 3d, 7d, 5d}, MatrixAlignment.COLUMNS);
+        assertEquals(expected, m);
     }
 
     private void set(Matrix3d m, String matrix) {

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix4dTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix4dTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.math;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Matrix4dTest {
+
+    @Test
+    public void transpose() {
+        final Matrix4d mExpected = new Matrix4d().setIdentity();
+        set(mExpected, "[1, 2, 3, 4], [8, 6, 7, 2], [-9, -4, 5, 1], [13, 0, 2 -1]");
+
+        final Matrix4d mTransposedExpected = new Matrix4d();
+        set(mTransposedExpected, "[1, 8, -9, 13], [2, 6, -4, 0], [3, 7, 5, 2], [4, 2, 1, -1]");
+
+        Matrix4d m = new Matrix4d(mExpected);
+
+        Matrix4d mTransposed = m.transpose(new Matrix4d());
+        assertEquals(mTransposedExpected, mTransposed);
+        assertEquals(mExpected, m); //m remains untouched
+
+        Matrix4d mTransposedTransposed = mTransposed.transpose(new Matrix4d());
+        assertEquals(mExpected, mTransposedTransposed); //double transpose results in original matrix
+
+        m.transpose();
+        assertEquals(mTransposedExpected, m); //m
+    }
+
+    @Test
+    public void inverse() {
+        final Matrix4d m = new Matrix4d();
+        set(m, "[1, 2, 3, 4], [8, 6, 7, 2], [-9, -4, 5, 1], [13, 0, 2 -1]");
+
+        final Matrix4d mInvExpected = new Matrix4d();
+        set(mInvExpected, "[0.0356846473, -0.0240663900, -0.0182572614, 0.0763485477], [-0.0804979253, 0.1356846473, -0.0867219917, -0.1373443983], [-0.0663900415, 0.0912863071, 0.1037344398, 0.0207468880], [0.3311203320, -0.1302904564, -0.0298755187, 0.0340248963]");
+
+        final Matrix4d mInverted = new Matrix4d();
+        m.inverse(mInverted);
+        assertEquals(mInvExpected, mInverted);
+
+        final Matrix4d multiplied = m.multiply(mInverted, new Matrix4d());
+        assertEquals(Matrix4d.identityMatrix(), multiplied);
+    }
+
+    private void set(Matrix4d m, String matrix) {
+        Matcher matcher = Pattern.compile("([0-9\\-.]+)").matcher(matrix);
+        for (int r = 0; r < 4; r++) {
+            for (int c = 0; c < 4; c++) {
+                if (matcher.find()) {
+                    m.set(r, c, Double.parseDouble(matcher.group(1)));
+                }
+            }
+        }
+    }
+
+    private static void assertEquals(Matrix4d expected, Matrix4d actual) {
+        if (!expected.isFuzzyEqual(actual)) {
+            fail(String.format("Matrix not fuzzy equal.%nExpected: %s%nActual:%s", expected, actual));
+        }
+    }
+
+}

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/TransformationMatrixTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/TransformationMatrixTest.java
@@ -1,0 +1,25 @@
+package org.eclipse.mosaic.lib.math;
+
+import org.eclipse.mosaic.lib.spatial.TransformationMatrix;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TransformationMatrixTest {
+
+    @Test
+    public void translate() {
+        TransformationMatrix transformation = new TransformationMatrix();
+        transformation.translate(1, 2, 3);
+
+        Vector3d x = new Vector3d(0, 0, 0);
+        transformation.transform(x);
+        Assert.assertEquals(1.0, x.x, 0.00001);
+        Assert.assertEquals(2.0, x.y, 0.00001);
+        Assert.assertEquals(3.0, x.z, 0.00001);
+
+        Assert.assertEquals(1.0, transformation.get(0, 3), 0.00001);
+        Assert.assertEquals(2.0, transformation.get(1, 3), 0.00001);
+        Assert.assertEquals(3.0, transformation.get(2, 3), 0.00001);
+    }
+
+}

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/RotationMatrixTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/RotationMatrixTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.spatial;
+
+import static org.junit.Assert.fail;
+
+import org.eclipse.mosaic.lib.math.Matrix3d;
+import org.eclipse.mosaic.lib.math.Vector3d;
+
+import org.junit.Test;
+
+public class RotationMatrixTest {
+
+    @Test
+    public void transposeRotationMatrix() {
+        final RotationMatrix rotation = new RotationMatrix();
+        rotation.rotate(37, new Vector3d(0,1,0));
+
+        RotationMatrix inverse = new RotationMatrix();
+        rotation.inverse(inverse);
+        RotationMatrix transposed = new RotationMatrix();
+        rotation.transpose(transposed);
+
+        assertEquals(inverse, transposed);
+    }
+
+    private static void assertEquals(Matrix3d expected, Matrix3d actual) {
+        if(!expected.isFuzzyEqual(actual)) {
+            fail(String.format("Matrix not fuzzy equal.%nExpected: %s%nActual: %s", expected, actual));
+        }
+    }
+}

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/TransformationMatrixTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/TransformationMatrixTest.java
@@ -1,6 +1,22 @@
-package org.eclipse.mosaic.lib.math;
+/*
+ * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
 
-import org.eclipse.mosaic.lib.spatial.TransformationMatrix;
+package org.eclipse.mosaic.lib.spatial;
+
+import org.eclipse.mosaic.lib.math.Vector3d;
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/TransformationMatrixTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/TransformationMatrixTest.java
@@ -15,6 +15,12 @@
 
 package org.eclipse.mosaic.lib.spatial;
 
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.lang.Math.toRadians;
+import static org.junit.Assert.fail;
+
+import org.eclipse.mosaic.lib.math.Matrix3d;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 import org.junit.Assert;
@@ -36,6 +42,34 @@ public class TransformationMatrixTest {
         Assert.assertEquals(1.0, transformation.get(0, 3), 0.00001);
         Assert.assertEquals(2.0, transformation.get(1, 3), 0.00001);
         Assert.assertEquals(3.0, transformation.get(2, 3), 0.00001);
+    }
+
+    @Test
+    public void rotate() {
+        final RotationMatrix expected = new RotationMatrix()
+                .rotate(37, new Vector3d(1,0,0));
+
+        final TransformationMatrix transformationMatrix = new TransformationMatrix();
+        transformationMatrix
+                .rotate(45, new Vector3d(1,0,0))
+                .rotate(90, new Vector3d(0,1,0))
+                .rotate(270, new Vector3d(0,1,0))
+                .rotate(-8, new Vector3d(1,0,0));
+
+
+        final RotationMatrix actual = transformationMatrix.getRotation();
+        assertEquals(expected, actual);
+        Assert.assertEquals(1, actual.get(0, 0), 0.0001);
+        Assert.assertEquals(sin(toRadians(37)), actual.get(2, 1), 0.0001);
+        Assert.assertEquals(-sin(toRadians(37)), actual.get(1, 2), 0.0001);
+        Assert.assertEquals(cos(toRadians(37)), actual.get(1, 1), 0.0001);
+        Assert.assertEquals(cos(toRadians(37)), actual.get(2, 2), 0.0001);
+    }
+
+    private static void assertEquals(Matrix3d expected, Matrix3d actual) {
+        if(!expected.isFuzzyEqual(actual)) {
+            fail(String.format("Matrix not fuzzy equal.%nExpected: %s%nActual: %s", expected, actual));
+        }
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Karl Schrab <karl.schrab@fokus.fraunhofer.de>

## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* The method set of Matrix3d and Matrix4d was quite different. This PR aligns those methods to have a very similar API. 
* Both `Matrix3d` and `Matrix4d`, provide the following methods: `setIdentity`, `setZero`, `get(row, col)`, `set(row, col, value)`, `add`, `multiply`, `transpose`, `inverse`, `copy`, `isFuzzyEqual`, `equals`, `hashCode`, and `toString`
* `Matrix4d` now very generic. Everything which was related to transformation matrix has been moved to a separate class `TransformationMatrix`
* `TransformationMatrix` provides additional methods `translate`, `scale`, `rotate`, `getRotation`, `getTranslation`
* New instances of `Matrix3d` and `Matrix4d` initialize with zeros, whereas `TransformationMatrix` initializes with identity matrix.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special Notes to Reviewer

@fabmax I did not change the alignment in the Matrix3d array yet. if we would do this we would need to transpose the rotation matrix every time before we pass it to jbullet and transpose again when reading the array.