### PR TITLE
Renamed MatrixAlignment to MatrixElementOrder

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix3d.java
@@ -29,7 +29,7 @@ public class Matrix3d implements Serializable {
     /**
      * Array holding value of the matrix. Values are stored in column-major order.
      *
-     * @see MatrixAlignment#COLUMNS
+     * @see MatrixElementOrder#COLUMN_MAJOR
      */
     protected final double[] m = new double[9];
 
@@ -78,32 +78,32 @@ public class Matrix3d implements Serializable {
      * Copies the values from the given matrix to this matrix.
      */
     public Matrix3d set(Matrix3d m) {
-        set(m.m, MatrixAlignment.COLUMNS);
+        set(m.m, MatrixElementOrder.COLUMN_MAJOR);
         return this;
     }
 
     /**
-     * Sets the values of the matrix by the given double array. The alignment
+     * Sets the values of the matrix by the given double array. The order
      * parameter defines how the values in the given array are arranged
      * (either column or row-wise).
      */
-    public Matrix3d set(double[] values, MatrixAlignment alignment) {
+    public Matrix3d set(double[] values, MatrixElementOrder inputOrder) {
         System.arraycopy(values, 0, this.m, 0, 9);
-        if (alignment == MatrixAlignment.ROWS) {
+        if (inputOrder == MatrixElementOrder.ROW_MAJOR) {
             transpose();
         }
         return this;
     }
 
     /**
-     * Sets the values of the matrix by the given float array. The alignment
+     * Sets the values of the matrix by the given float array. The order
      * parameter defines how the values in the given array are arranged
      * (either column or row-wise).
      */
-    public Matrix3d set(float[] values, MatrixAlignment alignment) {
+    public Matrix3d set(float[] values, MatrixElementOrder inputOrder) {
         for (int r = 0; r < 3; r++) {
             for (int c = 0; c < 3; c++) {
-                m[c * 3 + r] = alignment == MatrixAlignment.COLUMNS
+                m[c * 3 + r] = inputOrder == MatrixElementOrder.COLUMN_MAJOR
                         ? values[c * 3 + r]
                         : values[r * 3 + c];
             }
@@ -113,13 +113,13 @@ public class Matrix3d implements Serializable {
 
     /**
      * Returns the values of the matrix and writes it into the the given double array.
-     * The alignment parameter defines how the values in the given array will be arranged
+     * The order parameter defines how the values in the given array will be arranged
      * (either column or row-wise).
      */
-    public double[] getAsDoubleArray(double[] result, MatrixAlignment alignment) {
+    public double[] getAsDoubleArray(double[] result, MatrixElementOrder outputOrder) {
         for (int r = 0; r < 3; r++) {
             for (int c = 0; c < 3; c++) {
-                result[c * 3 + r] = alignment == MatrixAlignment.COLUMNS
+                result[c * 3 + r] = outputOrder == MatrixElementOrder.COLUMN_MAJOR
                         ? m[c * 3 + r]
                         : m[r * 3 + c];
             }
@@ -129,13 +129,13 @@ public class Matrix3d implements Serializable {
 
     /**
      * Returns the values of the matrix and writes it into the the given float array.
-     * The alignment parameter defines how the values in the given array will be arranged
+     * The order parameter defines how the values in the given array will be arranged
      * (either column or row-wise).
      */
-    public float[] getAsFloatArray(float[] result, MatrixAlignment alignment) {
+    public float[] getAsFloatArray(float[] result, MatrixElementOrder outputOrder) {
         for (int r = 0; r < 3; r++) {
             for (int c = 0; c < 3; c++) {
-                result[c * 3 + r] = alignment == MatrixAlignment.COLUMNS
+                result[c * 3 + r] = outputOrder == MatrixElementOrder.COLUMN_MAJOR
                         ? (float) m[c * 3 + r]
                         : (float) m[r * 3 + c];
             }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Matrix4d.java
@@ -29,7 +29,7 @@ public class Matrix4d implements Serializable {
     /**
      * Array holding value of the matrix. Values are stored in column-major order.
      *
-     * @see MatrixAlignment#COLUMNS
+     * @see MatrixElementOrder#COLUMN_MAJOR
      */
     protected final double[] m = new double[16];
 
@@ -83,27 +83,27 @@ public class Matrix4d implements Serializable {
     }
 
     /**
-     * Sets the values of the matrix by the given double array. The alignment
+     * Sets the values of the matrix by the given double array. The order
      * parameter defines how the values in the given array are arranged
      * (either column or row-wise).
      */
-    public Matrix4d set(double[] values, MatrixAlignment alignment) {
+    public Matrix4d set(double[] values, MatrixElementOrder inputOrder) {
         System.arraycopy(values, 0, this.m, 0, 16);
-        if (alignment == MatrixAlignment.ROWS) {
+        if (inputOrder == MatrixElementOrder.ROW_MAJOR) {
             transpose();
         }
         return this;
     }
 
     /**
-     * Sets the values of the matrix by the given float array. The alignment
+     * Sets the values of the matrix by the given float array. The order
      * parameter defines how the values in the given array are arranged
      * (either column or row-wise).
      */
-    public Matrix4d set(float[] values, MatrixAlignment alignment) {
+    public Matrix4d set(float[] values, MatrixElementOrder inputOrder) {
         for (int r = 0; r < 4; r++) {
             for (int c = 0; c < 4; c++) {
-                m[c * 4 + r] = alignment == MatrixAlignment.COLUMNS
+                m[c * 4 + r] = inputOrder == MatrixElementOrder.COLUMN_MAJOR
                         ? values[c * 4 + r]
                         : values[r * 4 + c];
             }
@@ -113,13 +113,13 @@ public class Matrix4d implements Serializable {
 
     /**
      * Returns the values of the matrix and writes it into the the given double array.
-     * The alignment parameter defines how the values in the given array will be arranged
+     * The order parameter defines how the values in the given array will be arranged
      * (either column or row-wise).
      */
-    public double[] getAsDoubleArray(double[] result, MatrixAlignment alignment) {
+    public double[] getAsDoubleArray(double[] result, MatrixElementOrder outputOrder) {
         for (int r = 0; r < 4; r++) {
             for (int c = 0; c < 4; c++) {
-                result[c * 4 + r] = alignment == MatrixAlignment.COLUMNS
+                result[c * 4 + r] = outputOrder == MatrixElementOrder.COLUMN_MAJOR
                         ? m[c * 4 + r]
                         : m[r * 4 + c];
             }
@@ -129,13 +129,13 @@ public class Matrix4d implements Serializable {
 
     /**
      * Returns the values of the matrix and writes it into the the given float array.
-     * The alignment parameter defines how the values in the given array will be arranged
+     * The order parameter defines how the values in the given array will be arranged
      * (either column or row-wise).
      */
-    public float[] getAsFloatArray(float[] result, MatrixAlignment alignment) {
+    public float[] getAsFloatArray(float[] result, MatrixElementOrder outputOrder) {
         for (int r = 0; r < 4; r++) {
             for (int c = 0; c < 4; c++) {
-                result[c * 4 + r] = alignment == MatrixAlignment.COLUMNS
+                result[c * 4 + r] = outputOrder == MatrixElementOrder.COLUMN_MAJOR
                         ? (float) m[c * 4 + r]
                         : (float) m[r * 4 + c];
             }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MatrixElementOrder.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/MatrixElementOrder.java
@@ -15,16 +15,17 @@
 
 package org.eclipse.mosaic.lib.math;
 
-public enum MatrixAlignment {
+public enum MatrixElementOrder {
 
     /**
      * Values are stored row-major order. That is, in a 3x3 matrix, the first 3 values
      * belong to the first row, the second 3 values to the second row, and so on.
      */
-    ROWS,
+    ROW_MAJOR,
+
     /**
      * Values are stored in column-major order. That is, in a 3x3 matrix, the first 3 values
      * belong to the first column, the second 3 values to the second column, and so on.
      */
-    COLUMNS
+    COLUMN_MAJOR
 }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/RotationMatrix.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/RotationMatrix.java
@@ -17,7 +17,7 @@ package org.eclipse.mosaic.lib.spatial;
 
 import org.eclipse.mosaic.lib.math.MathUtils;
 import org.eclipse.mosaic.lib.math.Matrix3d;
-import org.eclipse.mosaic.lib.math.MatrixAlignment;
+import org.eclipse.mosaic.lib.math.MatrixElementOrder;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 public class RotationMatrix extends Matrix3d {
@@ -143,13 +143,13 @@ public class RotationMatrix extends Matrix3d {
     }
 
     @Override
-    public RotationMatrix set(double[] values, MatrixAlignment alignment) {
-        return (RotationMatrix) super.set(values, alignment);
+    public RotationMatrix set(double[] values, MatrixElementOrder inputOrder) {
+        return (RotationMatrix) super.set(values, inputOrder);
     }
 
     @Override
-    public RotationMatrix set(float[] values, MatrixAlignment alignment) {
-        return (RotationMatrix) super.set(values, alignment);
+    public RotationMatrix set(float[] values, MatrixElementOrder inputOrder) {
+        return (RotationMatrix) super.set(values, inputOrder);
     }
 
     @Override

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
@@ -16,7 +16,7 @@
 package org.eclipse.mosaic.lib.spatial;
 
 import org.eclipse.mosaic.lib.math.Matrix4d;
-import org.eclipse.mosaic.lib.math.MatrixAlignment;
+import org.eclipse.mosaic.lib.math.MatrixElementOrder;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 /**
@@ -185,13 +185,13 @@ public class TransformationMatrix extends Matrix4d {
     }
 
     @Override
-    public TransformationMatrix set(float[] values, MatrixAlignment alignment) {
-        return (TransformationMatrix) super.set(values, alignment);
+    public TransformationMatrix set(float[] values, MatrixElementOrder inputOrder) {
+        return (TransformationMatrix) super.set(values, inputOrder);
     }
 
     @Override
-    public TransformationMatrix set(double[] values, MatrixAlignment alignment) {
-        return (TransformationMatrix) super.set(values, alignment);
+    public TransformationMatrix set(double[] values, MatrixElementOrder inputOrder) {
+        return (TransformationMatrix) super.set(values, inputOrder);
     }
 
     @Override

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/TransformationMatrix.java
@@ -94,9 +94,9 @@ public class TransformationMatrix extends Matrix4d {
      * result is written into the result vector.
      */
     public Vector3d getTranslation(Vector3d result) {
-        result.x = get(0,3);
-        result.y = get(1,3);
-        result.z = get(2,3);
+        result.x = get(0, 3);
+        result.y = get(1, 3);
+        result.z = get(2, 3);
         return result;
     }
 

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix3dTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/math/Matrix3dTest.java
@@ -68,16 +68,16 @@ public class Matrix3dTest {
         final Matrix3d m = new Matrix3d();
         set(m, "[1, 2, 3], [8, 6, 7], [-9, -4, 5]");
 
-        float[] resultf = m.getAsFloatArray(new float[9], MatrixAlignment.ROWS);
+        float[] resultf = m.getAsFloatArray(new float[9], MatrixElementOrder.ROW_MAJOR);
         assertTrue(Arrays.equals(new float[] {1f, 2f, 3f, 8f, 6f, 7f, -9f, -4f, 5f}, resultf));
 
-        resultf = m.getAsFloatArray(new float[9], MatrixAlignment.COLUMNS);
+        resultf = m.getAsFloatArray(new float[9], MatrixElementOrder.COLUMN_MAJOR);
         assertTrue(Arrays.equals(new float[] {1f, 8f, -9f, 2f, 6f, -4f, 3f, 7f, 5f}, resultf));
 
-        double[] resultd = m.getAsDoubleArray(new double[9], MatrixAlignment.ROWS);
+        double[] resultd = m.getAsDoubleArray(new double[9], MatrixElementOrder.ROW_MAJOR);
         assertTrue(Arrays.equals(new double[] {1d, 2d, 3d, 8d, 6d, 7d, -9d, -4d, 5d}, resultd));
 
-        resultd = m.getAsDoubleArray(new double[9], MatrixAlignment.COLUMNS);
+        resultd = m.getAsDoubleArray(new double[9], MatrixElementOrder.COLUMN_MAJOR);
         assertTrue(Arrays.equals(new double[] {1d, 8d, -9d, 2d, 6d, -4d, 3d, 7d, 5d}, resultd));
     }
 
@@ -87,16 +87,16 @@ public class Matrix3dTest {
         set(expected, "[1, 2, 3], [8, 6, 7], [-9, -4, 5]");
 
         Matrix3d m = new Matrix3d();
-        m.set(new float[] {1f, 2f, 3f, 8f, 6f, 7f, -9f, -4f, 5f}, MatrixAlignment.ROWS);
+        m.set(new float[] {1f, 2f, 3f, 8f, 6f, 7f, -9f, -4f, 5f}, MatrixElementOrder.ROW_MAJOR);
         assertEquals(expected, m);
 
-        m.set(new double[] {1d, 2d, 3d, 8d, 6d, 7d, -9d, -4d, 5d}, MatrixAlignment.ROWS);
+        m.set(new double[] {1d, 2d, 3d, 8d, 6d, 7d, -9d, -4d, 5d}, MatrixElementOrder.ROW_MAJOR);
         assertEquals(expected, m);
 
-        m.set(new float[] {1f, 8f, -9f, 2f, 6f, -4f, 3f, 7f, 5f}, MatrixAlignment.COLUMNS);
+        m.set(new float[] {1f, 8f, -9f, 2f, 6f, -4f, 3f, 7f, 5f}, MatrixElementOrder.COLUMN_MAJOR);
         assertEquals(expected, m);
 
-        m.set(new double[] {1d, 8d, -9d, 2d, 6d, -4d, 3d, 7d, 5d}, MatrixAlignment.COLUMNS);
+        m.set(new double[] {1d, 8d, -9d, 2d, 6d, -4d, 3d, 7d, 5d}, MatrixElementOrder.COLUMN_MAJOR);
         assertEquals(expected, m);
     }
 


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

Follow up to #161 
Renamed `MatrixAlignment` to `MatrixElementOrder` as this is a more suitable name.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

