### PR TITLE
fix(mosaic-application): CAM ignored actual configured vehicle class

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/VehicleUnit.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/VehicleUnit.java
@@ -33,7 +33,6 @@ import org.eclipse.mosaic.interactions.vehicle.VehicleSlowDown;
 import org.eclipse.mosaic.interactions.vehicle.VehicleSpeedChange;
 import org.eclipse.mosaic.interactions.vehicle.VehicleSpeedChange.VehicleSpeedChangeType;
 import org.eclipse.mosaic.interactions.vehicle.VehicleStop;
-import org.eclipse.mosaic.lib.enums.VehicleClass;
 import org.eclipse.mosaic.lib.enums.VehicleStopMode;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
@@ -265,11 +264,11 @@ public class VehicleUnit extends AbstractSimulationUnit implements VehicleOperat
         }
 
         VehicleAwarenessData awarenessData = new VehicleAwarenessData(
-                VehicleClass.Car,
+                getInitialVehicleType().getVehicleClass(),
                 vehicleData.getSpeed(),
                 vehicleData.getHeading(),
                 getInitialVehicleType().getLength(),
-                0,
+                getInitialVehicleType().getWidth(),
                 vehicleData.getDriveDirection(),
                 vehicleData.getRoadPosition().getLaneIndex(),
                 longitudinalAcceleration


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

CAMs sent with `sendCam` method always ignored the actual configured vehicle class of the vehicle.

## Issue(s) related to this PR

 * Resolves #171 
 
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

