### PR TITLE
feat(sumo): Upgrade to recent libsumo changes

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/CommandException.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/CommandException.java
@@ -21,6 +21,14 @@ public class CommandException extends Exception {
 
     private final Status status;
 
+    public CommandException(String errorMessage) {
+        this(errorMessage, new Status(Status.STATUS_ERR, errorMessage));
+    }
+
+    public CommandException(Status status) {
+        this(status.getDescription(), status);
+    }
+
     public CommandException(String errorMessage, Status status) {
         super(errorMessage);
         this.status = status;

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/TrafficLightGetControlledJunctions.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/TrafficLightGetControlledJunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ * Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,15 +22,15 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 import java.util.List;
 
 /**
- * This class represents the SUMO command which allows to get the controlled lanes by traffic light apps.
+ * This class represents the SUMO command which allows to get the list of controlled junctions by traffic light apps.
  */
-public interface TrafficLightGetControlledLanes {
+public interface TrafficLightGetControlledJunctions {
     /**
-     * This method executes the command with the given arguments in order to get the controlled lanes in the traffic light simulations.
+     * This method executes the command with the given arguments in order to get the controlled junctions in the traffic light simulations.
      *
      * @param bridge Connection to Traci.
      * @param tlId   Id of the traffic light.
-     * @return List of the traffic light Id's
+     * @return List of the junction Ids
      * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
      * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
      */

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/Status.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/Status.java
@@ -21,18 +21,18 @@ package org.eclipse.mosaic.fed.sumo.bridge.api.complex;
  */
 public class Status {
 
-    public static final int STATUS_OK = 0x00;
+    public static final byte STATUS_OK = 0x00;
 
-    public static final int STATUS_ERR = 0xff;
+    public static final byte STATUS_ERR = (byte) 0xff;
     /**
      * result type of the status.
      */
-    private byte resultType;
+    private final byte resultType;
 
     /**
      * description of the status in the case of an error.
      */
-    private String description;
+    private final String description;
 
     /**
      * Constructor using fields.

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/JunctionGetPosition.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/JunctionGetPosition.java
@@ -15,6 +15,7 @@
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.util.objects.Position;
 
@@ -23,8 +24,13 @@ import org.eclipse.sumo.libsumo.TraCIPosition;
 
 public class JunctionGetPosition implements org.eclipse.mosaic.fed.sumo.bridge.api.JunctionGetPosition {
 
-    public Position execute(Bridge bridge, String junctionId) {
-        TraCIPosition traCIPosition = Junction.getPosition(junctionId);
-        return new Position(CartesianPoint.xyz(traCIPosition.getX(), traCIPosition.getY(), traCIPosition.getZ() < -1000 ? 0 : traCIPosition.getZ()));
+    public Position execute(Bridge bridge, String junctionId) throws CommandException {
+        try {
+            TraCIPosition traCIPosition = Junction.getPosition(junctionId);
+            return new Position(CartesianPoint.xyz(traCIPosition.getX(), traCIPosition.getY(), traCIPosition.getZ() < -1000 ? 0 : traCIPosition.getZ()));
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not position of junction with ID: " + junctionId);
+        }
+
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/SimulationSimulateStep.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/SimulationSimulateStep.java
@@ -23,37 +23,57 @@ import org.eclipse.mosaic.fed.sumo.bridge.api.complex.LaneAreaSubscriptionResult
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.LeadingVehicle;
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.TrafficLightSubscriptionResult;
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.VehicleSubscriptionResult;
+import org.eclipse.mosaic.fed.sumo.config.CSumo;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.util.objects.Position;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.sumo.libsumo.InductionLoop;
 import org.eclipse.sumo.libsumo.LaneArea;
 import org.eclipse.sumo.libsumo.Simulation;
-import org.eclipse.sumo.libsumo.StringVector;
+import org.eclipse.sumo.libsumo.StringDoublePair;
 import org.eclipse.sumo.libsumo.TraCIPosition;
+import org.eclipse.sumo.libsumo.TraCIVehicleData;
 import org.eclipse.sumo.libsumo.TrafficLight;
 import org.eclipse.sumo.libsumo.Vehicle;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 
 public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridge.api.SimulationSimulateStep {
 
-    final static Set<String> VEHICLE_SUBSCRIPTIONS = new HashSet<>();
-    final static Set<String> INDUCTION_LOOP_SUBSCRIPTIONS = new HashSet<>();
-    final static Set<String> LANE_AREA_SUBSCRIPTIONS = new HashSet<>();
-    final static Set<String> TRAFFIC_LIGHT_SUBSCRIPTIONS = new HashSet<>();
+    final static List<String> VEHICLE_SUBSCRIPTIONS = new ArrayList<>();
+    final static List<String> INDUCTION_LOOP_SUBSCRIPTIONS = new ArrayList<>();
+    final static List<String> LANE_AREA_SUBSCRIPTIONS = new ArrayList<>();
+    final static List<String> TRAFFIC_LIGHT_SUBSCRIPTIONS = new ArrayList<>();
+
+    private final boolean fetchEmissions;
+    private final boolean fetchLeader;
+    private final boolean fetchSignals;
+
+    public SimulationSimulateStep(Bridge bridge, CSumo sumoConfiguration) {
+        VEHICLE_SUBSCRIPTIONS.clear();
+        INDUCTION_LOOP_SUBSCRIPTIONS.clear();
+        LANE_AREA_SUBSCRIPTIONS.clear();
+        TRAFFIC_LIGHT_SUBSCRIPTIONS.clear();
+
+        fetchEmissions = sumoConfiguration.subscriptions.contains(CSumo.SUBSCRIPTION_EMISSIONS);
+        fetchSignals = sumoConfiguration.subscriptions.contains(CSumo.SUBSCRIPTION_SIGNALS);
+        fetchLeader = sumoConfiguration.subscriptions.contains(CSumo.SUBSCRIPTION_LEADER);
+    }
 
     public SimulationSimulateStep() {
         VEHICLE_SUBSCRIPTIONS.clear();
         INDUCTION_LOOP_SUBSCRIPTIONS.clear();
         LANE_AREA_SUBSCRIPTIONS.clear();
         TRAFFIC_LIGHT_SUBSCRIPTIONS.clear();
+
+        fetchEmissions = true;
+        fetchSignals = true;
+        fetchLeader = true;
     }
 
     public List<AbstractSubscriptionResult> execute(Bridge bridge, long time) throws CommandException, InternalFederateException {
@@ -66,19 +86,28 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
         readTrafficLights(results);
 
         return results;
+
     }
 
     private void readVehicles(List<AbstractSubscriptionResult> results) {
-        String mosaicVehicleId;
-        for (String sumoVehicleId : Vehicle.getIDList()) {
-            mosaicVehicleId = Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(sumoVehicleId);
+        for (String arrived : Simulation.getArrivedIDList()) {
+            VEHICLE_SUBSCRIPTIONS.remove(Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(arrived));
+        }
 
-            if (!VEHICLE_SUBSCRIPTIONS.contains(mosaicVehicleId)) {
-                continue;
-            }
+        String sumoVehicleId;
+        for (String mosaicVehicleId : VEHICLE_SUBSCRIPTIONS) {
+            sumoVehicleId = Bridge.VEHICLE_ID_TRANSFORMER.toExternalId(mosaicVehicleId);
 
             VehicleSubscriptionResult result = new VehicleSubscriptionResult();
             result.id = mosaicVehicleId;
+
+            TraCIPosition traCIPosition = Vehicle.getPosition(sumoVehicleId);
+            if (traCIPosition.getX() < -1000 && traCIPosition.getY() < -1000) {
+                continue;
+            }
+
+            result.position = new Position(CartesianPoint.xyz(traCIPosition.getX(), traCIPosition.getY(), traCIPosition.getZ() < -1000 ? 0 : traCIPosition.getZ()));
+
             result.speed = Vehicle.getSpeed(sumoVehicleId);
             result.distanceDriven = Vehicle.getDistance(sumoVehicleId);
             result.heading = Vehicle.getAngle(sumoVehicleId);
@@ -86,11 +115,12 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
             result.acceleration = Vehicle.getAcceleration(sumoVehicleId);
             result.minGap = Vehicle.getMinGap(sumoVehicleId);
 
-            TraCIPosition traCIPosition = Vehicle.getPosition(sumoVehicleId);
-            result.position = new Position(CartesianPoint.xyz(traCIPosition.getX(), traCIPosition.getY(), traCIPosition.getZ() < -1000 ? 0 : traCIPosition.getZ()));
 
             result.stoppedStateEncoded = Vehicle.getStopState(sumoVehicleId);
-            result.signalsEncoded = Vehicle.getSignals(sumoVehicleId);
+
+            if (fetchSignals) {
+                result.signalsEncoded = Vehicle.getSignals(sumoVehicleId);
+            }
 
             result.routeId = Vehicle.getRouteID(sumoVehicleId);
 
@@ -99,43 +129,45 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
             result.lateralLanePosition = Vehicle.getLateralLanePosition(sumoVehicleId);
             result.laneIndex = Vehicle.getLaneIndex(sumoVehicleId);
 
-            result.co2 = Vehicle.getCO2Emission(sumoVehicleId);
-            result.co = Vehicle.getCOEmission(sumoVehicleId);
-            result.hc = Vehicle.getHCEmission(sumoVehicleId);
-            result.pmx = Vehicle.getPMxEmission(sumoVehicleId);
-            result.nox = Vehicle.getNOxEmission(sumoVehicleId);
-            result.fuel = Vehicle.getFuelConsumption(sumoVehicleId);
+            if (fetchEmissions) {
+                result.co2 = Vehicle.getCO2Emission(sumoVehicleId);
+                result.co = Vehicle.getCOEmission(sumoVehicleId);
+                result.hc = Vehicle.getHCEmission(sumoVehicleId);
+                result.pmx = Vehicle.getPMxEmission(sumoVehicleId);
+                result.nox = Vehicle.getNOxEmission(sumoVehicleId);
+                result.fuel = Vehicle.getFuelConsumption(sumoVehicleId);
+            }
 
-            //FIXME use Vehicle.getLeader() to retrieve leader (currently not possible with API)
             result.leadingVehicle = LeadingVehicle.NO_LEADER;
 
-            results.add(result);
-        }
+            if (fetchLeader) {
+                final StringDoublePair leader = Vehicle.getLeader(sumoVehicleId);
+                if (StringUtils.isNotBlank(leader.getFirst())) {
+                    result.leadingVehicle = new LeadingVehicle(
+                            Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(leader.getFirst()),
+                            leader.getSecond()
+                    );
+                }
+            }
 
-        for (String arrived : Simulation.getArrivedIDList()) {
-            VEHICLE_SUBSCRIPTIONS.remove(Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(arrived));
+            results.add(result);
         }
     }
 
 
     private void readInductionLoops(List<AbstractSubscriptionResult> results) {
-        StringVector inductionLoopIds = InductionLoop.getIDList();
-
-        for (String inductionLoop : inductionLoopIds) {
-            if (!INDUCTION_LOOP_SUBSCRIPTIONS.contains(inductionLoop)) {
-                continue;
-            }
-
+        for (String inductionLoop : INDUCTION_LOOP_SUBSCRIPTIONS) {
             InductionLoopSubscriptionResult result = new InductionLoopSubscriptionResult();
             result.id = inductionLoop;
             result.meanSpeed = InductionLoop.getLastStepMeanSpeed(inductionLoop);
             result.meanVehicleLength = InductionLoop.getLastStepMeanLength(inductionLoop);
             result.vehiclesOnInductionLoop = new ArrayList<>();
 
-            for (String vehicle: InductionLoop.getLastStepVehicleIDs(inductionLoop)) {
+            for (TraCIVehicleData inductionLoopVeh : InductionLoop.getVehicleData(inductionLoop)) {
                 InductionLoopVehicleData vehicleData = new InductionLoopVehicleData();
-                vehicleData.vehicleId = Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(vehicle);
-                //TODO add more vehicle data! (use InductionLoop.getVehicleData(inductionLoop), which is not fully implemented yet)
+                vehicleData.vehicleId = Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(inductionLoopVeh.getId());
+                vehicleData.entryTime = (long) (inductionLoopVeh.getEntryTime() * TIME.NANO_SECOND);
+                vehicleData.leaveTime = (long) (inductionLoopVeh.getLeaveTime() * TIME.NANO_SECOND);
                 result.vehiclesOnInductionLoop.add(vehicleData);
             }
             results.add(result);
@@ -143,11 +175,7 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
     }
 
     private void readLaneAreas(List<AbstractSubscriptionResult> results) {
-        for (String laneArea : LaneArea.getIDList()) {
-            if (!LANE_AREA_SUBSCRIPTIONS.contains(laneArea)) {
-                continue;
-            }
-
+        for (String laneArea : LANE_AREA_SUBSCRIPTIONS) {
             LaneAreaSubscriptionResult result = new LaneAreaSubscriptionResult();
             result.id = laneArea;
             result.vehicleCount = LaneArea.getLastStepVehicleNumber(laneArea);
@@ -155,7 +183,7 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
             result.haltingVehicles = LaneArea.getLastStepHaltingNumber(laneArea);
             result.length = LaneArea.getLength(laneArea);
 
-            for (String vehicle: LaneArea.getLastStepVehicleIDs(laneArea)) {
+            for (String vehicle : LaneArea.getLastStepVehicleIDs(laneArea)) {
                 result.vehicles.add(Bridge.VEHICLE_ID_TRANSFORMER.fromExternalId(vehicle));
             }
             results.add(result);
@@ -163,11 +191,7 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
     }
 
     private void readTrafficLights(List<AbstractSubscriptionResult> results) {
-        for (String trafficLight : TrafficLight.getIDList()) {
-            if (!TRAFFIC_LIGHT_SUBSCRIPTIONS.contains(trafficLight)) {
-                continue;
-            }
-
+        for (String trafficLight : TRAFFIC_LIGHT_SUBSCRIPTIONS) {
             TrafficLightSubscriptionResult result = new TrafficLightSubscriptionResult();
             result.id = trafficLight;
             result.currentProgramId = TrafficLight.getProgram(trafficLight);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetControlledJunctions.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetControlledJunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Fraunhofer FOKUS and others. All rights reserved.
+ * Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,6 +12,7 @@
  *
  * Contact: mosaic@fokus.fraunhofer.de
  */
+
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
@@ -19,13 +20,16 @@ import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 
 import org.eclipse.sumo.libsumo.TrafficLight;
 
-public class TrafficLightGetCurrentProgram implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetCurrentProgram {
+import java.util.List;
 
-    public String execute(Bridge bridge, String tlId) throws CommandException {
+public class TrafficLightGetControlledJunctions implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetControlledJunctions {
+
+    public List<String> execute(Bridge bridge, String tlId) throws CommandException {
         try {
-            return TrafficLight.getProgram(tlId);
+            return TrafficLight.getControlledJunctions(tlId);
         } catch(IllegalArgumentException e) {
-            throw new CommandException("Could not read program id for Traffic Light: " + tlId);
+            throw new CommandException("Could not read list of controlled junctions for Traffic Light: " + tlId);
         }
     }
+
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetControlledLanes.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetControlledLanes.java
@@ -15,6 +15,7 @@
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 
 import org.eclipse.sumo.libsumo.TrafficLight;
 
@@ -22,8 +23,12 @@ import java.util.List;
 
 public class TrafficLightGetControlledLanes implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetControlledLanes {
 
-    public List<String> execute(Bridge bridge, String tlId) {
-        return TrafficLight.getControlledLanes(tlId);
+    public List<String> execute(Bridge bridge, String tlId) throws CommandException {
+        try {
+            return TrafficLight.getControlledLanes(tlId);
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not read list of controlled lanes for Traffic Light: " + tlId);
+        }
     }
 
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetControlledLinks.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetControlledLinks.java
@@ -15,23 +15,33 @@
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 
-import com.google.common.collect.Lists;
-import org.eclipse.sumo.libsumo.SWIGTYPE_p_std__vectorT_std__vectorT_libsumo__TraCILink_t_t;
+import org.eclipse.sumo.libsumo.TraCILink;
+import org.eclipse.sumo.libsumo.TraCILinkVector;
 import org.eclipse.sumo.libsumo.TrafficLight;
-import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TrafficLightGetControlledLinks implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetControlledLinks {
 
 
-    public List<TrafficLightControlledLink> execute(Bridge bridge, String tlId) {
-        SWIGTYPE_p_std__vectorT_std__vectorT_libsumo__TraCILink_t_t controlledLinks
-                = TrafficLight.getControlledLinks(tlId);
-        //TODO currently not implemented on libsumo side
-        LoggerFactory.getLogger(this.getClass()).warn("Reading the controlled links of traffic lights is not implemented yet in libsumo.");
-        return Lists.newArrayList();
+    public List<TrafficLightControlledLink> execute(Bridge bridge, String tlId) throws CommandException {
+        try {
+            List<TrafficLightControlledLink> controlledLinks = new ArrayList<>();
+            int i=0;
+            for (TraCILinkVector links : TrafficLight.getControlledLinks(tlId)) {
+                for (TraCILink link : links) {
+                    controlledLinks.add(
+                            new TrafficLightControlledLink(i++, link.getFromLane(), link.getToLane())
+                    );
+                }
+            }
+            return controlledLinks;
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not read list of controlled links for Traffic Light: " + tlId);
+        }
     }
 
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetCurrentPhase.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetCurrentPhase.java
@@ -15,13 +15,18 @@
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 
 import org.eclipse.sumo.libsumo.TrafficLight;
 
 public class TrafficLightGetCurrentPhase implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetCurrentPhase {
 
-    public int execute(Bridge bridge, String tlId) {
-        return TrafficLight.getPhase(tlId);
+    public int execute(Bridge bridge, String tlId) throws CommandException {
+        try {
+            return TrafficLight.getPhase(tlId);
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not read phases for Traffic Light: " + tlId);
+        }
     }
 
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetPrograms.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetPrograms.java
@@ -31,16 +31,20 @@ import java.util.List;
 public class TrafficLightGetPrograms implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetPrograms {
 
     public List<SumoTrafficLightLogic> execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
-        List<SumoTrafficLightLogic> logics = new ArrayList<>();
-        for (TraCILogic traciLogic : TrafficLight.getAllProgramLogics(tlId)) {
-            List<SumoTrafficLightLogic.Phase> phases = new ArrayList<>();
-            TraCIPhaseVector traciPhases = traciLogic.getPhases();
-            for (TraCIPhase traciPhase : traciPhases) {
-                phases.add(new SumoTrafficLightLogic.Phase((int) (traciPhase.getDuration() * TIME.MILLI_SECOND), traciPhase.getState()));
-            }
+        try {
+            List<SumoTrafficLightLogic> logics = new ArrayList<>();
+            for (TraCILogic traciLogic : TrafficLight.getAllProgramLogics(tlId)) {
+                List<SumoTrafficLightLogic.Phase> phases = new ArrayList<>();
+                TraCIPhaseVector traciPhases = traciLogic.getPhases();
+                for (TraCIPhase traciPhase : traciPhases) {
+                    phases.add(new SumoTrafficLightLogic.Phase((int) (traciPhase.getDuration() * TIME.MILLI_SECOND), traciPhase.getState()));
+                }
 
-            logics.add(new SumoTrafficLightLogic(traciLogic.getProgramID(), phases, traciLogic.getCurrentPhaseIndex()));
+                logics.add(new SumoTrafficLightLogic(traciLogic.getProgramID(), phases, traciLogic.getCurrentPhaseIndex()));
+            }
+            return logics;
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not read list of programs for Traffic Light: " + tlId);
         }
-        return logics;
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetState.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetState.java
@@ -15,12 +15,17 @@
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 
 import org.eclipse.sumo.libsumo.TrafficLight;
 
 public class TrafficLightGetState implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetState {
 
-    public String execute(Bridge bridge, String tlId) {
-        return TrafficLight.getRedYellowGreenState(tlId);
+    public String execute(Bridge bridge, String tlId) throws CommandException {
+        try {
+            return TrafficLight.getRedYellowGreenState(tlId);
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not read phases for Traffic Light: " + tlId);
+        }
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetTimeOfNextSwitch.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/TrafficLightGetTimeOfNextSwitch.java
@@ -15,12 +15,17 @@
 package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
 
 import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
 
 import org.eclipse.sumo.libsumo.TrafficLight;
 
 public class TrafficLightGetTimeOfNextSwitch implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetTimeOfNextSwitch {
 
-    public double execute(Bridge bridge, String tlId) {
-        return TrafficLight.getNextSwitch(tlId);
+    public double execute(Bridge bridge, String tlId) throws CommandException {
+        try {
+            return TrafficLight.getNextSwitch(tlId);
+        } catch(IllegalArgumentException e) {
+            throw new CommandException("Could not read next switch time for Traffic Light: " + tlId);
+        }
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleSubscribe.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleSubscribe.java
@@ -19,6 +19,8 @@ import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
 public class VehicleSubscribe implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSubscribe {
 
     public void execute(Bridge bridge, String vehicleId, long startTime, long endTime) {
-        SimulationSimulateStep.VEHICLE_SUBSCRIPTIONS.add(vehicleId);
+        if (!SimulationSimulateStep.VEHICLE_SUBSCRIPTIONS.contains(vehicleId)) {
+            SimulationSimulateStep.VEHICLE_SUBSCRIPTIONS.add(vehicleId);
+        }
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/JunctionGetPosition.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/JunctionGetPosition.java
@@ -63,8 +63,7 @@ public class JunctionGetPosition
     public Position execute(Bridge bridge, String junctionId) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge, junctionId).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get Position of Junction %s.", junctionId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Couldn't get Position of Junction %s.", junctionId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/LaneGetLength.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/LaneGetLength.java
@@ -64,8 +64,7 @@ public class LaneGetLength
     public Double execute(Bridge bridge, String edgeId, int laneIndex) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge, edgeId + "_" + laneIndex).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get Length of Edge %s on Lane %d.", edgeId, laneIndex),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Couldn't get Length of Edge %s on Lane %d.", edgeId, laneIndex)
                 )
         );
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/RouteGetEdges.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/RouteGetEdges.java
@@ -71,8 +71,8 @@ public class RouteGetEdges
     public List<String> execute(Bridge bridge, String routeId) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge, routeId).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't extract Edges of Route %s.", routeId),
-                        new Status((byte) Status.STATUS_ERR, ""))
+                        String.format(Locale.ENGLISH, "Couldn't extract Edges of Route %s.", routeId)
+                )
         );
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/RouteGetIds.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/RouteGetIds.java
@@ -56,7 +56,7 @@ public class RouteGetIds
 
     public List<String> execute(Bridge bridge) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge).orElseThrow(
-                () -> new CommandException("Couldn't get Route-Id's.", new Status((byte) Status.STATUS_ERR, ""))
+                () -> new CommandException("Could not read list of Route Ids.")
         );
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/SimulationGetDepartedVehicleIds.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/SimulationGetDepartedVehicleIds.java
@@ -66,7 +66,7 @@ public class SimulationGetDepartedVehicleIds
      */
     public List<String> execute(Bridge bridge) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge).orElseThrow(
-                () -> new CommandException("Couldn't get departed Vehicles.", new Status((byte) Status.STATUS_ERR, ""))
+                () -> new CommandException("Could not read list of departed Vehicles.")
         );
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/SimulationGetTrafficLightIds.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/SimulationGetTrafficLightIds.java
@@ -65,7 +65,7 @@ public class SimulationGetTrafficLightIds
      */
     public List<String> execute(Bridge bridge) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge).orElseThrow(
-                () -> new CommandException("Couldn't get TrafficLight-Id's.", new Status((byte) Status.STATUS_ERR, ""))
+                () -> new CommandException("Could not read list of TrafficLight Ids.")
         );
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/SimulationGetVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/SimulationGetVersion.java
@@ -56,7 +56,7 @@ public class SimulationGetVersion
      */
     public CurrentVersion execute(Bridge bridge) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge).orElseThrow(
-                () -> new CommandException("Couldn't get Traci API Version", new Status((byte) Status.STATUS_ERR, ""))
+                () -> new CommandException("Could not read Traci API Version")
         );
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetControlledJunctions.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetControlledJunctions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+import com.google.common.collect.Lists;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class TrafficLightGetControlledJunctions implements org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightGetControlledJunctions {
+
+    boolean warned = false;
+
+    public List<String> execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
+        if (!warned) {
+            LoggerFactory.getLogger(this.getClass()).warn("Could not return list of controlled junctions for traffic light. Not implemented in SUMO yet.");
+            warned = true;
+        }
+        return Lists.newArrayList(tlId);
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetControlledLanes.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetControlledLanes.java
@@ -65,8 +65,7 @@ public class TrafficLightGetControlledLanes
     public List<String> execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge, tlId).orElseThrow(
                 () -> new CommandException(String.format(
-                        Locale.ENGLISH, "Couldn't get controlled Lanes for TrafficLight %s.", tlId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        Locale.ENGLISH, "Could not read list of controlled Lanes for TrafficLight %s.", tlId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetControlledLinks.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetControlledLinks.java
@@ -67,8 +67,7 @@ public class TrafficLightGetControlledLinks
     public List<TrafficLightControlledLink> execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
         return super.executeAndReturn(bridge, tlId).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get controlled Links for TrafficLight %s.", tlId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Could not read list of controlled Links for TrafficLight %s.", tlId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetCurrentPhase.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetCurrentPhase.java
@@ -50,8 +50,7 @@ public class TrafficLightGetCurrentPhase
     public int execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge, tlId).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get current Phase for TrafficLight: %s", tlId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Could not read current Phase for TrafficLight: %s", tlId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetCurrentProgram.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetCurrentProgram.java
@@ -62,8 +62,7 @@ public class TrafficLightGetCurrentProgram
     public String execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge, tlId).orElseThrow(
                 () -> new CommandException(String.format(
-                        Locale.ENGLISH, "Couldn't get current Program for TrafficLight: %s", tlId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        Locale.ENGLISH, "Could not read current Program for TrafficLight: %s", tlId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetState.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetState.java
@@ -64,8 +64,7 @@ public class TrafficLightGetState
     public String execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge, tlId).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get State for TrafficLight %s.", tlId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Could not read State for TrafficLight %s.", tlId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetTimeOfNextSwitch.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/TrafficLightGetTimeOfNextSwitch.java
@@ -50,8 +50,7 @@ public class TrafficLightGetTimeOfNextSwitch
     public double execute(Bridge bridge, String tlId) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge, tlId).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get Time of next switch for TrafficLight %s.", tlId),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Could not read Time of next switch for TrafficLight %s.", tlId)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleGetRouteId.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleGetRouteId.java
@@ -65,8 +65,7 @@ public class VehicleGetRouteId
     public String execute(Bridge bridge, String vehicle) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge, vehicle).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't extract Route-Id of Vehicle: %s.", vehicle),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Could not extract Route-Id of Vehicle: %s.", vehicle)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleGetVehicleTypeId.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleGetVehicleTypeId.java
@@ -63,8 +63,7 @@ public class VehicleGetVehicleTypeId
     public String execute(Bridge bridge, String vehicle) throws CommandException, InternalFederateException {
         return executeAndReturn(bridge, vehicle).orElseThrow(
                 () -> new CommandException(
-                        String.format(Locale.ENGLISH, "Couldn't get TypeId for Vehicle: %s.", vehicle),
-                        new Status((byte) Status.STATUS_ERR, "")
+                        String.format(Locale.ENGLISH, "Could not read TypeId for Vehicle: %s.", vehicle)
                 )
         );
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveTrafficLightValue.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveTrafficLightValue.java
@@ -47,6 +47,12 @@ public class CommandRetrieveTrafficLightValue {
      */
     public final static int VAR_CONTROLLED_LINKS = 0x27;
 
+
+    /**
+     * The links controlled by the traffic light.
+     */
+    public final static int VAR_CONTROLLED_JUNCTIONS = 0x27;
+
     /**
      * The index of the current phase in the current program.
      */

--- a/legal/templates/license-header-2022.txt
+++ b/legal/templates/license-header-2022.txt
@@ -1,0 +1,12 @@
+Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0
+
+SPDX-License-Identifier: EPL-2.0
+
+Contact: mosaic@fokus.fraunhofer.de

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.sqlite-jdbc>3.20.0</version.sqlite-jdbc><!-- 3.20.0 is approved in CQ14652 -->
         <version.stax2-api>4.1</version.stax2-api><!-- 4.1 is approved in CQ17826 -->
         <version.woodstox-core>5.1.0</version.woodstox-core><!-- 5.1.0 is approved in CQ17827 -->
-        <version.libsumo>1.9.2</version.libsumo>
+        <version.libsumo>1.12.0-SNAPSHOT</version.libsumo>
     </properties>
 
     <dependencies>
@@ -454,6 +454,7 @@
                         <validHeaders>
                             <header>${parent.dir}/legal/templates/license-header-2020.txt</header>
                             <header>${parent.dir}/legal/templates/license-header-2021.txt</header>
+                            <header>${parent.dir}/legal/templates/license-header-2022.txt</header>
                         </validHeaders>
                         <headerDefinitions>
                         </headerDefinitions>


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* Integrated support for new libsumo methods `Vehicle.getLeader` and `InductionLoop.getVehicleData`, and `TrafficLight.getControlledLinks`
* Fixed code which creates traffic light programs from SUMO data. The previous code assumed, that traffic light groups have the very same name as the junction node. This is only true for network files generated by scenario-convert, but not necessarily true for networks generated with other tools, such as NETEDIT. Here we need to read the junction nodes controlled by the traffic light first, before we can fetch its position. The fix, however, only works for libsumo implementation, as TraCI does not provide such command yet.
* Refactored large method `SimulationFacade.simulateUntil` to be more readable. It now uses one map which holds required information about vehicle state, which was previously handled using multiple maps. This is easier to read and to maintain, and also gains little performance due to less map look ups.

## Issue(s) related to this PR

 * Internal issue 291
  
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [ ] All tests pass.

## Special notes to reviewer

