### PR TITLE
fix(routing): snapping query points on node instead of edges

### DIFF
--- a/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/DatabaseUtils.java
+++ b/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/DatabaseUtils.java
@@ -282,4 +282,26 @@ public class DatabaseUtils {
         }
     }
 
+    /**
+     * Return the node of a connection by the given index. If the index is negative,
+     * the node is chosen starting from the target of the connection. Examples:
+     * 0 returns the first node, -1 returns the last node.
+     * If the given index is outside the possible range of nodes,
+     * it returns the first or last node of the connection.
+     *
+     * @param connection the connection
+     * @param index the index (negative
+     */
+    public static Node getNodeByIndex(final Connection connection, final int index) {
+        final List<Node> nodes = connection.getNodes();
+        if (nodes.isEmpty()) {
+            return null;
+        }
+        if (index < 0) {
+            return nodes.get(Math.max(0, nodes.size() + index));
+        } else {
+            return nodes.get(Math.min(nodes.size() - 1, index));
+        }
+    }
+
 }

--- a/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/road/Connection.java
+++ b/lib/mosaic-database/src/main/java/org/eclipse/mosaic/lib/database/road/Connection.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.mosaic.lib.database.road;
 
+import org.eclipse.mosaic.lib.database.DatabaseUtils;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +41,11 @@ public class Connection {
     private final List<Node> nodes = new ArrayList<>();
     private final Map<String, Connection> outgoing = new HashMap<>();
     private final Map<String, Connection> incoming = new HashMap<>();
+
+    /** Cached first node */
+    private transient Node from;
+    /** Cached last node */
+    private transient Node to;
 
     public Connection(@Nonnull String id, @Nonnull Way way) {
         this(id, way, false);
@@ -86,11 +93,10 @@ public class Connection {
      * @return Null if no from node exist, otherwise the node.
      */
     public Node getFrom() {
-        if (!nodes.isEmpty()) {
-            return nodes.get(0);
+        if (from == null) {
+            from = DatabaseUtils.getNodeByIndex(this, 0);
         }
-
-        return null;
+        return from;
     }
 
     /**
@@ -99,10 +105,10 @@ public class Connection {
      * @return Null if no to node exist, otherwise the node.
      */
     public Node getTo() {
-        if (!nodes.isEmpty()) {
-            return nodes.get(nodes.size() - 1);
+        if (to == null) {
+            to = DatabaseUtils.getNodeByIndex(this, -1);
         }
-        return null;
+        return to;
     }
 
     /**
@@ -202,6 +208,7 @@ public class Connection {
     public void addNode(@Nonnull Node node) {
         Objects.requireNonNull(node);
         nodes.add(node);
+        to = null;
     }
 
     /**
@@ -213,6 +220,7 @@ public class Connection {
     public void addNodes(@Nonnull List<Node> node) {
         Objects.requireNonNull(node);
         nodes.addAll(node);
+        to = null;
     }
 
     /**

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/RoutingParameters.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/RoutingParameters.java
@@ -29,6 +29,8 @@ public class RoutingParameters {
 
     private boolean considerTurnCosts = false;
 
+    private double restrictionCosts = Double.POSITIVE_INFINITY;
+
     private VehicleClass vehicleClass = VehicleClass.Car;
 
     public int getNumAlternativeRoutes() {
@@ -74,6 +76,20 @@ public class RoutingParameters {
     public RoutingParameters considerTurnCosts(boolean considerTurnCosts) {
         this.considerTurnCosts = considerTurnCosts;
         return this;
+    }
+
+    /**
+     * Defines the costs to apply for turn restrictions. Use {@code Double#POSITIVE_INFINITY} to forbid all turn restrictions (recommended).
+     *
+     * @param restrictionCosts the value to apply as costs when a turn is restricted
+     */
+    public RoutingParameters costsForTurnRestriction(double restrictionCosts) {
+        this.restrictionCosts = Math.max(0d, restrictionCosts);
+        return this;
+    }
+
+    public double getRestrictionCosts() {
+        return restrictionCosts;
     }
 
     /**

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
@@ -62,7 +62,7 @@ public class GraphHopperRouting {
 
     /**
      * If the distance of the query position to the closest node is lower than this
-     * value, than the closest node is used definitely as the source or target of the route.
+     * value, then the closest node is used definitely as the source or target of the route.
      * If the distance is larger, the route may start or end on the connection the query is matched on.
      */
     public static final double TARGET_NODE_QUERY_DISTANCE = 1d;
@@ -182,22 +182,22 @@ public class GraphHopperRouting {
 
     private QueryResult createQueryForTarget(RoutingPosition target, FlagEncoder flagEncoder) {
         final EdgeFilter toEdgeFilter = createEdgeFilterForRoutingPosition(target, flagEncoder);
-        QueryResult qrTo = ghApi.getLocationIndex().findClosest(target.getPosition().getLatitude(), target.getPosition().getLongitude(), toEdgeFilter);
+        QueryResult queryTarget = ghApi.getLocationIndex().findClosest(target.getPosition().getLatitude(), target.getPosition().getLongitude(), toEdgeFilter);
         if (target.getConnectionId() != null) {
-            return fixQueryResultIfNoClosestEdgeFound(qrTo, target, flagEncoder);
+            return fixQueryResultIfNoClosestEdgeFound(queryTarget, target, flagEncoder);
         } else {
-            return fixQueryResultIfSnappedPointIsCloseToTowerNode(qrTo, target);
+            return fixQueryResultIfSnappedPointIsCloseToTowerNode(queryTarget, target);
         }
     }
 
     private QueryResult createQueryForSource(RoutingPosition source, FlagEncoder flagEncoder) {
         final EdgeFilter fromEdgeFilter = createEdgeFilterForRoutingPosition(source, flagEncoder);
-        QueryResult qrFrom = ghApi.getLocationIndex().findClosest(source.getPosition().getLatitude(), source.getPosition().getLongitude(), fromEdgeFilter);
+        QueryResult querySource = ghApi.getLocationIndex().findClosest(source.getPosition().getLatitude(), source.getPosition().getLongitude(), fromEdgeFilter);
         if (source.getConnectionId() != null) {
-            qrFrom = fixQueryResultIfSnappedPointIsTowerNode(qrFrom, source, fromEdgeFilter);
-            return fixQueryResultIfNoClosestEdgeFound(qrFrom, source, flagEncoder);
+            querySource = fixQueryResultIfSnappedPointIsTowerNode(querySource, source, fromEdgeFilter);
+            return fixQueryResultIfNoClosestEdgeFound(querySource, source, flagEncoder);
         } else {
-            return fixQueryResultIfSnappedPointIsCloseToTowerNode(qrFrom, source);
+            return fixQueryResultIfSnappedPointIsCloseToTowerNode(querySource, source);
         }
     }
 

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/TurnWeightingOptional.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/TurnWeightingOptional.java
@@ -25,8 +25,9 @@ import com.graphhopper.storage.TurnCostExtension;
  */
 class TurnWeightingOptional extends TurnWeighting {
 
-    private boolean enableTurnCosts;
-    private TurnCostExtension tcExt;
+    private final boolean enableTurnCosts;
+    private final TurnCostExtension tcExt;
+    private final double restrictedCosts;
 
     /**
      * Creates a {@link TurnWeighting} extension which disables or enables the consideration of turn costs, but always
@@ -36,10 +37,12 @@ class TurnWeightingOptional extends TurnWeighting {
      * @param turnCostExt     the turn cost extension of the graph
      * @param enableTurnCosts if <code>true</code>, turn costs and restrictions are considered,
      *                        if <code>false</code>, only turn restrictions are considered
+     * @param restrictedCosts the costs to apply if a turn is restricted (use Double.POSITIVE_INFINITY to forbid turn)
      */
-    public TurnWeightingOptional(Weighting superWeighting, TurnCostExtension turnCostExt, boolean enableTurnCosts) {
+    public TurnWeightingOptional(Weighting superWeighting, TurnCostExtension turnCostExt, boolean enableTurnCosts, double restrictedCosts) {
         super(superWeighting, turnCostExt);
         this.tcExt = turnCostExt;
+        this.restrictedCosts = restrictedCosts;
         this.enableTurnCosts = enableTurnCosts;
     }
 
@@ -47,7 +50,7 @@ class TurnWeightingOptional extends TurnWeighting {
     public double calcTurnWeight(int edgeFrom, int nodeVia, int edgeTo) {
         long turnFlags = tcExt.getTurnCostFlags(edgeFrom, nodeVia, edgeTo);
         if (getFlagEncoder().isTurnRestricted(turnFlags)) {
-            return Double.POSITIVE_INFINITY;
+            return restrictedCosts;
         }
 
         if (enableTurnCosts) {


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [x] Enhancement

## Description

* When passing a `RoutePosition` as source or target for a routing query, the implementation first tries to match the given position onto the road, by either snapping it to a node (`Position.TOWER`) or connection (`Position.EDGE`). In some rare cases, the queried position was mapped onto a connection, although the position was very close to a node (few millimeters). To fix those cases, we now switch the snapping mode of the `QueryResult` to `Position.TOWER`, if the queried position is very close to the closest point of the matched edge. The distance to control this behavior can be adjusted with the `TARGET_NODE_QUERY_DISTANCE` field.
* Added a new method to `RoutingParameters` to define how much costs are applied for a turn restrictions. Setting this value allows to ignore turn-restrictions to some extend (e.g. for demo cases).

## Issue(s) related to this PR

 * Internal issue 320 
 
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

