### PR TITLE
fix(application): improved log when conventional vehicle receives battery data

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ErrorRegister.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ErrorRegister.java
@@ -71,6 +71,7 @@ public enum ErrorRegister {
     // 0x01000080 to 0x0100008F vehicle
     VEHICLE_UnknownEvent(0x01000080, "Process unknown event."),
     VEHICLE_NoEventResource(0x01000081, "Process event with no resource."),
+    VEHICLE_NotElectric(0x01000082, "A conventional vehicle cannot handle battery data."),
     // 0x01000090 to 0x0100009F traffic management center
     TRAFFIC_MANAGEMENT_CENTER_UnknownEvent(0x01000090, "Process unknown event."),
     TRAFFIC_MANAGEMENT_CENTER_NoEventResource(0x01000091, "Process event with no resource."),

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/VehicleUnit.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/VehicleUnit.java
@@ -40,6 +40,7 @@ import org.eclipse.mosaic.lib.enums.VehicleStopMode;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
 import org.eclipse.mosaic.lib.objects.v2x.etsi.cam.VehicleAwarenessData;
+import org.eclipse.mosaic.lib.objects.vehicle.BatteryData;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleRoute;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
@@ -124,7 +125,7 @@ public class VehicleUnit extends AbstractSimulationUnit implements VehicleOperat
 
         if (!handleEventResource(resource, event.getNice())) {
             getOsLog().error("Unknown event resource: {}", event);
-            throw new RuntimeException(ErrorRegister.VEHICLE_NoEventResource.toString());
+            throw new RuntimeException(ErrorRegister.VEHICLE_UnknownEvent.toString());
         }
     }
 
@@ -132,6 +133,9 @@ public class VehicleUnit extends AbstractSimulationUnit implements VehicleOperat
         if (resource instanceof VehicleData) {
             updateVehicleInfo((VehicleData) resource);
             return true;
+        }
+        if (resource instanceof BatteryData) {
+            throw new RuntimeException(ErrorRegister.VEHICLE_NotElectric.toString());
         }
         return false;
     }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

When BatteryData was generated and spread for vehicle which was not configured with `vehicleClass = ElectricVehicle`, an error message was raised which was not really helpful and required debugging to find the configuration error. This is now fixed by writing a meaningful message into the exception.

## Issue(s) related to this PR

 *internal issue 327 
 
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [ ] All tests pass.

## Special notes to reviewer

