### PR TITLE
feat(mapping): Configure departure connection of vehicle

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
@@ -405,7 +405,7 @@ public class CentralNavigationComponent {
                 }
                 return new VehicleDeparture.Builder(route.getId())
                         .departureLane(departure.getLaneSelectionMode(), departure.getDepartureLane(), departure.getDeparturePos())
-                        .departureSpeed(departure.getDepartSpeedMode(), departure.getDepartSpeed())
+                        .departureSpeed(departure.getDepartureSpeedMode(), departure.getDepartureSpeed())
                         .create();
             }
         }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/OriginDestinationVehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/OriginDestinationVehicleFlowGenerator.java
@@ -37,7 +37,7 @@ public class OriginDestinationVehicleFlowGenerator {
      */
     private final List<List<Double>> odValues;
     private final VehicleDeparture.LaneSelectionMode laneSelectionMode;
-    private final VehicleDeparture.DepartSpeedMode departSpeedMode;
+    private final VehicleDeparture.DepartureSpeedMode departureSpeedMode;
     private final double startingTime;
     private final Double maxTime;
 
@@ -54,7 +54,7 @@ public class OriginDestinationVehicleFlowGenerator {
         this.startingTime = matrixMapperConfiguration.startingTime;
         this.maxTime = matrixMapperConfiguration.maxTime;
         this.laneSelectionMode = matrixMapperConfiguration.laneSelectionMode;
-        this.departSpeedMode = matrixMapperConfiguration.departSpeedMode;
+        this.departureSpeedMode = matrixMapperConfiguration.departSpeedMode;
     }
 
     /**
@@ -83,7 +83,7 @@ public class OriginDestinationVehicleFlowGenerator {
                 vehicleConfiguration.startingTime = startingTime;
                 vehicleConfiguration.maxTime = maxTime;
                 vehicleConfiguration.laneSelectionMode = laneSelectionMode;
-                vehicleConfiguration.departSpeedMode = departSpeedMode;
+                vehicleConfiguration.departSpeedMode = departureSpeedMode;
                 // Assuming, if we only have set a flow, that we want to have an unlimited number of vehicles
 
                 framework.addVehicleStream(new VehicleFlowGenerator(vehicleConfiguration, randomNumberGenerator, flowNoise));

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -92,7 +92,7 @@ public class VehicleFlowGenerator {
      * RANDOM = The {@link CVehicle#departSpeed} will be overridden by a random value
      * MAXIMUM = The {@link CVehicle#departSpeed} will be overridden by the max value
      */
-    private VehicleDeparture.DepartSpeedMode departSpeedMode;
+    private VehicleDeparture.DepartureSpeedMode departureSpeedMode;
     private VehicleDeparture.LaneSelectionMode laneSelectionMode;
     private long start = 0;
     private long end = Long.MAX_VALUE;
@@ -125,12 +125,12 @@ public class VehicleFlowGenerator {
         this.randomNumberGenerator = randomNumberGenerator;
 
         // set simple values
-        this.departureConnectionIndex = vehicleConfiguration.departureConnectionIndex;
+        this.departureConnectionIndex = vehicleConfiguration.departConnectionIndex;
         this.pos = vehicleConfiguration.pos;
         this.route = vehicleConfiguration.route;
         this.group = vehicleConfiguration.group;
         this.departSpeed = vehicleConfiguration.departSpeed;
-        this.departSpeedMode = vehicleConfiguration.departSpeedMode;
+        this.departureSpeedMode = vehicleConfiguration.departSpeedMode;
         this.laneSelectionMode = vehicleConfiguration.laneSelectionMode;
         // If maxNumberVehicles wasn't given in mapping, we assume that it should be an endless flow, so we set it to Integer.MAX_VALUE
         // and handle this case accordingly in the timeAdvance() method
@@ -423,7 +423,7 @@ public class VehicleFlowGenerator {
         VehicleDeparture vehicleDeparture = new VehicleDeparture.Builder(route)
                 .departureLane(laneSelectionMode, lane, pos)
                 .departureConnection(departureConnectionIndex)
-                .departureSpeed(departSpeedMode, departSpeed)
+                .departureSpeed(departureSpeedMode, departSpeed)
                 .create();
 
         Interaction interaction;

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -74,6 +74,7 @@ public class VehicleFlowGenerator {
     private final LaneIndexSelector laneSelector;
     private final SpawningMode spawningMode;
     private final List<VehicleTypeSpawner> types;
+    private final int departureConnectionIndex;
     private final int pos;
     private final String route;
     private final GeoCircle origin;
@@ -124,6 +125,7 @@ public class VehicleFlowGenerator {
         this.randomNumberGenerator = randomNumberGenerator;
 
         // set simple values
+        this.departureConnectionIndex = vehicleConfiguration.departureConnectionIndex;
         this.pos = vehicleConfiguration.pos;
         this.route = vehicleConfiguration.route;
         this.group = vehicleConfiguration.group;
@@ -420,6 +422,7 @@ public class VehicleFlowGenerator {
 
         VehicleDeparture vehicleDeparture = new VehicleDeparture.Builder(route)
                 .departureLane(laneSelectionMode, lane, pos)
+                .departureConnection(departureConnectionIndex)
                 .departureSpeed(departSpeedMode, departSpeed)
                 .create();
 
@@ -435,8 +438,9 @@ public class VehicleFlowGenerator {
         }
 
         try {
-            LOG.info("Creating Vehicle. time={}, name={}, route={}, laneSelectionMode={}, lane={}, pos={}, type={}, departSpeed={}",
-                    framework.getTime(), name, route, laneSelectionMode, lane, pos, type, departSpeed);
+            LOG.info("Creating Vehicle. time={}, name={}, route={}, laneSelectionMode={}, lane={}, departureConnectionIndex{}, pos={}, "
+                            + "type={}, departSpeed={}",
+                    framework.getTime(), name, route, laneSelectionMode, lane, departureConnectionIndex, pos, type, departSpeed);
             framework.getRti().triggerInteraction(interaction);
         } catch (IllegalValueException e) {
             LOG.error("Couldn't send an {} interaction in VehicleStreamGenerator.timeAdvance()", interaction.getTypeId(), e);
@@ -450,6 +454,7 @@ public class VehicleFlowGenerator {
                 .append("spawningMode", spawningMode)
                 .append("lanes", lanes)
                 .append("types", types)
+                .append("departureConnectionIndex", departureConnectionIndex)
                 .append("pos", pos)
                 .append("departSpeed", departSpeed)
                 .append("route", route)

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/COriginDestinationMatrixMapper.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/COriginDestinationMatrixMapper.java
@@ -18,8 +18,6 @@ package org.eclipse.mosaic.fed.mapping.config.units;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.lib.geo.GeoCircle;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture;
-import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
-import org.eclipse.mosaic.lib.util.gson.UnitFieldAdapter;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -87,7 +85,7 @@ public class COriginDestinationMatrixMapper {
      * MAXIMUM = The {@link CVehicle#departSpeed} will be overridden by the max value
      */
     @JsonAdapter(CVehicle.DepartSpeedModeTypeAdapter.class)
-    public VehicleDeparture.DepartSpeedMode departSpeedMode = VehicleDeparture.DepartSpeedMode.MAXIMUM;
+    public VehicleDeparture.DepartureSpeedMode departSpeedMode = VehicleDeparture.DepartureSpeedMode.MAXIMUM;
 
 
     /**

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
@@ -165,7 +165,12 @@ public class CVehicle implements Comparable<CVehicle> {
     public boolean deterministic = true;
 
     /**
-     * Position within the route where the vehicle(-s) should be spawned.
+     * The index of the connection of the route where the vehicle will start on.
+     */
+    public int departureConnectionIndex = 0;
+
+    /**
+     * Position within the connection of the route where the vehicle(-s) should be spawned.
      */
     public int pos = 0;
 
@@ -221,6 +226,7 @@ public class CVehicle implements Comparable<CVehicle> {
                 .append(targetFlow, that.targetFlow)
                 .append(departSpeed, that.departSpeed)
                 .append(deterministic, that.deterministic)
+                .append(departureConnectionIndex, that.departureConnectionIndex)
                 .append(pos, that.pos)
                 .append(maxTime, that.maxTime)
                 .append(spawningMode, that.spawningMode)
@@ -252,6 +258,7 @@ public class CVehicle implements Comparable<CVehicle> {
                 .append(types)
                 .append(typeDistribution)
                 .append(deterministic)
+                .append(departureConnectionIndex)
                 .append(pos)
                 .append(route)
                 .append(origin)

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
@@ -17,7 +17,7 @@ package org.eclipse.mosaic.fed.mapping.config.units;
 
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.lib.geo.GeoCircle;
-import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.DepartSpeedMode;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.DepartureSpeedMode;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.LaneSelectionMode;
 import org.eclipse.mosaic.lib.util.gson.AbstractEnumDefaultValueTypeAdapter;
 import org.eclipse.mosaic.lib.util.gson.UnitFieldAdapter;
@@ -112,7 +112,7 @@ public class CVehicle implements Comparable<CVehicle> {
      * MAXIMUM = The {@link CVehicle#departSpeed} will be overridden by the max value
      */
     @JsonAdapter(DepartSpeedModeTypeAdapter.class)
-    public DepartSpeedMode departSpeedMode = DepartSpeedMode.MAXIMUM;
+    public DepartureSpeedMode departSpeedMode = DepartureSpeedMode.MAXIMUM;
 
     /**
      * List of possible vehicle types to be spawned. In this list you can simply refer to an
@@ -167,7 +167,7 @@ public class CVehicle implements Comparable<CVehicle> {
     /**
      * The index of the connection of the route where the vehicle will start on.
      */
-    public int departureConnectionIndex = 0;
+    public int departConnectionIndex = 0;
 
     /**
      * Position within the connection of the route where the vehicle(-s) should be spawned.
@@ -226,7 +226,7 @@ public class CVehicle implements Comparable<CVehicle> {
                 .append(targetFlow, that.targetFlow)
                 .append(departSpeed, that.departSpeed)
                 .append(deterministic, that.deterministic)
-                .append(departureConnectionIndex, that.departureConnectionIndex)
+                .append(departConnectionIndex, that.departConnectionIndex)
                 .append(pos, that.pos)
                 .append(maxTime, that.maxTime)
                 .append(spawningMode, that.spawningMode)
@@ -258,7 +258,7 @@ public class CVehicle implements Comparable<CVehicle> {
                 .append(types)
                 .append(typeDistribution)
                 .append(deterministic)
-                .append(departureConnectionIndex)
+                .append(departConnectionIndex)
                 .append(pos)
                 .append(route)
                 .append(origin)
@@ -267,9 +267,9 @@ public class CVehicle implements Comparable<CVehicle> {
                 .toHashCode();
     }
 
-    static class DepartSpeedModeTypeAdapter extends AbstractEnumDefaultValueTypeAdapter<DepartSpeedMode> {
+    static class DepartSpeedModeTypeAdapter extends AbstractEnumDefaultValueTypeAdapter<DepartureSpeedMode> {
         public DepartSpeedModeTypeAdapter() {
-            super(DepartSpeedMode.MAXIMUM);
+            super(DepartureSpeedMode.MAXIMUM);
         }
     }
 

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -252,8 +252,14 @@
                     "type": "boolean",
                     "default": true
                 },
+                "departConnectionIndex": {
+                    "description": "The index of the connection of the route where the vehicle will start on.",
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 0
+                },
                 "pos": {
-                    "description": "Position within the route where the vehicle(s) should be spawned.",
+                    "description": "Position within the connection of the route where the vehicle(s) should be spawned.",
                     "type": "number",
                     "minimum": 0,
                     "default": 0

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/DepartSpeedTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/DepartSpeedTest.java
@@ -61,7 +61,7 @@ public class DepartSpeedTest {
         CVehicle vehicle = mapping.vehicles.get(0);
         assertNotEquals(vehicle, null);
         assertEquals(100, vehicle.departSpeed, 0);
-        assertEquals(VehicleDeparture.DepartSpeedMode.PRECISE, vehicle.departSpeedMode);
+        assertEquals(VehicleDeparture.DepartureSpeedMode.PRECISE, vehicle.departSpeedMode);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class DepartSpeedTest {
         CVehicle vehicle = mapping.vehicles.get(1);
         assertNotEquals(vehicle, null);
         assertEquals(200, vehicle.departSpeed, 0);
-        assertEquals(VehicleDeparture.DepartSpeedMode.RANDOM, vehicle.departSpeedMode);
+        assertEquals(VehicleDeparture.DepartureSpeedMode.RANDOM, vehicle.departSpeedMode);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class DepartSpeedTest {
         CVehicle vehicle = mapping.vehicles.get(2);
         assertNotEquals(vehicle, null);
         assertEquals(300, vehicle.departSpeed, 0);
-        assertEquals(VehicleDeparture.DepartSpeedMode.MAXIMUM, vehicle.departSpeedMode);
+        assertEquals(VehicleDeparture.DepartureSpeedMode.MAXIMUM, vehicle.departSpeedMode);
     }
 
     @Test
@@ -85,6 +85,6 @@ public class DepartSpeedTest {
         CVehicle vehicle = mapping.vehicles.get(3);
         assertNotEquals(vehicle, null);
         assertEquals(500, vehicle.departSpeed, 0);
-        assertEquals(VehicleDeparture.DepartSpeedMode.MAXIMUM, vehicle.departSpeedMode);
+        assertEquals(VehicleDeparture.DepartureSpeedMode.MAXIMUM, vehicle.departSpeedMode);
     }
 }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -304,6 +304,7 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
             String vehicleType = interaction.getMapping().getVehicleType().getName();
             String routeId = interaction.getDeparture().getRouteId();
             String departPos = String.format(Locale.ENGLISH, "%.2f", interaction.getDeparture().getDeparturePos());
+            int departIndex = interaction.getDeparture().getDepartureConnectionIndex();
             String departSpeed = extractDepartureSpeed(interaction);
             String laneId = extractDepartureLane(interaction);
 
@@ -316,6 +317,10 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
                         throw new IllegalArgumentException(
                                 "Unknown route " + routeId + " for vehicle with departure time " + interaction.getTime()
                         );
+                    }
+
+                    if (departIndex > 0) {
+                        routeId = cutAndAddRoute(routeId, departIndex);
                     }
 
                     bridge.getSimulationControl().addVehicle(vehicleId, routeId, vehicleType, laneId, departPos, departSpeed);
@@ -335,6 +340,21 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
                 iterator.remove();
             }
         }
+    }
+
+    private String cutAndAddRoute(String routeId, int departIndex) throws InternalFederateException {
+        String newRouteId = routeId + "_cut" + departIndex;
+        if (routeCache.containsKey(newRouteId)) {
+            return newRouteId;
+        }
+        final VehicleRoute route = routeCache.get(routeId);
+        final List<String> connections = route.getConnectionIds();
+        if (departIndex >= connections.size()) {
+            throw new IllegalArgumentException("The departIndex=" + departIndex + " is too large for route with id=" + routeId);
+        }
+        final VehicleRoute cutRoute = new VehicleRoute(newRouteId, connections.subList(departIndex, connections.size()), route.getNodeIds(), route.getLength());
+        propagateRouteIfAbsent(newRouteId, cutRoute);
+        return newRouteId;
     }
 
     private void subscribeToNotYetSubscribedVehicles(long time) throws InternalFederateException {

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -406,9 +406,9 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
     }
 
     private String extractDepartureSpeed(VehicleRegistration interaction) {
-        switch (interaction.getDeparture().getDepartSpeedMode()) {
+        switch (interaction.getDeparture().getDepartureSpeedMode()) {
             case PRECISE:
-                return String.format(Locale.ENGLISH, "%.2f", interaction.getDeparture().getDepartSpeed());
+                return String.format(Locale.ENGLISH, "%.2f", interaction.getDeparture().getDepartureSpeed());
             case RANDOM:
                 return "random";
             case MAXIMUM:

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassadorTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassadorTest.java
@@ -231,7 +231,7 @@ public class SumoAmbassadorTest {
         // PREPARE
         VehicleDeparture departInfo = mock(VehicleDeparture.class);
         when(departInfo.getRouteId()).thenReturn("0");
-        when(departInfo.getDepartSpeedMode()).thenReturn(VehicleDeparture.DepartSpeedMode.MAXIMUM);
+        when(departInfo.getDepartureSpeedMode()).thenReturn(VehicleDeparture.DepartureSpeedMode.MAXIMUM);
         when(departInfo.getLaneSelectionMode()).thenReturn(VehicleDeparture.LaneSelectionMode.DEFAULT);
 
         // RUN send added vehicle and run first step

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/VehicleDeparture.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/VehicleDeparture.java
@@ -23,7 +23,7 @@ public class VehicleDeparture implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public enum DepartSpeedMode {
+    public enum DepartureSpeedMode {
         /* the vehicle departs with the speed given in the mapping definiton of the spawner */
         PRECISE,
         /* the vehicle departs with a random speed */
@@ -80,12 +80,12 @@ public class VehicleDeparture implements Serializable {
     /**
      * The speed with which the vehicle will depart, if present space is free.
      */
-    private final double departSpeed;
+    private final double departureSpeed;
 
     /**
      * The mode with which the departure speed is chosen depending on the current traffic situation.
      */
-    private final DepartSpeedMode departSpeedMode;
+    private final DepartureSpeedMode departureSpeedMode;
 
     /**
      * The mode with which the departure lane is chosen depending on the current traffic situation.
@@ -93,14 +93,14 @@ public class VehicleDeparture implements Serializable {
     private final LaneSelectionMode laneSelectionMode;
 
     private VehicleDeparture(String routeId, int departureLane, int departureConnectionIndex, double departurePos,
-                             double departSpeed, DepartSpeedMode departSpeedMode,
+                             double departureSpeed, DepartureSpeedMode departureSpeedMode,
                              LaneSelectionMode laneSelectionMode) {
         this.routeId = routeId;
         this.departureLane = departureLane;
         this.departureConnectionIndex = departureConnectionIndex;
         this.departurePos = departurePos;
-        this.departSpeed = departSpeed;
-        this.departSpeedMode = departSpeedMode;
+        this.departureSpeed = departureSpeed;
+        this.departureSpeedMode = departureSpeedMode;
         this.laneSelectionMode = laneSelectionMode;
     }
 
@@ -120,12 +120,12 @@ public class VehicleDeparture implements Serializable {
         return departurePos;
     }
 
-    public double getDepartSpeed() {
-        return departSpeed;
+    public double getDepartureSpeed() {
+        return departureSpeed;
     }
 
-    public DepartSpeedMode getDepartSpeedMode() {
-        return departSpeedMode;
+    public DepartureSpeedMode getDepartureSpeedMode() {
+        return departureSpeedMode;
     }
 
     public LaneSelectionMode getLaneSelectionMode() {
@@ -138,8 +138,8 @@ public class VehicleDeparture implements Serializable {
         private int departureLane;
         private int departureConnectionIndex;
         private double departurePos;
-        private double departSpeed;
-        private DepartSpeedMode departSpeedMode;
+        private double departureSpeed;
+        private DepartureSpeedMode departureSpeedMode;
         private LaneSelectionMode laneSelectionMode;
 
         public Builder(String routeId) {
@@ -158,21 +158,21 @@ public class VehicleDeparture implements Serializable {
             return this;
         }
 
-        public Builder departureSpeed(DepartSpeedMode departSpeedMode, double departSpeed) {
-            this.departSpeed = departSpeed;
-            this.departSpeedMode = departSpeedMode;
+        public Builder departureSpeed(DepartureSpeedMode departureSpeedMode, double departSpeed) {
+            this.departureSpeed = departSpeed;
+            this.departureSpeedMode = departureSpeedMode;
             return this;
         }
 
         public Builder departureSpeed(double speed) {
-            this.departSpeed = speed;
-            this.departSpeedMode = DepartSpeedMode.PRECISE;
+            this.departureSpeed = speed;
+            this.departureSpeedMode = DepartureSpeedMode.PRECISE;
             return this;
         }
 
         public VehicleDeparture create() {
-            return new VehicleDeparture(routeId, departureLane, departureConnectionIndex, departurePos, departSpeed,
-                    departSpeedMode, laneSelectionMode);
+            return new VehicleDeparture(routeId, departureLane, departureConnectionIndex, departurePos, departureSpeed,
+                    departureSpeedMode, laneSelectionMode);
         }
     }
 }

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/VehicleDeparture.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/VehicleDeparture.java
@@ -68,7 +68,12 @@ public class VehicleDeparture implements Serializable {
     private final int departureLane;
 
     /**
-     * The departure offset from the beginning of the lane, where the vehicle will be spawned on.
+     * The index of the connection of the route, where the vehicle will start on.
+     */
+    private final int departureConnectionIndex;
+
+    /**
+     * The departure offset from the beginning of the lane on the departure connection, where the vehicle will be spawned on.
      */
     private final double departurePos;
 
@@ -87,11 +92,12 @@ public class VehicleDeparture implements Serializable {
      */
     private final LaneSelectionMode laneSelectionMode;
 
-    private VehicleDeparture(String routeId, int departureLane, double departurePos,
+    private VehicleDeparture(String routeId, int departureLane, int departureConnectionIndex, double departurePos,
                              double departSpeed, DepartSpeedMode departSpeedMode,
                              LaneSelectionMode laneSelectionMode) {
         this.routeId = routeId;
         this.departureLane = departureLane;
+        this.departureConnectionIndex = departureConnectionIndex;
         this.departurePos = departurePos;
         this.departSpeed = departSpeed;
         this.departSpeedMode = departSpeedMode;
@@ -104,6 +110,10 @@ public class VehicleDeparture implements Serializable {
 
     public int getDepartureLane() {
         return departureLane;
+    }
+
+    public int getDepartureConnectionIndex() {
+        return departureConnectionIndex;
     }
 
     public double getDeparturePos() {
@@ -126,6 +136,7 @@ public class VehicleDeparture implements Serializable {
         private final String routeId;
 
         private int departureLane;
+        private int departureConnectionIndex;
         private double departurePos;
         private double departSpeed;
         private DepartSpeedMode departSpeedMode;
@@ -142,6 +153,11 @@ public class VehicleDeparture implements Serializable {
             return this;
         }
 
+        public Builder departureConnection(int departureConnectionIndex) {
+            this.departureConnectionIndex = departureConnectionIndex;
+            return this;
+        }
+
         public Builder departureSpeed(DepartSpeedMode departSpeedMode, double departSpeed) {
             this.departSpeed = departSpeed;
             this.departSpeedMode = departSpeedMode;
@@ -155,7 +171,8 @@ public class VehicleDeparture implements Serializable {
         }
 
         public VehicleDeparture create() {
-            return new VehicleDeparture(routeId, departureLane, departurePos, departSpeed, departSpeedMode, laneSelectionMode);
+            return new VehicleDeparture(routeId, departureLane, departureConnectionIndex, departurePos, departSpeed,
+                    departSpeedMode, laneSelectionMode);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Felix Lutz <felix.lutz@fokus.fraunhofer.de>

## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

The departure connection/edge of a vehicle can now be configured via index in mapping.
Index 0 represents the first connection of a vehicle, index 1 the second connection, etc.

## Issue(s) related to this PR

Resolves internal issue [324](https://gitlab.fokus.fraunhofer.de/simulation/mosaic/mosaic-extended/-/issues/324)
 
 
## Affected parts of the online documentation

Mapping configuration

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

