### PR TITLE
fix(omnetpp): read correct omnetpp.ini

### DIFF
--- a/fed/mosaic-omnetpp/src/main/java/org/eclipse/mosaic/fed/omnetpp/ambassador/OmnetppAmbassador.java
+++ b/fed/mosaic-omnetpp/src/main/java/org/eclipse/mosaic/fed/omnetpp/ambassador/OmnetppAmbassador.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mosaic.fed.omnetpp.ambassador;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.eclipse.mosaic.lib.coupling.AbstractNetworkAmbassador;
 import org.eclipse.mosaic.rti.api.FederateExecutor;
 import org.eclipse.mosaic.rti.api.federatestarter.DockerFederateExecutor;
@@ -23,6 +22,8 @@ import org.eclipse.mosaic.rti.api.federatestarter.ExecutableFederateExecutor;
 import org.eclipse.mosaic.rti.api.federatestarter.NopFederateExecutor;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
 import org.eclipse.mosaic.rti.config.CLocalHost.OperatingSystem;
+
+import org.apache.commons.lang3.ObjectUtils;
 
 import javax.annotation.Nonnull;
 
@@ -46,7 +47,7 @@ public class OmnetppAmbassador extends AbstractNetworkAmbassador {
         switch (os) {
             case LINUX:
                 String omnetppConfigFileName = ObjectUtils.defaultIfNull(config.federateConfigurationFile, "omnetpp.ini");
-                String omnetppConfigFilePath = "omnetpp-federate/src/" + omnetppConfigFileName;
+                String omnetppConfigFilePath = "omnetpp-federate/simulations/" + omnetppConfigFileName;
                 String inetSourceDirectories = "inet:omnetpp-federate/src";
                 return new ExecutableFederateExecutor(this.descriptor, "omnetpp-federate/omnetpp-federate",
                         "-u", "Cmdenv",

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/time/AbstractTimeManagement.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/time/AbstractTimeManagement.java
@@ -188,7 +188,7 @@ public abstract class AbstractTimeManagement extends Observable implements TimeM
         logger.info("Ended: " + dateFormat.format(new Date(currentTime)));
         logger.info("Duration: {} (RTF: {})",
                 DurationFormatUtils.formatDuration(durationMs, "HH'h' mm'm' ss.SSS's'"),
-                durationMs > 0 ? FORMAT_TWO_DIGIT.format((getEndTime() / TIME.MILLI_SECOND) / durationMs) : 0
+                durationMs > 0 ? FORMAT_TWO_DIGIT.format((time / TIME.MILLI_SECOND) / durationMs) : 0
         );
         logger.info("");
         if (statusCode == STATUS_CODE_SUCCESS) {


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

* Omnet++ Federate was started with a wrong path to omnetpp.ini
* AbstractNetworkAmbassasdor does not throw exception if a source node for whatever reason is not simulated anymore. This still tends to happen occasionally.
* Add timestamp to some logs in AbstractNetworkAmbassador
* The RTF shown at the end of the simulation now respects the case if the simulation was aborted. 

## Issue(s) related to this PR

 * Internal issue 314 
 
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

