### PR TITLE
fix(geomath): fixed intersection test in quadtree

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/BoundingBox.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/BoundingBox.java
@@ -109,9 +109,9 @@ public class BoundingBox {
     }
 
     public boolean contains(double x, double y, double z) {
-        return x >= min.x && x <= max.x &&
-                y >= min.y && y <= max.y &&
-                z >= min.z && z <= max.z;
+        return x >= min.x && x <= max.x
+                && y >= min.y && y <= max.y
+                && z >= min.z && z <= max.z;
     }
 
     public double distanceToPoint(Vector3d pt) {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/QuadTree.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/QuadTree.java
@@ -324,15 +324,10 @@ public class QuadTree<T> {
         }
 
         boolean intersects(BoundingBox area) {
-            //TODO check if this method could be shortened
-            return area.contains(minX, 0, minZ)
-                    || area.contains(minX, 0, maxZ)
-                    || area.contains(maxX, 0, minZ)
-                    || area.contains(maxX, 0, maxZ)
-                    || isInBounds(area.min.x, 0, area.min.z)
-                    || isInBounds(area.min.x, 0, area.max.z)
-                    || isInBounds(area.max.x, 0, area.min.z)
-                    || isInBounds(area.max.x, 0, area.max.z);
+            return area.min.x <= maxX
+                    && area.max.x >= minX
+                    && area.min.z <= maxZ
+                    && area.max.z >= minZ;
         }
 
         private void addObjectNode(QuadTree<?>.ObjectAndNode item) {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/QuadTree.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/QuadTree.java
@@ -333,7 +333,7 @@ public class QuadTree<T> {
         private void addObjectNode(QuadTree<?>.ObjectAndNode item) {
             objectsCount++;
 
-            if (childNodes == null) {
+            if (isLeaf()) {
                 objects.add(item);
                 item.node = this;
                 if (objectsCount > SPLIT_SIZE && depth < MAX_DEPTH) {
@@ -378,10 +378,9 @@ public class QuadTree<T> {
         }
 
         private void join() {
-            objects.addAll(childNodes[0].objects);
-            objects.addAll(childNodes[1].objects);
-            objects.addAll(childNodes[2].objects);
-            objects.addAll(childNodes[3].objects);
+            for (int i = 0; i <= 3; i++) {
+                objects.addAll(childNodes[i].objects);
+            }
             childNodes = null;
         }
 

--- a/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/QuadTreeTest.java
+++ b/lib/mosaic-geomath/src/test/java/org/eclipse/mosaic/lib/spatial/QuadTreeTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.spatial;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.mosaic.lib.math.Vector3d;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QuadTreeTest {
+
+
+    private QuadTree<Vector3d> tree;
+
+    @Before
+    public void setup() {
+        // setup new tree for each test
+        QuadTree.configure(2, 1, 3);
+        BoundingBox treeBounds = new BoundingBox();
+        treeBounds.add(new Vector3d(0, 0, 0));
+        treeBounds.add(new Vector3d(100, 0, 100));
+        tree = new QuadTree<>(new SpatialItemAdapter.PointAdapter<>(), treeBounds);
+    }
+
+    @Test
+    public void addObject_Success() {
+        assertTrue(tree.addItem(new Vector3d(5, 0, 5)));
+        assertEquals(1, tree.getSize());
+    }
+
+    @Test
+    public void removeObject_Success() {
+        Vector3d element = new Vector3d(5, 0, 5);
+        assertTrue(tree.addItem(element));
+        assertEquals(1, tree.getSize());
+        tree.removeObject(element);
+        assertEquals(0, tree.getSize());
+    }
+
+    @Test
+    public void addObject_Failure() {
+        assertFalse(tree.addItem(new Vector3d(-10, 0, -10)));
+        assertEquals(0, tree.getSize());
+    }
+
+    @Test
+    public void queryRange_Success() {
+        // SETUP
+        tree.addItem(new Vector3d(5, 0, 5));
+        BoundingBox queryRange = new BoundingBox();
+        queryRange.add(new Vector3d(0, 0, 0));
+        queryRange.add(new Vector3d(10, 0, 10));
+        List<Vector3d> result = new ArrayList<>();
+        QuadTreeTraversal.getObjectsInBoundingArea(tree, queryRange, result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void queryRange_Failure_NoObjectsInArea() {
+        // SETUP
+        tree.addItem(new Vector3d(5, 0, 5));
+        BoundingBox queryRange = new BoundingBox();
+        queryRange.add(new Vector3d(6, 0, 6));
+        queryRange.add(new Vector3d(10, 0, 10));
+        List<Vector3d> result = new ArrayList<>();
+        QuadTreeTraversal.getObjectsInBoundingArea(tree, queryRange, result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void queryRange_Success_TestIntersectMethod() {
+        // SETUP
+        tree.addItem(new Vector3d(5, 0, 5));
+        tree.addItem(new Vector3d(10, 0, 10));
+        tree.addItem(new Vector3d(15, 0, 15));
+        BoundingBox queryRange = new BoundingBox();
+        queryRange.add(new Vector3d(13, 0, 12));
+        queryRange.add(new Vector3d(24, 0, 26));
+        List<Vector3d> result = new ArrayList<>();
+        QuadTreeTraversal.getObjectsInBoundingArea(tree, queryRange, result);
+        assertEquals(3, tree.getSize());
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void joinFunctionality() {
+        // SETUP
+        Vector3d element1 = new Vector3d(5, 0, 5);
+        Vector3d element2 = new Vector3d(75, 0, 75);
+        tree.addItem(element1);
+        tree.addItem(element2);
+        tree.addItem(new Vector3d(75, 0, 0));
+        assertEquals(4, tree.getRoot().childNodes.length);
+        for (int i = 0; i < 4; i++) {
+            assertTrue(tree.getRoot().childNodes[i].isLeaf());
+        }
+        tree.removeObject(element1);
+        tree.removeObject(element2);
+        assertTrue(tree.getRoot().isLeaf());
+
+    }
+}


### PR DESCRIPTION
Signed-off-by: Karl Schrab <karl.schrab@fokus.fraunhofer.de>

## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

Fixes the intersection test in QuadTree for checking a the search area intersects with a quad tile.

## Issue(s) related to this PR

 * Internal Issue 340
 
 
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [ ] All tests pass.

## Special notes to reviewer

