### PR TITLE
fix(app): consider class loader during deserialization of message payload

### DIFF
--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/cam/UserTaggedValueReadingApp.java
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/cam/UserTaggedValueReadingApp.java
@@ -57,7 +57,10 @@ public class UserTaggedValueReadingApp extends AbstractApplication<VehicleOperat
 
         if (msg instanceof Cam) {
             try {
-                getLog().infoSimTime(this, "CAM message arrived, userTaggedValue: {}", CamSendingApp.DEFAULT_OBJECT_SERIALIZATION.fromBytes(((Cam) msg).getUserTaggedValue()));
+                getLog().infoSimTime(this, "CAM message arrived, userTaggedValue: {}",
+                        CamSendingApp.DEFAULT_OBJECT_SERIALIZATION
+                                .fromBytes(((Cam) msg).getUserTaggedValue(), this.getClass().getClassLoader())
+                );
             } catch (IOException | ClassNotFoundException e) {
                 getLog().error("An error occurred", e);
             }

--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/cam/mapping_config.cam.json
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/cam/mapping_config.cam.json
@@ -29,7 +29,7 @@
                     "weight": 0.3
                 },
                 {
-                    "applications": [ "org.eclipse.mosaic.app.tutorial.cam.CAMSendingApp" ],
+                    "applications": [ "org.eclipse.mosaic.app.tutorial.cam.CamSendingApp" ],
                     "name": "Car",
                     "group": "CAMSenders",
                     "weight": 0.6

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ObjectInputStreamWithClassLoader.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ObjectInputStreamWithClassLoader.java
@@ -20,26 +20,20 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 
-/**
- * TODO: this is somewhat copied
- */
-public class ObjectInputStreamWithLoader extends ObjectInputStream {
-    private ClassLoader loader;
+public class ObjectInputStreamWithClassLoader extends ObjectInputStream {
+    private final ClassLoader loader;
 
-    public ObjectInputStreamWithLoader(InputStream in, ClassLoader theLoader)
-            throws IOException {
+    public ObjectInputStreamWithClassLoader(InputStream in, ClassLoader loader) throws IOException {
         super(in);
-        this.loader = theLoader;
+        this.loader = loader;
     }
 
     @Override
-    protected Class<?> resolveClass(ObjectStreamClass aClass)
-            throws IOException, ClassNotFoundException {
+    protected Class<?> resolveClass(ObjectStreamClass objectStreamClass) throws IOException, ClassNotFoundException {
         if (loader == null) {
-            return super.resolveClass(aClass);
-        } else {
-            String name = aClass.getName();
-            return Class.forName(name, false, loader);
+            return super.resolveClass(objectStreamClass);
         }
+        return Class.forName(objectStreamClass.getName(), false, loader);
+
     }
 }

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ObjectInputStreamWithLoader.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ObjectInputStreamWithLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+/**
+ * TODO: this is somewhat copied
+ */
+public class ObjectInputStreamWithLoader extends ObjectInputStream {
+    private ClassLoader loader;
+
+    public ObjectInputStreamWithLoader(InputStream in, ClassLoader theLoader)
+            throws IOException {
+        super(in);
+        this.loader = theLoader;
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass aClass)
+            throws IOException, ClassNotFoundException {
+        if (loader == null) {
+            return super.resolveClass(aClass);
+        } else {
+            String name = aClass.getName();
+            return Class.forName(name, false, loader);
+        }
+    }
+}

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/SerializationUtils.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/SerializationUtils.java
@@ -57,6 +57,12 @@ public final class SerializationUtils<T> {
         }
     }
 
+    public T fromBytes(byte[] bytes, ClassLoader classLoader) throws IOException, ClassNotFoundException {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes); ObjectInput in = new ObjectInputStreamWithLoader(bis, classLoader)) {
+            return (T) in.readObject();
+        }
+    }
+
     public byte[] toBytes(T t) throws IOException {
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream(); ObjectOutput out = new ObjectOutputStream(bos)) {
             out.writeObject(t);

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/SerializationUtils.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/SerializationUtils.java
@@ -57,8 +57,12 @@ public final class SerializationUtils<T> {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public T fromBytes(byte[] bytes, ClassLoader classLoader) throws IOException, ClassNotFoundException {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes); ObjectInput in = new ObjectInputStreamWithLoader(bis, classLoader)) {
+        try (
+                ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+                ObjectInput in = new ObjectInputStreamWithClassLoader(bis, classLoader)
+        ) {
             return (T) in.readObject();
         }
     }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

* with this PR it is possible to call the `fromBytes(...)` method in `SerializationUtils` with an additional `ClassLoader`
* this is relevant as `SerializationUtils` uses a separate `ClassLoader` out of the box

## Issue(s) related to this PR

 * Relates to  [discussion 164](https://github.com/eclipse/mosaic/discussions/164)
 
 
## Affected parts of the online documentation

none

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

