### PR TITLE
fix(omnetpp): use correct omnetpp.ini when starting federate with Docker

### DIFF
--- a/fed/mosaic-omnetpp/src/main/java/org/eclipse/mosaic/fed/omnetpp/ambassador/OmnetppAmbassador.java
+++ b/fed/mosaic-omnetpp/src/main/java/org/eclipse/mosaic/fed/omnetpp/ambassador/OmnetppAmbassador.java
@@ -70,7 +70,7 @@ public class OmnetppAmbassador extends AbstractNetworkAmbassador {
         this.dockerFederateExecutor = new DockerFederateExecutor(
                 dockerImage,
                 "omnetpp-federate/simulations",
-                "/home/mosaic/bin/fed/omnetpp/omnetpp-federate/configuration"
+                "/home/mosaic/bin/fed/omnetpp/omnetpp-federate/simulations"
         );
         return dockerFederateExecutor;
     }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

The path mounted from `OmnetppAmbassador`  did not match the path defined in the `bin/fed/omnetpp/Dockerfile`. This is fixed and the OMNeT++ federate now uses the correct `omnetpp.ini` as defined in the scenario.

## Issue(s) related to this PR

 * Internal issue 352
 
## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

