### PR TITLE
feat(mapping): possibility to set maxSpeed to zero

### DIFF
--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -131,7 +131,7 @@
                     "description": "Maximal speed. If defined as a number, then the default unit is m/s. Alternatively this can be defined as a string to include the unit of measurement (e.g. '50 kmh').",
                     "anyOf": [
                         { "type": "string", "maxLength": 15 },
-                        { "type": "number", "exclusiveMinimum": 0 }
+                        { "type": "number", "minimum": 0 }
                     ]
                 },
                 "minGap": {


### PR DESCRIPTION

Signed-off-by: Felix Lutz <felix.lutz@fokus.fraunhofer.de>

## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

This PR makes it possible to set the parameter `maxSpeed` in the `mapping_config`  to zero in order to directly spawn parking vehicles. This feature only works with Phabmacs as SUMO only accepts `maxSpeed` values greater than zero.

## Issue(s) related to this PR

 * Link to [Eclipse Mosaic repository](https://gitlab.fokus.fraunhofer.de/simulation/mosaic/mosaic-extended/-/issues/235) issue
 
 
## Affected parts of the online documentation

Yes

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [ ] All tests pass.

## Special notes to reviewer

