### PR TITLE
fix(sumo): do not remove vehicles which left parking areas

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -469,9 +469,13 @@ public class SimulationFacade {
 
         final SumoVehicleState sumoVehicle = getVehicleState(veh.id);
         final VehicleStopMode vehicleStopMode = decodeStopMode(veh.stoppedStateEncoded);
-        final boolean isParking = vehicleStopMode == VehicleStopMode.PARK_ON_ROADSIDE || vehicleStopMode == VehicleStopMode.PARK_IN_PARKING_AREA;
+        final boolean isParking = vehicleStopMode.isParking();
         final boolean hasInvalidPosition = veh.position == null || !veh.position.isValid();
         final boolean isNewVehicle = sumoVehicle.lastVehicleData == null;
+        /* When a vehicle is trying to leave a parking area but the lane it's trying to enter is occupied, vehicles are put in a similar
+         * state as when spawned. The position will be invalid until the lane is free. Therefore, we need to handle this case separately. */
+        final boolean isWaitingToLeaveParking = !isNewVehicle && hasInvalidPosition // check for "waiting" state
+                && sumoVehicle.lastVehicleData.getVehicleStopMode().isParking(); // check if was parked
 
         if (hasInvalidPosition && isNewVehicle) {
             /* if a vehicle has not yet been simulated but loaded by SUMO, the vehicle's position will be invalid.
@@ -480,7 +484,7 @@ public class SimulationFacade {
             return null;
         }
 
-        if (hasInvalidPosition) {
+        if (hasInvalidPosition && !isWaitingToLeaveParking) {
             /* If the vehicle, however,  has already been in the simulation (lastVehicleData was valid),
              * then there seems to be an error and the vehicle state will not be updated, resulting in a removal of the vehicle. */
             log.warn("vehicle {} has no valid position and will be removed.", veh.id);
@@ -502,8 +506,7 @@ public class SimulationFacade {
                 .sensors(createSensorData(sumoVehicle, veh.leadingVehicle, veh.followerVehicle, veh.minGap))
                 .laneArea(vehicleSegmentInfo.get(veh.id));
 
-
-        if (isParking) {
+        if (isParking || isWaitingToLeaveParking) {
             if (!sumoVehicle.lastVehicleData.isStopped()) {
                 log.info("Vehicle {} has parked at {} (edge: {})", veh.id, veh.position, veh.edgeId);
             }
@@ -513,9 +516,23 @@ public class SimulationFacade {
                     // for parking vehicles, there are no consumptions and emissions to measure
                     .consumptions(new VehicleConsumptions(
                             new Consumptions(0d), sumoVehicle.lastVehicleData.getVehicleConsumptions().getAllConsumptions())
-                    ).emissions(new VehicleEmissions(
-                            new Emissions(0d, 0d, 0d, 0d, 0d), sumoVehicle.lastVehicleData.getVehicleEmissions().getAllEmissions())
-                    );
+                    ).emissions(
+                            new VehicleEmissions(new Emissions(0d, 0d, 0d, 0d, 0d),
+                                    sumoVehicle.lastVehicleData.getVehicleEmissions().getAllEmissions()));
+            if (isWaitingToLeaveParking) {
+                log.debug("Vehicle {} is currently waiting to leave parking area on edge {}.",
+                        veh.id, sumoVehicle.lastVehicleData.getRoadPosition().getConnectionId());
+                // if the vehicle is waiting to leave a parking area, we assume it's still parked and copy previous vehicle data
+                vehicleDataBuilder
+                        .position(sumoVehicle.lastVehicleData.getPosition(), sumoVehicle.lastVehicleData.getProjectedPosition())
+                        .movement(0.0d, 0.0d, fixDistanceDriven(-1, sumoVehicle.lastVehicleData))
+                        .orientation(DriveDirection.UNAVAILABLE, sumoVehicle.lastVehicleData.getHeading(), sumoVehicle.lastVehicleData.getSlope())
+                        .route(sumoVehicle.lastVehicleData.getRouteId())
+                        .signals(sumoVehicle.lastVehicleData.getVehicleSignals())
+                        .stopped(sumoVehicle.lastVehicleData.getVehicleStopMode())
+                        .sensors(sumoVehicle.lastVehicleData.getVehicleSensors())
+                        .laneArea(sumoVehicle.lastVehicleData.getLaneAreaId());
+            }
         } else {
             vehicleDataBuilder
                     .road(getRoadPosition(veh, sumoVehicle.lastVehicleData))

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/enums/VehicleStopMode.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/enums/VehicleStopMode.java
@@ -37,5 +37,9 @@ public enum VehicleStopMode {
     /**
      * Parks the vehicle at a parking area. The vehicle has to be close to the parking area.
      */
-    PARK_IN_PARKING_AREA
+    PARK_IN_PARKING_AREA;
+
+    public boolean isParking() {
+        return this == PARK_ON_ROADSIDE || this == PARK_IN_PARKING_AREA;
+    }
 }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

* in SUMO, when a vehicle tries to leave a parking area but the "leaving lane" is occupied, it enters a state similar to being newly spawned:
    * wait until lane is no longer occupied --> start driving on route
* during this state vehicles will have a invalid position, resulting in invalid `VehicleData` and the vehicle being removed from simulation
* previously we did catch this behavior in the same way as we do now, but didn't properly remove the vehicles from simulation

* with this PR we properly catch vehicles trying to leave parking areas and handle their `VehicleData` as still being parked

## Issue(s) related to this PR

* Relates to internal issue 353
 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

