### PR TITLE
fix(sumo): properly read tl logic params

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/TrafficLightProgramTraciReader.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/TrafficLightProgramTraciReader.java
@@ -61,6 +61,7 @@ public class TrafficLightProgramTraciReader extends AbstractTraciResultReader<Su
         for (int i = 0; i < numberOfParams; i++) {
             paramReader.readFromStream(in); // key/value pair as list with two items
         }
+        numBytesRead += paramReader.getNumberOfBytesRead();
         return new SumoTrafficLightLogic(logicId, phases, phaseIndex);
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/TrafficLightProgramTraciReader.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/TrafficLightProgramTraciReader.java
@@ -58,7 +58,7 @@ public class TrafficLightProgramTraciReader extends AbstractTraciResultReader<Su
         }
 
         int numberOfParams = readIntWithType(in);
-        for (int i = 0; i < numberOfParams; i++) {
+        for (int i = 0; i < numberOfParams; i++) { // each parameter is read using list reader
             paramReader.readFromStream(in); // key/value pair as list with two items
         }
         numBytesRead += paramReader.getNumberOfBytesRead();

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.net.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.net.xml
@@ -210,6 +210,7 @@
         <phase duration="31" state="rrrrGGgGrrr"/>
         <phase duration="4"  state="rrrryyyyrrr"/>
         <param key="test" value="this is just a test param"/>
+        <param key="test2" value="this is just a second test param"/>
     </tlLogic>
 
     <junction id="1" type="priority" x="0.00" y="0.00" incLanes="1_2_1_0 1_2_1_1" intLanes=":1_0_0" shape="0.00,0.00 -6.40,0.15 0.00,0.00">

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.net.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.net.xml
@@ -209,6 +209,7 @@
         <phase duration="4"  state="rryyrrrrrry"/>
         <phase duration="31" state="rrrrGGgGrrr"/>
         <phase duration="4"  state="rrrryyyyrrr"/>
+        <param key="test" value="this is just a test param"/>
     </tlLogic>
 
     <junction id="1" type="priority" x="0.00" y="0.00" incLanes="1_2_1_0 1_2_1_1" intLanes=":1_0_0" shape="0.00,0.00 -6.40,0.15 0.00,0.00">


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

- in this [discussion#220](https://github.com/eclipse/mosaic/discussions/220) an issue came up where the simulation wasn't running when adding params to tl-logics
- in `TrafficLightProgramTraciReader` we do read this parameters, however don't add the read bytes to the parent-command,
which lead to the simulation getting stuck, as the TraCI-coupling tried reading more bytes

## Issue(s) related to this PR

 * Related to this [discussion#220](https://github.com/eclipse/mosaic/discussions/220)
 
 
## Affected parts of the online documentation

none

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

