### PR TITLE
fix(omnetpp): avoid non-deletable Omnetpp result leftovers

### DIFF
--- a/bundle/src/assembly/resources/fed/omnetpp/Dockerfile
+++ b/bundle/src/assembly/resources/fed/omnetpp/Dockerfile
@@ -26,14 +26,13 @@ COPY ./*.tgz omnet_installer.sh ./
 RUN \
     ls -all && \
     ./omnet_installer.sh -q -t USER -o "/home/mosaic/bin/fed/omnetpp/omnetpp-5.5.1-src-linux.tgz" -i "/home/mosaic/bin/fed/omnetpp/inet-4.1.1-src.tgz" && \
-    mkdir -p omnetpp-federate/simulations
-
-VOLUME ["/home/mosaic/bin/fed/omnetpp/omnetpp-federate"]
+    mkdir -p omnetpp-federate/simulations && \
+    chmod -R 755 inet omnetpp-5.5.1 && \
+    chmod -R 777 omnetpp-federate
 
 EXPOSE 40001 40002
 
 ENTRYPOINT \
-    cp omnetpp-federate/src/omnetpp.ini omnetpp-federate/simulations/ && \
     omnetpp-federate/omnetpp-federate -u Cmdenv \
     -f omnetpp-federate/simulations/omnetpp.ini \
     -n "inet:omnetpp-federate/src" \

--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
@@ -124,7 +124,7 @@ public class DockerRun {
             options.add("--rm");
         }
 
-        if (!user.isEmpty()) {
+        if (user != null && !user.isEmpty()) {
             options.add("--user");
             options.add(user);
         }

--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
@@ -16,6 +16,7 @@
 package org.eclipse.mosaic.lib.docker;
 
 import com.sun.security.auth.module.UnixSystem;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
@@ -96,11 +97,10 @@ public class DockerRun {
      * Sets user to current user/group.
      */
     public DockerRun currentUser() {
-        String os = System.getProperty("os.name").toLowerCase();
         String user = null;
 
         // Currently, default user is set on Linux, only.
-        if (os.contains("linux")) {
+        if (SystemUtils.IS_OS_UNIX) {
             UnixSystem system = new UnixSystem();
             user = String.format("%d:%d", system.getUid(), system.getGid());
         }

--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mosaic.lib.docker;
 
+import com.sun.security.auth.module.UnixSystem;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
@@ -89,6 +90,22 @@ public class DockerRun {
     public DockerRun user(String user) {
         this.user = user;
         return this;
+    }
+
+    /**
+     * Sets user to current user/group.
+     */
+    public DockerRun currentUser() {
+        String os = System.getProperty("os.name").toLowerCase();
+        String user = null;
+
+        // Currently, default user is set on Linux, only.
+        if (os.contains("linux")) {
+            UnixSystem system = new UnixSystem();
+            user = String.format("%d:%d", system.getUid(), system.getGid());
+        }
+
+        return this.user(user);
     }
 
     /**

--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
@@ -31,6 +31,7 @@ public class DockerRun {
     private String name;
     private List<Pair<String, Object>> parameters = new Vector<>();
     private List<Pair<Integer, Integer>> portBindings = new Vector<>();
+    private String user;
     private List<Pair<File, String>> volumeBindings = new Vector<>();
     private boolean removeAfterRun = false;
     private boolean removeBeforeRun;
@@ -81,6 +82,16 @@ public class DockerRun {
     }
 
     /**
+     * Sets the user and group of container. See https://docs.docker.com/engine/reference/run/#user for details.
+     *
+     * @param user the user and group as string accepted by Docker's CLI parameter "--user".
+     */
+    public DockerRun user(String user) {
+        this.user = user;
+        return this;
+    }
+
+    /**
      * Adds an explicit volume binding this docker run command. The resulting
      * container can then share files with the host.
      *
@@ -111,6 +122,11 @@ public class DockerRun {
 
         if (removeAfterRun) {
             options.add("--rm");
+        }
+
+        if (!user.isEmpty()) {
+            options.add("--user");
+            options.add(user);
         }
 
         for (Pair<File, String> binding : volumeBindings) {

--- a/lib/mosaic-docker/src/test/java/org/eclipse/mosaic/lib/docker/DockerClientTest.java
+++ b/lib/mosaic-docker/src/test/java/org/eclipse/mosaic/lib/docker/DockerClientTest.java
@@ -220,6 +220,19 @@ public class DockerClientTest {
         verify(commandLine, never()).rm(anyString());
     }
 
+    @Test
+    public void user_explicit() {
+        String user = "Odo";
+        String image = "test-image";
+
+        //RUN
+        DockerContainer container = dockerClient.run(image).user(user).execute();
+
+        //VERIFY
+        assertNotNull(container);
+        verify(commandLine).runAndDetach(anyString(), argThat(containsInOrder("--user", user, "-P", "--name", image)));
+    }
+
     private static <T> ArgumentMatcher<List<T>> containsInOrder(final T... items) {
         return o -> {
             Iterator<T> itExpected = Arrays.asList(items).iterator();

--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/DockerFederateExecutor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/DockerFederateExecutor.java
@@ -78,6 +78,7 @@ public class DockerFederateExecutor implements FederateExecutor {
                 .name(containerName)
                 .removeBeforeRun()
                 .removeAfterRun()
+                .currentUser()
                 .volumeBinding(new File(workingDir, sharedDirectoryPath), imageVolume);
 
         for (Map.Entry<String, Object> param : parameters.entrySet()) {


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [x] Enhancement

## Description

- OMNeT++ federate's Dockerfile
  - permission fix: if Docker container is not run as root, OMNeT++ has access to all relevant files
  - unnecessary volume definition removed
  - `omnetpp.ini` overwrite removed
- `DockerRun` extended by methods to set the Docker container's user
  - `DockerRun.user(String)` - sets user explicitly
  - `DockerRun.currentUser()` - sets user to current user id and group id in the form: "UID:GID" (on linux systems only)
- `DockerFederateExecutor.startLocalFederate()` calls `DockerRun.currentUser()`

## Issue(s) related to this PR

 * internal issue 357
 
 
## Affected parts of the online documentation

No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

Test of `DockerRun.currentUser()` is not implementable in an elegant way.