### PR TITLE
feat(application): enable full 360 degree perception range

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModule.java
@@ -143,7 +143,7 @@ public class SimplePerceptionModule implements PerceptionModule<SimplePerception
                     return isBetweenVectors(tmpVector1, tmpVector2, leftBoundVector, rightBoundVector)
                             || liesOnVector(tmpVector1, leftBoundVector)
                             || liesOnVector(tmpVector1, rightBoundVector);
-                } else { // for >= 180 degree we do two checks: 1st between direction vector and right or 2nd between direction vector and left
+                } else { // for >= 180 degree do two checks: 1st between direction vector and right or 2nd between direction vector and left
                     return isBetweenVectors(tmpVector1, tmpVector2, directionVector, rightBoundVector)
                             || isBetweenVectors(tmpVector1, tmpVector2, leftBoundVector, directionVector)
                             || liesOnVector(tmpVector1, leftBoundVector)

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModule.java
@@ -134,7 +134,7 @@ public class SimplePerceptionModule implements PerceptionModule<SimplePerception
                 // we use tmpVector2 as origin from the viewpoint of this object
                 tmpVector2.set(0, 0, 0);
 
-                if (tmpVector1.magnitude() > configuration.getViewingRange()) { // other vehicle is in range
+                if (tmpVector1.magnitude() > configuration.getViewingRange()) { // other vehicle is NOT in range
                     return false;
                 }
                 if (MathUtils.isFuzzyEqual(configuration.getViewingAngle(), 360d)) { // for 360 degree viewing angle field-of-view check is obsolete

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -79,7 +79,7 @@ public class SimplePerceptionModuleTest {
         VehicleUnit egoVehicleUnit = spy(new VehicleUnit("veh_0", mock(VehicleType.class), null));
         doReturn(egoVehicleData).when(egoVehicleUnit).getVehicleData();
         simplePerceptionModule = spy(new SimplePerceptionModule(egoVehicleUnit, mock(Logger.class)));
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(108d, 200d));
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(90d, 200d));
 
         // setup ego vehicle
         when(egoVehicleData.getHeading()).thenReturn(90d);
@@ -99,15 +99,48 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
-    public void vehicleCannotBePerceived_toFarLeft_TrivialIndex() {
+    public void vehicleCannotBePerceived_OnLeftBoundVector_TrivialIndex() {
+        setupSpatialIndex(new MutableCartesianPoint(110, 110, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCannotBePerceived_OnRightBoundVector_TrivialIndex() {
+        setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCannotBePerceived_tooFarLeft_TrivialIndex() {
         setupSpatialIndex(new MutableCartesianPoint(105, 115, 0));
         assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
-    public void vehicleCannotBePerceived_toFarRight_TrivialIndex() {
+    public void vehicleCannotBePerceived_tooFarRight_TrivialIndex() {
         setupSpatialIndex(new MutableCartesianPoint(105, 90, 0));
         assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_270viewingAngle_VehicleOnDirectionVector() {
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(110, 100, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_FarLeft_270viewingAngle_TrivialIndex() {
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(105, 115, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_FarRight_270viewingAngle_TrivialIndex() {
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(105, 90, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
@@ -125,17 +158,47 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
-    public void vehicleCannotBePerceived_toFarLeft_QuadTree() {
+    public void vehicleCannotBePerceived_OnLeftBoundVector_QuadTree() {
+        useQuadTree();
+        setupSpatialIndex(new MutableCartesianPoint(110, 110, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCannotBePerceived_OnRightBoundVector_QuadTree() {
+        useQuadTree();
+        setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCannotBePerceived_tooFarLeft_QuadTree() {
         useQuadTree();
         setupSpatialIndex(new MutableCartesianPoint(105, 115, 0));
         assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
-    public void vehicleCannotBePerceived_toFarRight_QuadTree() {
+    public void vehicleCannotBePerceived_tooFarRight_QuadTree() {
         useQuadTree();
         setupSpatialIndex(new MutableCartesianPoint(105, 90, 0));
         assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_FarLeft_270viewingAngle_QuadTree() {
+        useQuadTree();
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(105, 115, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_FarRight_270viewingAngle_QuadTree() {
+        useQuadTree();
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(105, 90, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
@@ -153,17 +216,47 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
-    public void vehicleCannotBePerceived_toFarLeft_Grid() {
+    public void vehicleCannotBePerceived_OnLeftBoundVector_Grid() {
+        useGrid();
+        setupSpatialIndex(new MutableCartesianPoint(110, 110, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCannotBePerceived_OnRightBoundVector_Grid() {
+        useGrid();
+        setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCannotBePerceived_tooFarLeft_Grid() {
         useGrid();
         setupSpatialIndex(new MutableCartesianPoint(105, 115, 0));
         assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
-    public void vehicleCannotBePerceived_toFarRight_Grid() {
+    public void vehicleCannotBePerceived_tooFarRight_Grid() {
         useGrid();
         setupSpatialIndex(new MutableCartesianPoint(105, 90, 0));
         assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_FarLeft_270viewingAngle_Grid() {
+        useGrid();
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(105, 115, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
+    public void vehicleCanBePerceived_FarRight_270viewingAngle_Grid() {
+        useGrid();
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        setupSpatialIndex(new MutableCartesianPoint(105, 90, 0));
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     private void setupSpatialIndex(CartesianPoint... positions) {

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -105,6 +105,12 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
+    public void vehicleCannotBePerceived_OnLeftBoundVector_OppositeDirection_TrivialIndex() {
+        setupSpatialIndex(new MutableCartesianPoint(90, 90, 0));
+        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+    }
+
+    @Test
     public void vehicleCanBePerceived_OnRightBoundVector_TrivialIndex() {
         setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -32,6 +32,7 @@ import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.CartesianRectangle;
 import org.eclipse.mosaic.lib.geo.MutableCartesianPoint;
 import org.eclipse.mosaic.lib.junit.IpResolverRule;
+import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.lib.util.scheduling.EventManager;
@@ -99,15 +100,15 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
-    public void vehicleCannotBePerceived_OnLeftBoundVector_TrivialIndex() {
+    public void vehicleCanBePerceived_OnLeftBoundVector_TrivialIndex() {
         setupSpatialIndex(new MutableCartesianPoint(110, 110, 0));
-        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
-    public void vehicleCannotBePerceived_OnRightBoundVector_TrivialIndex() {
+    public void vehicleCanBePerceived_OnRightBoundVector_TrivialIndex() {
         setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
-        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
@@ -266,6 +267,7 @@ public class SimplePerceptionModuleTest {
             VehicleData vehicleDataMock = mock(VehicleData.class);
             when(vehicleDataMock.getProjectedPosition()).thenReturn(position);
             when(vehicleDataMock.getName()).thenReturn("veh_" + i++);
+            when(vehicleDataMock.getRoadPosition()).thenReturn(mock(IRoadPosition.class));
             vehiclesInIndex.add(vehicleDataMock);
         }
         vehicleIndex.updateVehicles(vehiclesInIndex);

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -32,7 +32,6 @@ import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.CartesianRectangle;
 import org.eclipse.mosaic.lib.geo.MutableCartesianPoint;
 import org.eclipse.mosaic.lib.junit.IpResolverRule;
-import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.lib.util.scheduling.EventManager;
@@ -159,17 +158,17 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
-    public void vehicleCannotBePerceived_OnLeftBoundVector_QuadTree() {
+    public void vehicleCanBePerceived_OnLeftBoundVector_QuadTree() {
         useQuadTree();
         setupSpatialIndex(new MutableCartesianPoint(110, 110, 0));
-        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
-    public void vehicleCannotBePerceived_OnRightBoundVector_QuadTree() {
+    public void vehicleCanBePerceived_OnRightBoundVector_QuadTree() {
         useQuadTree();
         setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
-        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
@@ -217,17 +216,17 @@ public class SimplePerceptionModuleTest {
     }
 
     @Test
-    public void vehicleCannotBePerceived_OnLeftBoundVector_Grid() {
+    public void vehicleCanBePerceived_OnLeftBoundVector_Grid() {
         useGrid();
         setupSpatialIndex(new MutableCartesianPoint(110, 110, 0));
-        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
-    public void vehicleCannotBePerceived_OnRightBoundVector_Grid() {
+    public void vehicleCanBePerceived_OnRightBoundVector_Grid() {
         useGrid();
         setupSpatialIndex(new MutableCartesianPoint(110, 90, 0));
-        assertEquals(0, simplePerceptionModule.getPerceivedVehicles().size());
+        assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
@@ -267,7 +266,6 @@ public class SimplePerceptionModuleTest {
             VehicleData vehicleDataMock = mock(VehicleData.class);
             when(vehicleDataMock.getProjectedPosition()).thenReturn(position);
             when(vehicleDataMock.getName()).thenReturn("veh_" + i++);
-            when(vehicleDataMock.getRoadPosition()).thenReturn(mock(IRoadPosition.class));
             vehiclesInIndex.add(vehicleDataMock);
         }
         vehicleIndex.updateVehicles(vehiclesInIndex);


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* This PR enables the perception module to use full 360° surround perception
* This is done by extending the methodology applied in the first place by using the dot-product of vectors
* However, the dot-product only works for viewing angles less than 180°, so instead of comparing the left- and right-bound vectors, we do two checks:
   * 1st check if point is right of leftBound and left of headingVector
   * or 2nd check if point is left of rightBound and right of headingVector
* the image describes the process
![360_degree_perception](https://user-images.githubusercontent.com/39306374/172846873-8ab545f5-4a2f-45fb-b550-9efa5349d407.png)

* additionally we explicitly include points lying on the edges of the viewing range, which wasn't the case before due to floating point inaccuracies

## Issue(s) related to this PR
 
## Affected parts of the online documentation

The perception module documentation should already be up to date

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

