### PR TITLE
fix(docker): bypass import of UnixSystem class if not available in jdk

### DIFF
--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
@@ -109,10 +109,10 @@ public class DockerRun {
             // Therefore, its import statement has to be bypassed on Windows.
             try {
                 Class<?> systemClass = Class.forName("com.sun.security.auth.module.UnixSystem");
-                Method getUid = systemClass.getDeclaredMethod("getUid", new Class[]{});
-                Method getGid = systemClass.getDeclaredMethod("getGid", new Class[]{});
+                Method getUid = systemClass.getDeclaredMethod("getUid");
+                Method getGid = systemClass.getDeclaredMethod("getGid");
                 Object system = systemClass.newInstance();
-                user = String.format("%d:%d", getUid.invoke(system), getGid.invoke(system));
+                user = String.format("%d:%d", (Long) getUid.invoke(system), (Long) getGid.invoke(system));
             } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 LOG.warn("Cannot fetch user id and group id. User will not be set.");
             }

--- a/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
+++ b/lib/mosaic-docker/src/main/java/org/eclipse/mosaic/lib/docker/DockerRun.java
@@ -15,11 +15,14 @@
 
 package org.eclipse.mosaic.lib.docker;
 
-import com.sun.security.auth.module.UnixSystem;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Vector;
 
@@ -27,6 +30,7 @@ import java.util.Vector;
  * Provides methods to easily compose a "docker run" command.
  */
 public class DockerRun {
+    private final static Logger LOG = LoggerFactory.getLogger(DockerRun.class);
 
     private final DockerClient client;
     private final String image;
@@ -99,10 +103,19 @@ public class DockerRun {
     public DockerRun currentUser() {
         String user = null;
 
-        // Currently, default user is set on Linux, only.
+        // Currently, default user is set on Unix systems, only.
         if (SystemUtils.IS_OS_UNIX) {
-            UnixSystem system = new UnixSystem();
-            user = String.format("%d:%d", system.getUid(), system.getGid());
+            // The class "com.sun.security.auth.module.UnixSystem" is not available on Windows.
+            // Therefore, its import statement has to be bypassed on Windows.
+            try {
+                Class<?> systemClass = Class.forName("com.sun.security.auth.module.UnixSystem");
+                Method getUid = systemClass.getDeclaredMethod("getUid", new Class[]{});
+                Method getGid = systemClass.getDeclaredMethod("getGid", new Class[]{});
+                Object system = systemClass.newInstance();
+                user = String.format("%d:%d", getUid.invoke(system), getGid.invoke(system));
+            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                LOG.warn("Cannot fetch user id and group id. User will not be set.");
+            }
         }
 
         return this.user(user);

--- a/lib/mosaic-docker/src/test/java/org/eclipse/mosaic/lib/docker/DockerClientTest.java
+++ b/lib/mosaic-docker/src/test/java/org/eclipse/mosaic/lib/docker/DockerClientTest.java
@@ -233,6 +233,15 @@ public class DockerClientTest {
         verify(commandLine).runAndDetach(anyString(), argThat(containsInOrder("--user", user, "-P", "--name", image)));
     }
 
+    @Test
+    public void user_auto() {
+        //RUN
+        DockerContainer container = dockerClient.run("test-image").currentUser().execute();
+
+        //VERIFY
+        assertNotNull(container);
+    }
+
     private static <T> ArgumentMatcher<List<T>> containsInOrder(final T... items) {
         return o -> {
             Iterator<T> itExpected = Arrays.asList(items).iterator();


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

- `com.sun.security.auth.module.UnixSystem` is not available on Windows
- bypass import of that class on non-Unix systems

## Issue(s) related to this PR

 * Link to [Eclipse Mosaic repository](https://github.com/eclipse/mosaic/issues) issue
 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

