### PR TITLE
fix(omnetpp): less verbose logging

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
@@ -10,7 +10,7 @@ simtime-resolution=1ns
 # --------------
 # scheduler-class and debugging option for more verbose logging
 scheduler-class = "omnetpp_federate::MosaicEventScheduler"
-mosaiceventscheduler-debug = true
+mosaiceventscheduler-debug = false
 # connection settings, when omnetpp-federate is started manually
 mosaiceventscheduler-host = "localhost"
 mosaiceventscheduler-port = 4998
@@ -36,8 +36,8 @@ Simulation.wlan[*].mac.rng-0 = 2
 #
 # MOSAIC log level equivalent:     INFO      DEBUG
 #---------------------------------------------------
-**.tx.cmdenv-log-level           = info   # = info
-**.rx.cmdenv-log-level           = info   # = info
+**.tx.cmdenv-log-level           = warn   # = info
+**.rx.cmdenv-log-level           = warn   # = info
 **.proxyApp.cmdenv-log-level     = info   # = info
 Simulation.mgmt.cmdenv-log-level = info   # = info
 


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description
- `omnetpp.ini` changed
  - less verbose logging

## Issue(s) related to this PR

 * internal issue 376
 
 
## Affected parts of the online documentation

no

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

