### PR TITLE
fix(ns3): set permission for execution as non-root user

### DIFF
--- a/bundle/src/assembly/resources/fed/ns3/Dockerfile
+++ b/bundle/src/assembly/resources/fed/ns3/Dockerfile
@@ -29,7 +29,9 @@ COPY ./ns* ./
 
 RUN \
     ./ns3_installer.sh -p --quiet && \
-    mkdir -p ns3/scratch
+    mkdir -p ns3/scratch && \
+    chmod -R 755 run.sh ns-allinone-3* && \
+    chmod -R 777 ns3
 
 VOLUME ["/home/mosaic/bin/fed/ns3/scratch"]
 


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

- permission fix for the case: ns3 container is not run as root
- By default the container is run as the current user (-> pull requests #227 and #228). This enables MOSAIC to delete temporary folders.

## Issue(s) related to this PR

 * internal issue 365
 
 
## Affected parts of the online documentation

non

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

