### PR TITLE
fix(docker): support parallel execution of docker federates

### DIFF
--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/DockerFederateExecutor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/DockerFederateExecutor.java
@@ -81,7 +81,6 @@ public class DockerFederateExecutor implements FederateExecutor {
         final DockerRun run = this.dockerClient
                 .run(image)
                 .name(containerName)
-                .removeBeforeRun()
                 .removeAfterRun()
                 .currentUser()
                 .volumeBinding(new File(workingDir, sharedDirectoryPath), imageVolume);

--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/DockerFederateExecutor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/DockerFederateExecutor.java
@@ -41,7 +41,7 @@ public class DockerFederateExecutor implements FederateExecutor {
     private final String image;
     private final String sharedDirectoryPath;
     private final String imageVolume;
-    private final String containerName;
+    private String containerName;
 
     private final Map<String, Object> parameters = new HashMap<>();
     private DockerClient dockerClient;
@@ -66,6 +66,11 @@ public class DockerFederateExecutor implements FederateExecutor {
      */
     public DockerFederateExecutor addParameter(String key, Object value) {
         parameters.put(key, value);
+        return this;
+    }
+
+    public DockerFederateExecutor setContainerName(String name) {
+        containerName = name;
         return this;
     }
 

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -382,7 +382,7 @@ public class MosaicSimulation {
 
             if (StringUtils.isNotEmpty(federate.dockerImage)) {
                 descriptor.setFederateExecutor(
-                        descriptor.getAmbassador().createDockerFederateExecutor(federate.dockerImage, host.operatingSystem)
+                        descriptor.getAmbassador().createDockerFederateExecutor(federate.dockerImage, host.operatingSystem).setContainerName(simulationId)
                 );
             } else {
                 int port = federate.port;

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -381,8 +381,9 @@ public class MosaicSimulation {
         if (descriptor.isToStartAndStop()) {
 
             if (StringUtils.isNotEmpty(federate.dockerImage)) {
+                final String container = federate.id + '-' + simulationId;
                 descriptor.setFederateExecutor(
-                        descriptor.getAmbassador().createDockerFederateExecutor(federate.dockerImage, host.operatingSystem).setContainerName(simulationId)
+                        descriptor.getAmbassador().createDockerFederateExecutor(federate.dockerImage, host.operatingSystem).setContainerName(container)
                 );
             } else {
                 int port = federate.port;

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -99,6 +99,9 @@ public class MosaicSimulation {
     private Logger log = null;
     private ClassLoader classLoader = ClassLoader.getSystemClassLoader();
 
+    private String scenarioId;
+    private String simulationId;
+
     public MosaicSimulation setRuntimeConfiguration(CRuntime runtimeConfiguration) {
         this.runtimeConfiguration = runtimeConfiguration;
         return this;
@@ -166,10 +169,13 @@ public class MosaicSimulation {
 
             Validate.isTrue(Files.exists(scenarioDirectory), "Scenario directory at '" + scenarioDirectory + "' does not exist.");
 
-            final String federationId = Validate.notBlank(scenarioConfiguration.simulation.id,
+            scenarioId = Validate.notBlank(scenarioConfiguration.simulation.id,
                     "No simulation id given in scenario configuration file"
             );
-            prepareLogging(federationId);
+            final Calendar cal = Calendar.getInstance();
+            final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
+            simulationId = dateFormat.format(cal.getTime()) + "-" + scenarioId;
+            prepareLogging(simulationId);
             printMosaicVersion();
 
             final MosaicComponentParameters simParams = readSimulationParameters(scenarioConfiguration)
@@ -237,7 +243,7 @@ public class MosaicSimulation {
 
         return new MosaicComponentParameters()
                 .setRealTimeBreak(realtimeBrake)
-                .setFederationId(scenarioConfiguration.simulation.id)
+                .setFederationId(scenarioId)
                 .setEndTime(scenarioConfiguration.simulation.duration * TIME.SECOND)
                 .setRandomSeed(scenarioConfiguration.simulation.randomSeed);
     }
@@ -470,9 +476,9 @@ public class MosaicSimulation {
     /**
      * Initialize logback and set properties used in logback.xml
      *
-     * @param federationId federation id is used for creating an according log folder
+     * @param simulationId simulation id is used for creating an according log folder
      */
-    private void prepareLogging(String federationId) {
+    private void prepareLogging(String simulationId) {
         // prepare logging directory
         String logDirectoryValue = readLogFolderFromLogback(logbackConfigurationFile);
 
@@ -480,9 +486,7 @@ public class MosaicSimulation {
         //so we just go the standard way
         Path logDirectory;
         if ("${logDirectory}".equals(logDirectoryValue) || logDirectoryValue == null) {
-            Calendar cal = Calendar.getInstance();
-            DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
-            logDirectory = LOG_DIRECTORY.resolve("log-" + dateFormat.format(cal.getTime()) + "-" + federationId);
+            logDirectory = LOG_DIRECTORY.resolve("log-" + simulationId);
         } else {
             logDirectory = Paths.get(logDirectoryValue);
         }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

- parallel execution of federates based on same Docker image was not possible due to simulation independent container names
- new private properties introduced to class `MosaicSimulation`:
  - `scenarioId`: for example `Barnim`
  - `simulationId`: for example `20220630-151732-Barnim`
- a Docker federate's container name is set to `MosaicSimulation.simulationId`

## Issue(s) related to this PR

 * internal issue 375
 
 
## Affected parts of the online documentation

none

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

