### PR TITLE
fix(omnetpp): revised omnetpp.ini

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
@@ -20,7 +20,7 @@ mosaiceventscheduler-port = 4998
 record-eventlog = false
 cmdenv-express-mode = false
 cmdenv-event-banners = false
-cmdenv-log-prefix = "%t: [%M] "
+cmdenv-log-prefix = "%t s: [%M] "
 
 # random numbers
 # -------------
@@ -61,10 +61,10 @@ Simulation.mgmt.cmdenv-log-level = info   # = info
 #**.wlan*.bitrate = 6Mbps
 
 **.wlan*.mac.typename = "Ieee80211Mac"
-**.wlan*.mac.qosStation = true
 **.wlan*.mac.*.rateSelection.*Bitrate = 3Mbps
 **.wlan*.mac.hcf.maxQueueSize = 10
-**.wlan*.mac.hcf.edca.**.cwMin = 15
+**.wlan*.mac.cwMin = 15
+**.wlan*.mac.cwMax = 1023
 **.wlan*.mac.dcf.recoveryProcedure.shortRetryLimit = 7
 **.wlan*.mac.dcf.recoveryProcedure.longRetryLimit = 7
 
@@ -84,11 +84,3 @@ Simulation.radioMedium.mediumLimitCache.carrierFrequency = 5.9GHz
 Simulation.radioMedium.propagation.typename = "ConstantSpeedPropagation"
 Simulation.radioMedium.pathLoss.typename = "FreeSpacePathLoss"
 Simulation.radioMedium.obstacleLoss.typename = ""
-
-###########   mobility    ###################
-**.mobility.constraintAreaMinX = 0m
-**.mobility.constraintAreaMinY = 0m
-**.mobility.constraintAreaMinZ = 0m
-**.mobility.constraintAreaMaxX = 5000m
-**.mobility.constraintAreaMaxY = 5000m
-**.mobility.constraintAreaMaxZ = 0m

--- a/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
@@ -66,7 +66,7 @@ Simulation.veh[*].udpApp.maxProcDelay = 0
 
 **.wlan*.mac.typename = "Ieee80211Mac"
 **.wlan*.mac.*.rateSelection.*Bitrate = 6Mbps
-**.wlan*.mac.hcf.maxQueueSize = 10
+**.wlan*.mac.*.maxQueueSize = 10
 **.wlan*.mac.**.cwMin = 15
 **.wlan*.mac.**.cwMax = 1023
 **.wlan*.mac.dcf.recoveryProcedure.shortRetryLimit = 7

--- a/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/omnetpp/omnetpp.ini
@@ -15,6 +15,11 @@ mosaiceventscheduler-debug = false
 mosaiceventscheduler-host = "localhost"
 mosaiceventscheduler-port = 4998
 
+# ClientServerChannel
+# -------------------
+# OMNeT++ log level names are valid, same hierarchy is used
+clientserverchannel-log-level = warn
+
 # RecordingModi
 # -------------
 record-eventlog = false
@@ -45,8 +50,8 @@ Simulation.mgmt.cmdenv-log-level = info   # = info
 
 
 ########### application settings ############ 
-#Simulation.rsu[*].udpApp.maxProcDelay = 1e-3
-#Simulation.veh[*].udpApp.maxProcDelay = 1e-3
+Simulation.rsu[*].udpApp.maxProcDelay = 0
+Simulation.veh[*].udpApp.maxProcDelay = 0
 
 
 ########### UDP Settings      ###############
@@ -58,13 +63,12 @@ Simulation.mgmt.cmdenv-log-level = info   # = info
 **.wlan*.mgmt.typename = "Ieee80211MgmtAdhoc"
 **.wlan*.agent.typename = ""
 **.wlan*.opMode = "p"
-#**.wlan*.bitrate = 6Mbps
 
 **.wlan*.mac.typename = "Ieee80211Mac"
-**.wlan*.mac.*.rateSelection.*Bitrate = 3Mbps
+**.wlan*.mac.*.rateSelection.*Bitrate = 6Mbps
 **.wlan*.mac.hcf.maxQueueSize = 10
-**.wlan*.mac.cwMin = 15
-**.wlan*.mac.cwMax = 1023
+**.wlan*.mac.**.cwMin = 15
+**.wlan*.mac.**.cwMax = 1023
 **.wlan*.mac.dcf.recoveryProcedure.shortRetryLimit = 7
 **.wlan*.mac.dcf.recoveryProcedure.longRetryLimit = 7
 


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

- revised omnetpp.ini:
  - no mobility section
  - log prefix extended by unit for simulation time
  - mac/phy layer settings revised

## Issue(s) related to this PR

 * internal issue 381
 
 
## Affected parts of the online documentation

none

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

