### PR TITLE
feat(sumo): upgrade to SUMO 1.14.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.13.0
+    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.14.0
     command:
     - cat
     tty: true

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Additional simulators and assessment features are provided by [Fraunhofer FOKUS]
 
 ## Related repositories
 
-* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.13.0`.
+* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.14.0`.
 * The coupling to [ns-3](https://www.nsnam.org) is realized by a federate implementation which can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/ns3-federate). 
   We currently support ns-3 version `3.34`. 
 * The coupling to [OMNeT++](https://omnetpp.org) is implemented in a very similar manner. The corresponding federate implementation can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/omnetpp-federate). 
@@ -60,7 +60,7 @@ For a successful build you need the following software to be installed:
 
 * **Maven 3.1.x** or higher.
 * **Java 8 or 11** - We recommend using the [Adoptium OpenJDK (aka Eclipse Temurin)](https://adoptium.net/?variant=openjdk8).
-* **SUMO 1.13.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
+* **SUMO 1.14.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
 
 ## Build
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
@@ -38,6 +38,7 @@ public enum SumoVersion {
     SUMO_1_11_x("1.11.*", TraciVersion.API_20),
     SUMO_1_12_x("1.12.*", TraciVersion.API_20),
     SUMO_1_13_x("1.13.*", TraciVersion.API_20),
+    SUMO_1_14_x("1.14.*", TraciVersion.API_20),
 
     /**
      * the lowest version supported by this client.
@@ -47,7 +48,7 @@ public enum SumoVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(SUMO_1_13_x.sumoVersion, SUMO_1_13_x.traciVersion);
+    HIGHEST(SUMO_1_14_x.sumoVersion, SUMO_1_14_x.traciVersion);
 
     private final String sumoVersion;
     private final TraciVersion traciVersion;

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
@@ -30,6 +30,7 @@ import org.eclipse.mosaic.fed.sumo.bridge.api.complex.SumoLaneChangeMode;
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.SumoSpeedMode;
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.TraciSimulationStepResult;
 import org.eclipse.mosaic.fed.sumo.config.CSumo;
+import org.eclipse.mosaic.fed.sumo.junit.SinceSumo;
 import org.eclipse.mosaic.fed.sumo.junit.SinceTraci;
 import org.eclipse.mosaic.fed.sumo.junit.SumoRunner;
 import org.eclipse.mosaic.fed.sumo.junit.SumoTraciRule;
@@ -395,7 +396,7 @@ public class TraciTest {
         }
     }
 
-    @SinceTraci(TraciVersion.API_20)
+    @SinceSumo(SumoVersion.SUMO_1_14_x)
     @Test
     public void testEmissionsAndFuelConsumptionCalculation() throws Exception {
         // SETUP
@@ -413,12 +414,12 @@ public class TraciTest {
 
         // ASSERT (for emission class HBEFA3/PC_G_EU4: http://sumo.dlr.de/wiki/Models/Emissions/HBEFA3-based)
         double per1kmFactor = 1000 / vehData.getDistanceDriven();
-        assertEquals(54.5, vehData.getVehicleConsumptions().getAllConsumptions().getFuel() * per1kmFactor, 1d);
+        assertEquals(69, vehData.getVehicleConsumptions().getAllConsumptions().getFuel() * per1kmFactor, 1d);
         assertEquals(490, vehData.getVehicleEmissions().getAllEmissions().getCo() * per1kmFactor, 2d);
-        assertEquals(126800, vehData.getVehicleEmissions().getAllEmissions().getCo2() * per1kmFactor, 100d);
+        assertEquals(161000, vehData.getVehicleEmissions().getAllEmissions().getCo2() * per1kmFactor, 100d);
         assertEquals(4.7, vehData.getVehicleEmissions().getAllEmissions().getHc() * per1kmFactor, 1d);
-        assertEquals(43.9, vehData.getVehicleEmissions().getAllEmissions().getNox() * per1kmFactor, 1d);
-        assertEquals(1.23, vehData.getVehicleEmissions().getAllEmissions().getPmx() * per1kmFactor, 0.1d);
+        assertEquals(52, vehData.getVehicleEmissions().getAllEmissions().getNox() * per1kmFactor, 1d);
+        assertEquals(1.35, vehData.getVehicleEmissions().getAllEmissions().getPmx() * per1kmFactor, 0.1d);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.sqlite-jdbc>3.20.0</version.sqlite-jdbc><!-- 3.20.0 is approved in CQ14652 -->
         <version.stax2-api>4.1</version.stax2-api><!-- 4.1 is approved in CQ17826 -->
         <version.woodstox-core>5.1.0</version.woodstox-core><!-- 5.1.0 is approved in CQ17827 -->
-        <version.libsumo>1.14.0-SNAPSHOT</version.libsumo><!-- only snapshot versions are available -->
+        <version.libsumo>1.14.0</version.libsumo><!-- only snapshot versions are available -->
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.sqlite-jdbc>3.20.0</version.sqlite-jdbc><!-- 3.20.0 is approved in CQ14652 -->
         <version.stax2-api>4.1</version.stax2-api><!-- 4.1 is approved in CQ17826 -->
         <version.woodstox-core>5.1.0</version.woodstox-core><!-- 5.1.0 is approved in CQ17827 -->
-        <version.libsumo>1.14.0</version.libsumo><!-- only snapshot versions are available -->
+        <version.libsumo>1.14.0</version.libsumo>
     </properties>
 
     <dependencies>

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -8,6 +8,6 @@ WORKDIR /home/jenkins
 RUN apt-get update &&  \
     apt-get install -y --allow-unauthenticated software-properties-common && \
     # adjust this output string to bypass potentiall caches
-    echo "Installing SUMO 1.13.0" && \
+    echo "Installing SUMO 1.14.0" && \
     add-apt-repository ppa:sumo/stable && \
     apt-get install -y sumo

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -10,9 +10,9 @@ build and tag the docker image with the latest SUMO version. This image should b
 and available in the PPA.
 
 ```shell script
-docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.13.0
+docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.14.0
 docker login
-docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.13.0
+docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.14.0
 ```  
 
 Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

Upgrades Code and CI to use new SUMO release 1.14.0. With the new version, fuel consumption is returned in mg instead of ml, thus the returned value is converted back to ml assuming a density of 0.74 g/cm³ (see https://kraftstoff-info.de/vergleich-der-kraftstoffe-nach-energiegehalt-und-dichte).

## Issue(s) related to this PR

 * Internal issue 392 
 
## Affected parts of the online documentation

 * Yes, will be fixed with the new release of MOSAIC.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

