### PR TITLE
fix(rti): clarification of usage of federationId and simulationId

### DIFF
--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -432,8 +432,6 @@ public class MosaicSimulation {
      * @throws Exception if something went wrong during initalization of any federate
      */
     private ComponentProvider createFederation(final MosaicComponentParameters simulationParams, final List<FederateDescriptor> federates) throws Exception {
-        final String simId = simulationParams.getFederationId();
-
         final ComponentProvider componentProvider = componentProviderFactory.createComponentProvider(simulationParams);
 
         FederationManagement federation = componentProvider.getFederationManagement();
@@ -442,13 +440,13 @@ public class MosaicSimulation {
         TimeManagement time = componentProvider.getTimeManagement();
 
         if (watchdogInterval > 0) {
-            final WatchDog watchDogThread = time.startWatchDog(simId, watchdogInterval);
+            final WatchDog watchDogThread = time.startWatchDog(federationId, watchdogInterval);
             federation.setWatchdog(watchDogThread);
         }
 
         if (externalWatchdogPort > 0) {
             log.debug("External watchdog port: " + externalWatchdogPort);
-            time.startExternalWatchDog(simId, externalWatchdogPort);
+            time.startExternalWatchDog(federationId, externalWatchdogPort);
         }
 
         final InteractionManagement inter = componentProvider.getInteractionManagement();

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -99,7 +99,7 @@ public class MosaicSimulation {
     private Logger log = null;
     private ClassLoader classLoader = ClassLoader.getSystemClassLoader();
 
-    private String scenarioId;
+    private String federationId;
     private String simulationId;
 
     public MosaicSimulation setRuntimeConfiguration(CRuntime runtimeConfiguration) {
@@ -169,12 +169,12 @@ public class MosaicSimulation {
 
             Validate.isTrue(Files.exists(scenarioDirectory), "Scenario directory at '" + scenarioDirectory + "' does not exist.");
 
-            scenarioId = Validate.notBlank(scenarioConfiguration.simulation.id,
+            federationId = Validate.notBlank(scenarioConfiguration.simulation.id,
                     "No simulation id given in scenario configuration file"
             );
             final Calendar cal = Calendar.getInstance();
             final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
-            simulationId = dateFormat.format(cal.getTime()) + "-" + scenarioId;
+            simulationId = dateFormat.format(cal.getTime()) + "-" + federationId;
             prepareLogging(simulationId);
             printMosaicVersion();
 
@@ -243,7 +243,7 @@ public class MosaicSimulation {
 
         return new MosaicComponentParameters()
                 .setRealTimeBreak(realtimeBrake)
-                .setFederationId(scenarioId)
+                .setFederationId(federationId)
                 .setEndTime(scenarioConfiguration.simulation.duration * TIME.SECOND)
                 .setRandomSeed(scenarioConfiguration.simulation.randomSeed);
     }


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

- rename: `MosaicSimulation.scenarioId` -> `MosaicSimulation.federationId`
- removal of unnecessary local variable `simId` in `MosaicSimulation.createFederation()`

## Issue(s) related to this PR

 * internal issue 384
 
 
## Affected parts of the online documentation

Are there any parts in the online documentation which are affected by this PR?

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

