### PR TITLE
fix(mapping): send VehicleRegistration only for equipped scenario-generated vehicles

### DIFF
--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -33,8 +33,6 @@ import org.eclipse.mosaic.rti.config.CLocalHost.OperatingSystem;
 
 import org.apache.commons.lang3.ObjectUtils;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -127,31 +125,34 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
             final CPrototype prototype = framework.getPrototypeByName(scenarioVehicle.getVehicleTypeId());
             if (prototype == null) {
                 log.debug(
-                        "There is no such CPrototype \"{}\" configured. No application will be mapped for vehicle \"{}\".",
+                        "There is no such prototype \"{}\" configured. No application will be mapped for vehicle \"{}\".",
                         scenarioVehicle.getVehicleTypeId(),
                         scenarioVehicle.getId()
                 );
                 return;
             }
 
-            List<String> applications = new ArrayList<>();
-            if (
-                    randomNumberGenerator.nextDouble() < ObjectUtils.defaultIfNull(prototype.weight, 1.0)
-                    && prototype.applications != null
-            ) {
-                applications = prototype.applications;
+            if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
+                log.debug(
+                        "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
+                        scenarioVehicle.getVehicleTypeId(),
+                        scenarioVehicle.getId(),
+                        prototype.weight
+                );
+                return;
             }
+
             final VehicleRegistration vehicleRegistration = new VehicleRegistration(
                     scenarioVehicle.getTime(),
                     scenarioVehicle.getName(),
                     prototype.group,
-                    applications,
+                    prototype.applications,
                     null,
                     new VehicleTypeSpawner(prototype).convertType()
             );
             try {
                 log.info("Mapping Scenario Vehicle. time={}, name={}, type={}, apps={}",
-                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleTypeId(), applications);
+                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleTypeId(), prototype.applications);
                 rti.triggerInteraction(vehicleRegistration);
             } catch (Exception e) {
                 throw new InternalFederateException(e);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -448,7 +448,7 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
     private void propagateRouteIfAbsent(String routeId, VehicleRoute route) throws InternalFederateException {
         // if the route is already known (because it is defined in a route-file) don't add route
         if (routeCache.containsKey(routeId)) {
-            log.warn("Couldn't add Route {}, because it is already known to SUMO.", routeId);
+            log.warn("Could not add route \"{}\", because it is already known to SUMO.", routeId);
         } else {
             routeCache.put(routeId, route);
             bridge.getRouteControl().addRoute(routeId, route.getConnectionIds());

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/util/MosaicConformVehicleIdTransformer.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/util/MosaicConformVehicleIdTransformer.java
@@ -34,7 +34,7 @@ public class MosaicConformVehicleIdTransformer implements IdTransformer<String, 
 
     private final static Logger log = LoggerFactory.getLogger(MosaicConformVehicleIdTransformer.class);
 
-    private BiMap<String, String> sumoToMosaicVehicleIdMap = HashBiMap.create(1024);
+    private final BiMap<String, String> sumoToMosaicVehicleIdMap = HashBiMap.create(1024);
 
     /**
      * Takes a MOSAIC conform vehicle id (e.g. veh_1) and returns the saved SUMO id in {@link #sumoToMosaicVehicleIdMap}.
@@ -66,7 +66,7 @@ public class MosaicConformVehicleIdTransformer implements IdTransformer<String, 
         if (mosaicVehicleId == null) {
             mosaicVehicleId = UnitNameGenerator.nextVehicleName();
             sumoToMosaicVehicleIdMap.put(sumoVehicleId, mosaicVehicleId);
-            log.info("Assigned vehicle id {} to vehicle {}", mosaicVehicleId, sumoVehicleId);
+            log.debug("Assigned vehicle id {} to vehicle {}", mosaicVehicleId, sumoVehicleId);
         }
         return mosaicVehicleId;
     }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

A `VehicleRegistration` is now only send for those `ScenarioVehicleRegistration`, which match prototype **and** weight condition. In previous versions a `VehicleRegistration` was send with an empty list of applications, if the weight condition was not met, resulting in unnecessary and misleading `VehicleRegistration` interactions.


## Issue(s) related to this PR

 * Internal issue 403
 
 
## Affected parts of the online documentation

No.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

