### PR TITLE
feat(ObjectInstatiation): enable gson serializeSpecialFloatingPointValues feature

### DIFF
--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/objects/ObjectInstantiation.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/objects/ObjectInstantiation.java
@@ -52,9 +52,13 @@ public class ObjectInstantiation<T> {
 
     private final Logger logger;
 
+    private boolean serializeSpecialFloatingPointValues = false;
+
     /**
-     * Creates a new {@link ObjectInstantiation} which creates an object based on the given
-     * {@link Class}. No debug information or warnings are logged during object instantiation.
+     * Creates a new {@link ObjectInstantiation} which creates an object based on
+     * the given
+     * {@link Class}. No debug information or warnings are logged during object
+     * instantiation.
      *
      * @param clazz The class to instantiate.
      */
@@ -63,16 +67,47 @@ public class ObjectInstantiation<T> {
     }
 
     /**
-     * Creates a new {@link ObjectInstantiation} which creates an object based on the given
-     * {@link Class}. Debug information and warnings are logged to the given {@link Logger} during
-     * object instantiation.
+     * Creates a new {@link ObjectInstantiation} which creates an object based on
+     * the given
+     * {@link Class}. No debug information or warnings are logged during object
+     * instantiation.
      *
      * @param clazz The class to instantiate.
+     */
+    public ObjectInstantiation(Class<T> clazz, boolean serializeSpecialFloatingPointValues) {
+        this(clazz, null);
+        this.serializeSpecialFloatingPointValues = serializeSpecialFloatingPointValues;
+    }
+
+    /**
+     * Creates a new {@link ObjectInstantiation} which creates an object based on
+     * the given
+     * {@link Class}. Debug information and warnings are logged to the given
+     * {@link Logger} during
+     * object instantiation.
+     *
+     * @param clazz  The class to instantiate.
      * @param logger The logger which is used to log debug information and warnings.
      */
     public ObjectInstantiation(Class<T> clazz, Logger logger) {
         this.clazz = clazz;
         this.logger = logger;
+    }
+
+    /**
+     * Creates a new {@link ObjectInstantiation} which creates an object based on
+     * the given
+     * {@link Class}. Debug information and warnings are logged to the given
+     * {@link Logger} during
+     * object instantiation.
+     *
+     * @param clazz  The class to instantiate.
+     * @param logger The logger which is used to log debug information and warnings.
+     */
+    public ObjectInstantiation(Class<T> clazz, Logger logger, boolean serializeSpecialFloatingPointValues) {
+        this.clazz = clazz;
+        this.logger = logger;
+        this.serializeSpecialFloatingPointValues = serializeSpecialFloatingPointValues;
     }
 
     /**
@@ -146,11 +181,15 @@ public class ObjectInstantiation<T> {
             validateFile(new ByteArrayInputStream(jsonAsByteArray), streamScheme);
         }
 
+        if (this.serializeSpecialFloatingPointValues) {
+            gsonBuilder = gsonBuilder.serializeSpecialFloatingPointValues();
+        }
         final Gson gson = gsonBuilder.create();
 
         T obj = null;
-        //get the Json from the File
-        try (final Reader reader = new InputStreamReader(new ByteArrayInputStream(jsonAsByteArray), StandardCharsets.UTF_8)) {
+        // get the Json from the File
+        try (final Reader reader = new InputStreamReader(new ByteArrayInputStream(jsonAsByteArray),
+                StandardCharsets.UTF_8)) {
             final JsonReader readerJson = new JsonReader(reader);
             obj = gson.fromJson(readerJson, clazz);
         } catch (IOException e) {
@@ -229,7 +268,7 @@ public class ObjectInstantiation<T> {
         try (JsonParser parser = service.createParser(input, schema, handler)) {
             while (parser.hasNext()) {
                 parser.next();
-                //ignore, we let GSON do the parsing later.
+                // ignore, we let GSON do the parsing later.
             }
         }
         if (!problems.isEmpty()) {
@@ -263,6 +302,5 @@ public class ObjectInstantiation<T> {
         }
         logger.warn(msg, objects);
     }
-
 
 }


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

`ObjectInstantiation<T>` now supports the `GsonBuilder.serializeSpecialFloatingPointValues()` feature which allows parameters of `T` to be i.e. `Double.POSITIVE_INFINITY` or `Double.NEGATIVE_INFINITY`. See [https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google)

## Issue(s) related to this PR

 * Internal issue 379
 
## Affected parts of the online documentation

No.

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

