### PR TITLE
feat(ns3): upgrade to ns-3 3.36.1

### DIFF
--- a/bundle/src/assembly/resources/fed/ns3/Dockerfile
+++ b/bundle/src/assembly/resources/fed/ns3/Dockerfile
@@ -21,7 +21,8 @@ RUN \
   python \
   unzip \
   rsync \
-  wget
+  wget \
+  cmake
 
 WORKDIR /home/mosaic/bin/fed/ns3
 

--- a/bundle/src/assembly/resources/fed/ns3/Dockerfile
+++ b/bundle/src/assembly/resources/fed/ns3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 LABEL \
     description="Docker image containing the MOSAIC adapted ns-3 federate" \
@@ -18,7 +18,7 @@ RUN \
   libxml2-dev \
   protobuf-compiler \
   patch \
-  python \
+  python3 \
   unzip \
   rsync \
   wget \

--- a/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
+++ b/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
@@ -49,7 +49,7 @@ required_programs=( python3 gcc unzip tar )
 required_libraries=( "libprotobuf-dev >= 3.7.0" "libxml2-dev" "libsqlite3-dev" )
 
 ####### configurable parameters ##########
-ns3_version="3.34"
+ns3_version="3.36.1"
 
 ####### automated parameters #############
 premake5_url="https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-linux.tar.gz"

--- a/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
+++ b/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
@@ -376,7 +376,7 @@ build_ns3()
 
   # adjust build instruction to cover scrambled files
   sed -i -e "s|/usr/local|.|" premake5.lua
-  sed -i -e "s|\"/usr/include\"|\"../ns-allinone-${ns3_version}/ns-${ns3_version}/build\"|" premake5.lua
+  sed -i -e "s|\"/usr/include\"|\"../ns-allinone-${ns3_version}/ns-${ns3_version}/build/include\"|" premake5.lua
   sed -i -e "s|\"/usr/lib\"|\"../ns-allinone-${ns3_version}/ns-${ns3_version}/build/lib\"|" premake5.lua
   if [ "${arg_regen_protobuf}" == "true" ]; then
     ./premake5 gmake --generate-protobuf --install


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

- ns-3 version increased from 3.34 to 3.36.1
- `Dockerfile`: installation of package `cmake`
- depends on changes of `premake5.lua` in federate repository

## Issue(s) related to this PR

 * internal issue 459
 * https://github.com/mosaic-addons/ns3-federate/pull/8
 
## Affected parts of the online documentation
- https://www.eclipse.org/mosaic/docs/simulators/network_simulator_ns3/
  - table: version
  - Installation -> Minimum Requirements: cmake

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

