### PR TITLE
feat(sumo): Start SUMO without the need of VehicleRoutesInitialization

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -196,8 +196,8 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
         log.debug("Received VehicleRoutesInitialization: {}", vehicleRoutesInitialization.getTime());
 
         cachedVehicleRoutesInitialization = vehicleRoutesInitialization;
-        if (sumoReadyToStart()) {
-            sumoStartupProcedure();
+        if (cachedVehicleTypesInitialization != null) {
+            addInitialRoutesFromRti();
         }
     }
 
@@ -211,13 +211,7 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
         log.debug("Received VehicleTypesInitialization");
 
         cachedVehicleTypesInitialization = vehicleTypesInitialization;
-        if (sumoReadyToStart()) {
-            sumoStartupProcedure();
-        }
-    }
-
-    private boolean sumoReadyToStart() {
-        return descriptor != null && cachedVehicleRoutesInitialization != null && cachedVehicleTypesInitialization != null;
+        sumoStartupProcedure();
     }
 
     private void sumoStartupProcedure() throws InternalFederateException {
@@ -225,7 +219,9 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
         startSumoLocal();
         initSumoConnection();
         readInitialRoutesFromTraci();
-        addInitialRoutes();
+        if (cachedVehicleRoutesInitialization != null) {
+            addInitialRoutesFromRti();
+        }
     }
 
     /**
@@ -248,7 +244,7 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
      *
      * @throws InternalFederateException if there was a problem with traci
      */
-    private void addInitialRoutes() throws InternalFederateException {
+    private void addInitialRoutesFromRti() throws InternalFederateException {
         for (Map.Entry<String, VehicleRoute> routeEntry : cachedVehicleRoutesInitialization.getRoutes().entrySet()) {
             propagateRouteIfAbsent(routeEntry.getKey(), routeEntry.getValue());
         }


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* This PR allows MOSAIC to start SUMO without the need of a `VehicleRoutesInitialization`-interaction
* to achieve this minor changes in the logic of the `SumoAmbassador` were necessary

## Issue(s) related to this PR

 * relates to internal issue 404
 
 
## Affected parts of the online documentation

No documentation is affected

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

