### PR TITLE
feat(mapping): Use Nanoseconds for vehicle-config time fields

### DIFF
--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/cam/mapping_config.cam.json
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/cam/mapping_config.cam.json
@@ -16,7 +16,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "targetFlow": 1800,
             "maxNumberVehicles": 10,
             "route": "1",

--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/interappcommunication/mapping_config.interapp.json
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/interappcommunication/mapping_config.interapp.json
@@ -16,7 +16,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "targetFlow": 1800,
             "maxNumberVehicles": 10,
             "route": "1",

--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/interunitcommunication/mapping_config.interunit.json
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/interunitcommunication/mapping_config.interunit.json
@@ -16,7 +16,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "targetFlow": 1800,
             "maxNumberVehicles": 10,
             "route": "1",

--- a/bundle/src/assembly/resources/scenarios/Barnim/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Barnim/mapping/mapping_config.json
@@ -34,7 +34,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "targetFlow": 1800,
             "maxNumberVehicles": 120,
             "pos": 1417,

--- a/bundle/src/assembly/resources/scenarios/HelloWorld/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/HelloWorld/mapping/mapping_config.json
@@ -14,7 +14,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1s",
             "targetFlow": 6000,
             "maxNumberVehicles": 400,
             "route": "2",
@@ -32,7 +32,7 @@
             ]
         },
         {
-            "startingTime": 1.0,
+            "startingTime": "1s",
             "targetFlow": 1000,
             "maxNumberVehicles": 50,
             "route": "1",

--- a/bundle/src/assembly/resources/scenarios/Highway/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Highway/mapping/mapping_config.json
@@ -26,7 +26,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1s",
             "targetFlow": 6000,
             "maxNumberVehicles": 400,
             "route": "2",
@@ -38,7 +38,7 @@
             ]
         },
         {
-            "startingTime": 1.0,
+            "startingTime": "1s",
             "targetFlow": 1000,
             "maxNumberVehicles": 50,
             "route": "1",

--- a/bundle/src/assembly/resources/scenarios/Sievekingplatz/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Sievekingplatz/mapping/mapping_config.json
@@ -19,7 +19,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 10.0,
+            "startingTime": "10s",
             "route": "3",
             "targetFlow": 1200,
             "maxNumberVehicles": 3,

--- a/bundle/src/assembly/resources/scenarios/Tiergarten/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/mapping/mapping_config.json
@@ -60,25 +60,25 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]
         },
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]
         },
         {
-            "startingTime": 8.0,
+            "startingTime": "8s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "TrafficLightCar" } ]
         },
         {
-            "startingTime": 10.0,
+            "startingTime": "10s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/OriginDestinationVehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/OriginDestinationVehicleFlowGenerator.java
@@ -38,8 +38,8 @@ public class OriginDestinationVehicleFlowGenerator {
     private final List<List<Double>> odValues;
     private final VehicleDeparture.LaneSelectionMode laneSelectionMode;
     private final VehicleDeparture.DepartureSpeedMode departureSpeedMode;
-    private final double startingTime;
-    private final Double maxTime;
+    private final long startingTime;
+    private final Long maxTime;
 
     /**
      * Constructor for {@link OriginDestinationVehicleFlowGenerator}.

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -42,6 +42,7 @@ import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.lib.objects.UnitNameGenerator;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
+import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
@@ -194,7 +195,6 @@ public class SpawningFramework {
             double remainderSum = 0;
             double scaleTraffic = mappingConfiguration.config != null ? mappingConfiguration.config.scaleTraffic : 1d;
             for (CVehicle vehicleConfiguration : mappingConfiguration.vehicles) {
-
                 //The "continue" still can be called if the spawner exists but the value of
                 // maxNumberVehicles was explicitly set to 0 in the mapping
                 //(convenient for testing of different mapping variations)
@@ -289,7 +289,7 @@ public class SpawningFramework {
         if (spawner.spawningMode != CVehicle.SpawningMode.CONSTANT) {
             return;
         }
-        spawner.startingTime = Math.max(0, Math.round(spawner.startingTime + rng.nextDouble(-20, 20)));
+        spawner.startingTime = Math.max(0, spawner.startingTime + rng.nextLong(-60 * TIME.SECOND, 60 * TIME.SECOND));
     }
 
     private void randomizeWeights(RandomNumberGenerator rng, List<CPrototype> types) {
@@ -303,7 +303,6 @@ public class SpawningFramework {
         for (CPrototype type : types) {
             if (type.weight != null && type.weight > 0) {
                 // randomize weight within a reasonable range
-
                 double newWeight = Math.round(rng.nextGaussian(type.weight, sum / 100d) * 100d) / 100d;
                 type.weight = Math.min(Math.max(type.weight - sum / 100d, newWeight), type.weight + sum / 100d);
                 sum -= type.weight;

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -186,14 +186,13 @@ public class VehicleFlowGenerator {
             CVehicle vehicleConfiguration, RandomNumberGenerator randomNumberGenerator, boolean flowNoise) {
 
         CVehicle.SpawningMode spawningMode = vehicleConfiguration.spawningMode;
-        long startingTime = (long) vehicleConfiguration.startingTime * TIME.SECOND;
+        long startingTime = vehicleConfiguration.startingTime;
         // if no maxTime was given determine it by dividing the maximum amount of vehicles by the desired flow and adding the start time
         long maxTime;
         if (vehicleConfiguration.maxTime == null) {
-            maxTime = (long) (((double) maxNumberVehicles / vehicleConfiguration.targetFlow) * (double) TIME.HOUR)
-                    + (long) vehicleConfiguration.startingTime * TIME.SECOND;
+            maxTime = (long) (((double) maxNumberVehicles / vehicleConfiguration.targetFlow) * (double) TIME.HOUR) + startingTime;
         } else {
-            maxTime = vehicleConfiguration.maxTime.longValue() * TIME.SECOND;
+            maxTime = vehicleConfiguration.maxTime;
         }
         double targetFlow = vehicleConfiguration.targetFlow;
         SpawningMode newSpawningMode;
@@ -311,10 +310,10 @@ public class VehicleFlowGenerator {
 
     void configure(CMappingConfiguration mappingParameterizationConfiguration) {
         if (mappingParameterizationConfiguration.start != null) {
-            this.start = Double.valueOf(mappingParameterizationConfiguration.start * TIME.SECOND).longValue();
+            this.start = mappingParameterizationConfiguration.start;
         }
         if (mappingParameterizationConfiguration.end != null) {
-            this.end = Double.valueOf(mappingParameterizationConfiguration.end * TIME.SECOND).longValue();
+            this.end = mappingParameterizationConfiguration.end;
         }
         Validate.isTrue(this.end > this.start);
     }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
@@ -16,6 +16,10 @@
 package org.eclipse.mosaic.fed.mapping.config;
 
 
+import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
+
+import com.google.gson.annotations.JsonAdapter;
+
 /**
  * Class that contains options for the parametrization of the Mapping.
  */
@@ -28,27 +32,29 @@ public class CMappingConfiguration {
     public double scaleTraffic = 1.0;
 
     /**
-     * Defines the point in time (in seconds) to start spawning vehicles. If not set (default),
-     * all vehicles will be spawned according to the vehicles configuration.
+     * Defines the point in time to start spawning vehicles. If not set (default),
+     * all vehicles will be spawned according to the vehicles' configuration. [ns]
      */
-    public Double start;
+    @JsonAdapter(TimeFieldAdapter.NanoSeconds.class)
+    public Long start;
 
     /**
-     * Defines the point in time (in seconds) to end spawning vehicles. If not set (default),
-     * all vehicles will be spawned according to the vehicles configuration or until the simulation ends.
+     * Defines the point in time to end spawning vehicles. If not set (default),
+     * all vehicles will be spawned according to the vehicles configuration or until the simulation ends. [ns]
      */
-    public Double end;
+    @JsonAdapter(TimeFieldAdapter.NanoSeconds.class)
+    public Long end;
 
     /**
-     * If set to <code>true</code> and if the parameter <code>start</code> is set, the starting
+     * If set to {@code true} and if the parameter {@code start} is set, the starting
      * times of each spawner is adjusted accordingly, so that we shouldn't wait
      * in case that simulation starting time and spawner starting time are widely spread out.
-     * All spawners before <code>start</code> will be completely ignored then.
+     * All spawners before {@code start} will be completely ignored then.
      */
     public boolean adjustStartingTimes = false;
 
     /**
-     * If set to <code>true</code>, all flow definitions defined by vehicle spawners with more than 1 vehicle
+     * If set to {@code true}, all flow definitions defined by vehicle spawners with more than 1 vehicle
      * result in slightly randomized departure times. The specified `targetFlow` of the vehicle spawner is kept.
      */
     public boolean randomizeFlows = false;

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/COriginDestinationMatrixMapper.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/COriginDestinationMatrixMapper.java
@@ -18,6 +18,7 @@ package org.eclipse.mosaic.fed.mapping.config.units;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.lib.geo.GeoCircle;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture;
+import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -55,15 +56,17 @@ public class COriginDestinationMatrixMapper {
     public List<List<Double>> odValues;
 
     /**
-     * Time at which the first vehicle will be created.
+     * Time at which the first vehicle will be created. [ns]
      */
-    public double startingTime = 0.0;
+    @JsonAdapter(TimeFieldAdapter.NanoSeconds.class)
+    public long startingTime = 0L;
 
     /**
-     * Simulation time in seconds at which no more vehicles will be created.
+     * Simulation time at which no more vehicles will be created. [ns]
      */
     @SerializedName(value = "maxTime", alternate = {"endingTime"})
-    public Double maxTime;
+    @JsonAdapter(TimeFieldAdapter.NanoSeconds.class)
+    public Long maxTime;
 
     /**
      * The lane selection mode which chooses the lane for the next departing vehicle.

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
@@ -20,6 +20,7 @@ import org.eclipse.mosaic.lib.geo.GeoCircle;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.DepartureSpeedMode;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.LaneSelectionMode;
 import org.eclipse.mosaic.lib.util.gson.AbstractEnumDefaultValueTypeAdapter;
+import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
 import org.eclipse.mosaic.lib.util.gson.UnitFieldAdapter;
 
 import com.google.gson.annotations.JsonAdapter;
@@ -47,15 +48,17 @@ public class CVehicle implements Comparable<CVehicle> {
     }
 
     /**
-     * Time at which the first vehicle will be created.
+     * Time at which the first vehicle will be created. [ns]
      */
-    public double startingTime = 0.0;
+    @JsonAdapter(TimeFieldAdapter.NanoSeconds.class)
+    public long startingTime = 0;
 
     /**
-     * Simulation time in seconds at which no more vehicles will be created.
+     * Simulation time in seconds at which no more vehicles will be created. [ns]
      */
     @SerializedName(value = "maxTime", alternate = {"endingTime"})
-    public Double maxTime;
+    @JsonAdapter(TimeFieldAdapter.NanoSeconds.class)
+    public Long maxTime;
 
     /**
      * Density of vehicles per hour. Vehicles will be spawned uniformly.
@@ -198,14 +201,14 @@ public class CVehicle implements Comparable<CVehicle> {
 
     @Override
     public int compareTo(CVehicle o) {
-        if (Double.compare(o.startingTime, 0) < 0 && Double.compare(this.startingTime, 0) < 0) {
+        if (o.startingTime < 0 && this.startingTime < 0) {
             return 0;
-        } else if (Double.compare(this.startingTime, 0) < 0) {
+        } else if (this.startingTime < 0) {
             return 1;
-        } else if (Double.compare(o.startingTime, 0) < 0) {
+        } else if (o.startingTime < 0) {
             return -1;
         } else {
-            return Double.compare(this.startingTime, o.startingTime);
+            return Long.compare(this.startingTime, o.startingTime);
         }
     }
 

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -60,14 +60,18 @@
             "type": "object",
             "properties": {
                 "start": {
-                    "description": "Defines the point in time (in seconds) to start spawning vehicles. If not set (default), all vehicles will be spawned according to the vehicles configuration.",
-                    "type": "number",
-                    "minimum": 0
+                    "description": "Defines the point in time (in nanoseconds) to start spawning vehicles. If not set (default), all vehicles will be spawned according to the vehicles configuration.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "end": {
-                    "description": "Defines the point in time (in seconds) to end spawning vehicles. If not set (default), all vehicles will be spawned according to the vehicles configuration or until the simulation ends.",
-                    "type": "number",
-                    "minimum": 0
+                    "description": "Defines the point in time (in nanoseconds) to end spawning vehicles. If not set (default), all vehicles will be spawned according to the vehicles configuration or until the simulation ends.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "scaleTraffic": {
                     "description": "Scales the traffic by the given factor. E.g. 2.0 would double the number of spawned vehicles",
@@ -194,15 +198,18 @@
             "type": "object",
             "properties": {
                 "startingTime": {
-                    "description": "Time at which the first vehicle will be created.",
-                    "type": "number",
-                    "minimum": 0,
-                    "default": 0.0
+                    "description": "Time in nanoseconds at which the first vehicle will be created.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "maxTime": {
-                    "description": "Simulation time in seconds at which no more vehicles will be created.",
-                    "type": "number",
-                    "minimum": 0
+                    "description": "Simulation time in nanoseconds at which no more vehicles will be created.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "targetFlow": {
                     "description": "Density of vehicles per hour. Vehicles will be spawned uniformly.",
@@ -331,15 +338,18 @@
                     }
                 },
                 "startingTime": {
-                    "description": "Time at which the first vehicle will be created.",
-                    "type": "number",
-                    "minimum": 0,
-                    "default": 0.0
+                    "description": "Time in nanoseconds at which the first vehicle will be created.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "maxTime": {
-                    "description": "Simulation time in seconds at which no more vehicles will be created.",
-                    "type": "number",
-                    "minimum": 0
+                    "description": "Simulation time in nanoseconds at which no more vehicles will be created.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0 }
+                    ]
                 },
                 "departSpeedMode": {
                     "description": "The depart speed mode determines the vehicle's speed at insertion.",

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFrameworkTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFrameworkTest.java
@@ -213,7 +213,7 @@ public class SpawningFrameworkTest {
     private CVehicle newSpawner(String prototype) {
         CVehicle spawner = new CVehicle();
         spawner.route = "1";
-        spawner.startingTime = 0;
+        spawner.startingTime = 0L;
         spawner.targetFlow = 1200;
         spawner.maxNumberVehicles = 100;
         spawner.types = Lists.newArrayList(newPrototype(prototype));

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/BarnimMappingTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/BarnimMappingTest.java
@@ -25,6 +25,7 @@ import org.eclipse.mosaic.fed.mapping.config.units.CRoadSideUnit;
 import org.eclipse.mosaic.fed.mapping.config.units.CVehicle;
 import org.eclipse.mosaic.lib.enums.VehicleClass;
 import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
+import org.eclipse.mosaic.rti.TIME;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -161,7 +162,7 @@ public class BarnimMappingTest {
         assertNull(vehicle.maxTime);
         assertEquals(vehicle.pos, 0);
         assertEquals(vehicle.route, "1");
-        assertEquals(5.0, vehicle.startingTime, 0.0);
+        assertEquals(5 * TIME.SECOND, vehicle.startingTime);
         checkVehicleTypes(vehicle);
     }
 

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/TiergartenMappingTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/TiergartenMappingTest.java
@@ -25,6 +25,7 @@ import org.eclipse.mosaic.fed.mapping.config.units.CRoadSideUnit;
 import org.eclipse.mosaic.fed.mapping.config.units.CTrafficLight;
 import org.eclipse.mosaic.fed.mapping.config.units.CVehicle;
 import org.eclipse.mosaic.lib.util.objects.ObjectInstantiation;
+import org.eclipse.mosaic.rti.TIME;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -198,7 +199,7 @@ public class TiergartenMappingTest {
         assertNull(vehicle1.maxTime);
         assertEquals(vehicle1.pos, 0);
         assertEquals(vehicle1.route, "0");
-        assertEquals(1.0, vehicle1.startingTime, 0.0);
+        assertEquals(1 * TIME.SECOND, vehicle1.startingTime);
         assertNotNull(vehicle1.types);
         assertEquals(vehicle1.types.size(), 1);
 
@@ -227,7 +228,7 @@ public class TiergartenMappingTest {
         assertNull(vehicle2.maxTime);
         assertEquals(vehicle2.pos, 0);
         assertEquals(vehicle2.route, "0");
-        assertEquals(5.0, vehicle2.startingTime, 0.0);
+        assertEquals(5 * TIME.SECOND, vehicle2.startingTime);
         assertNotNull(vehicle2.types);
         assertEquals(1, vehicle2.types.size());
 
@@ -256,7 +257,7 @@ public class TiergartenMappingTest {
         assertNull(vehicle3.maxTime);
         assertEquals(vehicle3.pos, 0);
         assertEquals(vehicle3.route, "0");
-        assertEquals(8.0, vehicle3.startingTime, 0.0);
+        assertEquals(8 * TIME.SECOND, vehicle3.startingTime);
         assertNotNull(vehicle3.types);
         assertEquals(1, vehicle3.types.size());
 
@@ -285,7 +286,7 @@ public class TiergartenMappingTest {
         assertNull(vehicle4.maxTime);
         assertEquals(0, vehicle4.pos);
         assertEquals("0", vehicle4.route);
-        assertEquals(10.0, vehicle4.startingTime, 0.0);
+        assertEquals(10 * TIME.SECOND, vehicle4.startingTime);
         assertNotNull(vehicle4.types);
         assertEquals(1, vehicle4.types.size());
 

--- a/fed/mosaic-mapping/src/test/resources/mapping/Barnim.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/Barnim.json
@@ -37,18 +37,23 @@
     ],
     "vehicles": [
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "targetFlow": 1200,
             "maxNumberVehicles": 120,
             "route": "1",
             "types": [
                 {
-                    "applications": [ "org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningAppCell", "org.eclipse.mosaic.app.tutorials.barnim.SlowDownApp" ],
+                    "applications": [
+                        "org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningAppCell",
+                        "org.eclipse.mosaic.app.tutorials.barnim.SlowDownApp"
+                    ],
                     "name": "PKW",
                     "weight": 0.1
                 },
                 {
-                    "applications": [ "org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp", "org.eclipse.mosaic.app.tutorials.barnim.SlowDownApp" ],
+                    "applications": [
+                        "org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp", "org.eclipse.mosaic.app.tutorials.barnim.SlowDownApp"
+                    ],
                     "name": "PKW",
                     "weight": 0.2
                 },

--- a/fed/mosaic-mapping/src/test/resources/mapping/Tiergarten.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/Tiergarten.json
@@ -48,25 +48,25 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "PKW" } ]
         },
         {
-            "startingTime": 5.0,
+            "startingTime": "5s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "PKW" } ]
         },
         {
-            "startingTime": 8.0,
+            "startingTime": "8s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "TLPKW" } ]
         },
         {
-            "startingTime": 10.0,
+            "startingTime": "10s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "PKW" } ]

--- a/fed/mosaic-mapping/src/test/resources/mapping_config.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config.json
@@ -1,49 +1,52 @@
 {
-	"prototypes":[
-		{
-			"name":"PKW",
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":70.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1
-		},
-		{
-			"name":"electricPKW",			
-			"vehicleClass": "ElectricVehicle",
-			"applications":["org.eclipse.mosaic.app.examples.eventprocessing.sampling.HelloWorldApp", "org.eclipse.mosaic.app.examples.eventprocessing.sampling.IntervalSamplingApp"],
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":40.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1
-		}
-	],
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 120,
-			"route":"1",
-			"types":[
-				{
-					"applications":["org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp"],
-					"name":"PKW",
-					"weight":0.2
-				},
-				{
-					"name":"PKW",
-					"weight":0.7
-				},
-				{
-					"name":"electricPKW",
-					"weight":0.1
-				}
-			]
-		}
-	]
+    "prototypes": [
+        {
+            "name": "PKW",
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 70.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1
+        },
+        {
+            "name": "electricPKW",
+            "vehicleClass": "ElectricVehicle",
+            "applications": [
+                "org.eclipse.mosaic.app.examples.eventprocessing.sampling.HelloWorldApp",
+                "org.eclipse.mosaic.app.examples.eventprocessing.sampling.IntervalSamplingApp"
+            ],
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 40.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1
+        }
+    ],
+    "vehicles": [
+        {
+            "startingTime": "5s",
+            "targetFlow": 1200,
+            "maxNumberVehicles": 120,
+            "route": "1",
+            "types": [
+                {
+                    "applications": [ "org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp" ],
+                    "name": "PKW",
+                    "weight": 0.2
+                },
+                {
+                    "name": "PKW",
+                    "weight": 0.7
+                },
+                {
+                    "name": "electricPKW",
+                    "weight": 0.1
+                }
+            ]
+        }
+    ]
 }

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_reference.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_reference.json
@@ -1,45 +1,44 @@
 {
-	"prototypes":[
-		{
-			"name":"Car",
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":70.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1
-		}
-	],
-	"typeDistributions": {
-		"myDistribution" : [
-			{
-				"name":"Car",
-				"applications":["Car1App"],
-				"weight": 20
-			},
-			{
-				"name":"Car",
-				"applications":["Car2App"],
-				"weight": 80
-			}
-		]
-	},
-
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 5,
-			"route":"1",
-			"typeDistribution": "myDistribution"
-		},
-		{
-			"startingTime": 20.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 5,
-			"route":"1",
-			"typeDistribution": "myDistribution"
-		}
-	]
+    "prototypes": [
+        {
+            "name": "Car",
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 70.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1
+        }
+    ],
+    "typeDistributions": {
+        "myDistribution": [
+            {
+                "name": "Car",
+                "applications": [ "Car1App" ],
+                "weight": 20
+            },
+            {
+                "name": "Car",
+                "applications": [ "Car2App" ],
+                "weight": 80
+            }
+        ]
+    },
+    "vehicles": [
+        {
+            "startingTime": "5s",
+            "targetFlow": 1200,
+            "maxNumberVehicles": 5,
+            "route": "1",
+            "typeDistribution": "myDistribution"
+        },
+        {
+            "startingTime": "20s",
+            "targetFlow": 1200,
+            "maxNumberVehicles": 5,
+            "route": "1",
+            "typeDistribution": "myDistribution"
+        }
+    ]
 }

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_scale.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_scale.json
@@ -1,51 +1,51 @@
 {
-	"prototypes":[
-		{
-			"name":"car"
-		}
-	],
-	"config" : {
-		"scaleTraffic": 1.3
-	},
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":923,
-			"maxNumberVehicles": 1,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app1"] }]
-		},
-		{
-			"startingTime": 10.0,
-			"targetFlow":923,
-			"maxNumberVehicles": 2,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app2"] }]
-		},
-		{
-			"startingTime": 20.0,
-			"targetFlow":554,
-			"maxNumberVehicles": 1,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app3"] }]
-		},
-		{
-			"startingTime": 30.0,
-			"targetFlow":923,
-			"maxNumberVehicles": 6,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app4"] }]
-		},
-		{
-			"startingTime": 46.0,
-			"targetFlow":923,
-			"route":"1",
-			"types":[
-				{
-					"name":"unlimitedCars",
-					"applications":["app5"]
-				}
-			]
-		}
-	]
+    "prototypes": [
+        {
+            "name": "car"
+        }
+    ],
+    "config": {
+        "scaleTraffic": 1.3
+    },
+    "vehicles": [
+        {
+            "startingTime": "5s",
+            "targetFlow": 923,
+            "maxNumberVehicles": 1,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app1" ] } ]
+        },
+        {
+            "startingTime": "10s",
+            "targetFlow": 923,
+            "maxNumberVehicles": 2,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app2" ] } ]
+        },
+        {
+            "startingTime": "20s",
+            "targetFlow": 554,
+            "maxNumberVehicles": 1,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app3" ] } ]
+        },
+        {
+            "startingTime": "30s",
+            "targetFlow": 923,
+            "maxNumberVehicles": 6,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app4" ] } ]
+        },
+        {
+            "startingTime": "46s",
+            "targetFlow": 923,
+            "route": "1",
+            "types": [
+                {
+                    "name": "unlimitedCars",
+                    "applications": [ "app5" ]
+                }
+            ]
+        }
+    ]
 }

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_timespan.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_timespan.json
@@ -1,49 +1,48 @@
 {
-	"prototypes":[
-		{
-			"name":"Car",
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":70.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1
-		}
-	],
-	"config" : {
-		"start": 10,
-		"end": 25
-	},
-	"typeDistributions": {
-		"myDistribution" : [
-			{
-				"name":"Car",
-				"applications":["Car1App"],
-				"weight": 20
-			},
-			{
-				"name":"Car",
-				"applications":["Car2App"],
-				"weight": 80
-			}
-		]
-	},
-
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 5,
-			"route":"1",
-			"typeDistribution": "myDistribution"
-		},
-		{
-			"startingTime": 20.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 5,
-			"route":"1",
-			"typeDistribution": "myDistribution"
-		}
-	]
+    "prototypes": [
+        {
+            "name": "Car",
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 70.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1
+        }
+    ],
+    "config": {
+        "start": "10s",
+        "end": "25s"
+    },
+    "typeDistributions": {
+        "myDistribution": [
+            {
+                "name": "Car",
+                "applications": [ "Car1App" ],
+                "weight": 20
+            },
+            {
+                "name": "Car",
+                "applications": [ "Car2App" ],
+                "weight": 80
+            }
+        ]
+    },
+    "vehicles": [
+        {
+            "startingTime": "5s",
+            "targetFlow": 1200,
+            "maxNumberVehicles": 5,
+            "route": "1",
+            "typeDistribution": "myDistribution"
+        },
+        {
+            "startingTime": "20s",
+            "targetFlow": 1200,
+            "maxNumberVehicles": 5,
+            "route": "1",
+            "typeDistribution": "myDistribution"
+        }
+    ]
 }

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_weights_in_prototype.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_weights_in_prototype.json
@@ -1,45 +1,45 @@
 {
-	"prototypes":[
-		{
-			"name":"Car1",
-			"applications":["Car1App"],
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":70.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1,
-			"weight": 20
-		},
-		{
-			"name":"Car2",
-			"vehicleClass": "ElectricVehicle",
-			"applications":["Car2App"],
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":40.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1,
-			"weight": 80
-		}
-	],
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 10,
-			"route":"1",
-			"types":[
-				{
-					"name":"Car1"
-				},
-				{
-					"name":"Car2"
-				}
-			]
-		}
-	]
+    "prototypes": [
+        {
+            "name": "Car1",
+            "applications": [ "Car1App" ],
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 70.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1,
+            "weight": 20
+        },
+        {
+            "name": "Car2",
+            "vehicleClass": "ElectricVehicle",
+            "applications": [ "Car2App" ],
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 40.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1,
+            "weight": 80
+        }
+    ],
+    "vehicles": [
+        {
+            "startingTime": "5s",
+            "targetFlow": 1200,
+            "maxNumberVehicles": 10,
+            "route": "1",
+            "types": [
+                {
+                    "name": "Car1"
+                },
+                {
+                    "name": "Car2"
+                }
+            ]
+        }
+    ]
 }

--- a/test/scenarios/cell-sns-cam-send-and-receive/mapping/mapping_config.json
+++ b/test/scenarios/cell-sns-cam-send-and-receive/mapping/mapping_config.json
@@ -82,7 +82,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 0.0,
+            "startingTime": "0s",
             "route": "0",
             "pos": 10,
             "maxNumberVehicles": 1,
@@ -94,7 +94,7 @@
             ]
         },
         {
-            "startingTime": 160.0,
+            "startingTime": "160s",
             "route": "0",
             "pos": 10,
             "maxNumberVehicles": 1,
@@ -108,7 +108,7 @@
             ]
         },
         {
-            "startingTime": 230.0,
+            "startingTime": "230s",
             "route": "0",
             "pos": 10,
             "maxNumberVehicles": 1,
@@ -120,7 +120,7 @@
             ]
         },
         {
-            "startingTime": 300.0,
+            "startingTime": "300s",
             "route": "0",
             "pos": 10,
             "maxNumberVehicles": 1,

--- a/test/scenarios/sumo-predefined-scenario-integration/mapping/mapping_config.json
+++ b/test/scenarios/sumo-predefined-scenario-integration/mapping/mapping_config.json
@@ -15,7 +15,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 0.0,
+            "startingTime": "0s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [

--- a/test/scenarios/sumo-traci-app-interaction/mapping/mapping_config.json
+++ b/test/scenarios/sumo-traci-app-interaction/mapping/mapping_config.json
@@ -27,12 +27,12 @@
     ],
     "vehicles": [
         {
-            "startingTime": 2.0,
+            "startingTime": "2s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]
         }, {
-            "startingTime": 6.0,
+            "startingTime": "6s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* All time values in vehicle and vehicle flow generations are now treated in nanoseconds and are stored as longs instead of doubles
* Now the `TimeFieldAdapter.NanoSeconds` is used for all time-values, i.e. `startingTime`, `maxTime`
* this has the consequence that **all** mapping_config.json needed to be adjusted
* some cleanup


## Issue(s) related to this PR

 * Relates to internal issue 421
 
 
## Affected parts of the online documentation

- Yes **all** occurences of vehicle mappings need to be adjusted accordingly

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

