### PR TITLE
refactor(rti): changes the handling of priorities when processing time advance requests

### DIFF
--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/OutputAmbassador.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/OutputAmbassador.java
@@ -23,6 +23,7 @@ import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.Interaction;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
+import org.eclipse.mosaic.rti.api.parameters.FederatePriority;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -89,7 +90,7 @@ public class OutputAmbassador extends AbstractFederateAmbassador {
             createOutputGenerator(loadConfiguration());
 
             this.nextTimestep = startTime + this.globalUpdateInterval;
-            this.rti.requestAdvanceTime(this.nextTimestep, this.globalUpdateInterval, (byte) 0);
+            this.rti.requestAdvanceTime(this.nextTimestep, this.globalUpdateInterval, FederatePriority.LOWEST);
         } catch (IllegalValueException e) {
             throw new InternalFederateException(e);
         }
@@ -179,7 +180,7 @@ public class OutputAmbassador extends AbstractFederateAmbassador {
             }
 
             this.nextTimestep += this.globalUpdateInterval;
-            this.rti.requestAdvanceTime(this.nextTimestep, this.globalUpdateInterval, (byte) 0);
+            this.rti.requestAdvanceTime(this.nextTimestep, this.globalUpdateInterval, FederatePriority.LOWEST);
         } catch (Exception e) {
             throw new InternalFederateException(e);
         }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
@@ -96,6 +96,7 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.federatestarter.ExecutableFederateExecutor;
 import org.eclipse.mosaic.rti.api.federatestarter.NopFederateExecutor;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
+import org.eclipse.mosaic.rti.api.parameters.FederatePriority;
 import org.eclipse.mosaic.rti.config.CLocalHost;
 
 import com.google.common.collect.Iterables;
@@ -395,7 +396,7 @@ public abstract class AbstractSumoAmbassador extends AbstractFederateAmbassador 
         }
 
         try {
-            rti.requestAdvanceTime(nextTimeStep, 0, (byte) 1);
+            rti.requestAdvanceTime(nextTimeStep, 0,  FederatePriority.higher(descriptor.getPriority()));
         } catch (IllegalValueException e) {
             log.error("Error during advanceTime request", e);
             throw new InternalFederateException(e);
@@ -1231,7 +1232,7 @@ public abstract class AbstractSumoAmbassador extends AbstractFederateAmbassador 
             rti.triggerInteraction(simulationStepResult.getTrafficDetectorUpdates());
             this.rti.triggerInteraction(simulationStepResult.getTrafficLightUpdates());
 
-            rti.requestAdvanceTime(nextTimeStep, 0, (byte) 2);
+            rti.requestAdvanceTime(nextTimeStep, 0,  FederatePriority.higher(descriptor.getPriority()));
 
             lastAdvanceTime = time;
         } catch (InternalFederateException | IOException | IllegalValueException e) {

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassadorTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassadorTest.java
@@ -59,6 +59,7 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
 import org.eclipse.mosaic.rti.api.parameters.FederateDescriptor;
+import org.eclipse.mosaic.rti.api.parameters.FederatePriority;
 import org.eclipse.mosaic.rti.config.CLocalHost;
 
 import com.google.common.collect.Lists;
@@ -105,6 +106,7 @@ public class SumoAmbassadorTest {
         testHostConfig.workingDirectory = workingDir.getAbsolutePath();
         when(handleMock.getHost()).thenReturn(testHostConfig);
         when(handleMock.getId()).thenReturn("sumo");
+        when(handleMock.getPriority()).thenReturn(FederatePriority.DEFAULT);
 
         traciClientBridgeMock = null;
         ambassador = new SumoAmbassador(new AmbassadorParameter("sumo", temporaryFolder.newFile("sumo/sumo_config.json"))) {
@@ -130,7 +132,8 @@ public class SumoAmbassadorTest {
         ambassador.initialize(0, 1000 * TIME.SECOND);
 
         // ASSERT
-        verify(rtiMock, times(1)).requestAdvanceTime(eq(0L), eq(0L), eq((byte) 1));
+        verify(rtiMock, times(1))
+                .requestAdvanceTime(eq(0L), eq(0L), eq((byte)(FederatePriority.DEFAULT -  1)));
         assertNull(traciClientBridgeMock);
     }
 

--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/parameters/FederateDescriptor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/parameters/FederateDescriptor.java
@@ -128,8 +128,7 @@ public class FederateDescriptor {
     }
 
     /**
-     * Returns the priority of this fedreate. The lower
-     * the value the higher the priority.
+     * Returns the priority of this federate. The lower the value the higher the priority.
      */
     public byte getPriority() {
         return priority;

--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/parameters/FederatePriority.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/parameters/FederatePriority.java
@@ -34,4 +34,35 @@ public final class FederatePriority {
      * The default priority assigned to all federates (= 50).
      */
     public static final byte DEFAULT = (HIGHEST + LOWEST) / 2;
+
+    public static boolean isInRange(int priority) {
+        return priority > LOWEST || priority < HIGHEST;
+    }
+
+    /**
+     * Returns a priority which is higher than the given one, if the given priority is not already HIGHEST.
+     */
+    public static byte higher(byte priority) {
+        return (byte) Math.max(HIGHEST, priority - 1);
+    }
+
+    /**
+     * Returns a priority which is lower than the given one, if the given priority is not already LOWEST.
+     */
+    public static byte lower(byte priority) {
+        return (byte) Math.min(LOWEST, priority + 1);
+    }
+
+    /**
+     * Compares two priority values with each other.
+     * If {@code a} has a higher priority than {@code b}, a value larger than 0 is returned.
+     * If {@code a} has a lower priority than {@code b}, a value smaller than 0 is returned.
+     * If {@code a} and  {@code b} have same priority, 0 is returned.
+     */
+    public static int compareTo(byte a, byte b) {
+        if (a == b) {
+            return 0;
+        }
+        return a < b ? 1 : -1;
+    }
 }

--- a/rti/mosaic-rti-api/src/test/java/org/eclipse/mosaic/rti/api/parameters/FederatePriorityTest.java
+++ b/rti/mosaic-rti-api/src/test/java/org/eclipse/mosaic/rti/api/parameters/FederatePriorityTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
 package org.eclipse.mosaic.rti.api.parameters;
 
 import static org.eclipse.mosaic.rti.api.parameters.FederatePriority.HIGHEST;

--- a/rti/mosaic-rti-api/src/test/java/org/eclipse/mosaic/rti/api/parameters/FederatePriorityTest.java
+++ b/rti/mosaic-rti-api/src/test/java/org/eclipse/mosaic/rti/api/parameters/FederatePriorityTest.java
@@ -1,0 +1,40 @@
+package org.eclipse.mosaic.rti.api.parameters;
+
+import static org.eclipse.mosaic.rti.api.parameters.FederatePriority.HIGHEST;
+import static org.eclipse.mosaic.rti.api.parameters.FederatePriority.LOWEST;
+import static org.eclipse.mosaic.rti.api.parameters.FederatePriority.compareTo;
+import static org.eclipse.mosaic.rti.api.parameters.FederatePriority.higher;
+import static org.eclipse.mosaic.rti.api.parameters.FederatePriority.lower;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class FederatePriorityTest {
+
+    @Test
+    public void testCompareTo() {
+        assertTrue(compareTo(HIGHEST, LOWEST) > 0);
+        assertTrue(compareTo(LOWEST, HIGHEST) < 0);
+        assertEquals(0, compareTo(LOWEST, LOWEST));
+    }
+
+    @Test
+    public void testHigher() {
+        byte priority = 23;
+        assertTrue(compareTo(higher(priority), priority) > 0);
+
+        // check if HIGHEST is not exceeded
+        assertEquals(0, compareTo(higher(HIGHEST), HIGHEST));
+    }
+
+    @Test
+    public void testLower() {
+        byte priority = 23;
+        assertTrue(compareTo(lower(priority), priority) < 0);
+
+        // check if LOWEST is not exceeded
+        assertEquals(0, compareTo(lower(LOWEST), LOWEST));
+    }
+
+}

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/MosaicRtiAmbassador.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/MosaicRtiAmbassador.java
@@ -22,6 +22,7 @@ import org.eclipse.mosaic.rti.api.Interaction;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.Monitor;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
+import org.eclipse.mosaic.rti.api.parameters.FederatePriority;
 
 import com.google.common.collect.ImmutableCollection;
 
@@ -44,7 +45,7 @@ public class MosaicRtiAmbassador implements RtiAmbassador {
 
     @Override
     public synchronized void requestAdvanceTime(long time) throws IllegalValueException {
-        requestAdvanceTime(time, 0, (byte) 0);
+        requestAdvanceTime(time, 0, FederatePriority.LOWEST);
     }
 
     @Override

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -344,8 +344,8 @@ public class MosaicSimulation {
 
         // create new descriptor and set common properties
         final int readPriority = federate.priority;
-        if (federate.priority > FederatePriority.LOWEST || federate.priority < FederatePriority.HIGHEST) {
-            throw new IllegalArgumentException("Provided priority " + federate.priority + "lies out of allowed range: "
+        if (FederatePriority.isInRange(readPriority)) {
+            throw new IllegalArgumentException("Provided priority " + readPriority + "lies out of allowed range: "
                     + FederatePriority.LOWEST + " - " + FederatePriority.HIGHEST + " (lowest priority - highest priority)");
         }
         final FederateDescriptor descriptor = new FederateDescriptor(federate.id, ambassador, (byte) readPriority);

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/config/CScenario.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/config/CScenario.java
@@ -55,8 +55,9 @@ public class CScenario {
         public long duration;
 
         /**
-         * The random seed to use for all random number generators. If not set (null),
-         * only
+         * The random seed to use for all random number generators. If not set,
+         * all random number generators are initialized with a different seed, thus every
+         * simulation run may return different results.
          */
         @Nullable
         public Long randomSeed;


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* Changes the handling of priorities when processing time advance requests. When ordering `FederateEvents`, the `priority` field was considered in descending order, meaning, that with two events with same time but different priority, the event with the _higher_ priority values was processed first. However, in the `runtime.json` the priority configuration was defined differently, with having lower values for higher priorities. 
* Therefore, this change inverts the ordering of `FederateEvents` with equal timestamps, by processing events with _lower_  priority values first:
  * Changed the ordering in `FederateEvent.compareTo` to process time advance requests with lower priority values first. The actual comparison was moved to `FederatePriority`.
  * When `receiveInteraction()` is called on an ambassador, the configured priority value is used as is (was converted previously, which not required anymore)
  * `SumoAmbassador` explicitly calls `requestAdvanceTime` with specific priority values for each future simulation step. These priority values were set to be higher than the default value, to "force" that the SUMO simulation step is executed before other ambassadors are called. This behavior was considered by using `FederatePriority.higher(descriptor.getPriority())`, which returns a lower priority value than configured which would lead to prioritization of the simulation step call.

## Issue(s) related to this PR

 * Internal issue 25
  
## Affected parts of the online documentation

* No

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer
