### PR TITLE
feat(output): Decimal Separator is now configurable

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
@@ -7,6 +7,7 @@
         <filename>output.csv</filename>
         <directory>.</directory>
         <separator>;</separator>
+        <decimalSeparator>.</decimalSeparator>
         <subscriptions>
             <subscription id="VehicleUpdates">
                 <entries>

--- a/bundle/src/assembly/resources/scenarios/HelloWorld/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/HelloWorld/output/output_config.xml
@@ -4,6 +4,7 @@
         <filename>output.csv</filename>
         <directory>.</directory>
         <separator>;</separator>
+        <decimalSeparator>.</decimalSeparator>
         <subscriptions>
             <subscription id="VehicleUpdates">
                 <entries>

--- a/bundle/src/assembly/resources/scenarios/Tiergarten/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/output/output_config.xml
@@ -7,6 +7,7 @@
         <filename>output.csv</filename>
         <directory>.</directory>
         <separator>;</separator>
+        <decimalSeparator>.</decimalSeparator>
         <subscriptions>
             <subscription id="VehicleUpdates">
                 <entries>

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/AbstractOutputGenerator.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/AbstractOutputGenerator.java
@@ -15,12 +15,11 @@
 
 package org.eclipse.mosaic.fed.output.ambassador;
 
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
-import org.apache.commons.lang3.StringUtils;
-
 import org.eclipse.mosaic.lib.util.InteractionUtils;
 import org.eclipse.mosaic.rti.api.Interaction;
 
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/ConfigHelper.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/ConfigHelper.java
@@ -15,11 +15,12 @@
 
 package org.eclipse.mosaic.fed.output.ambassador;
 
+import org.eclipse.mosaic.rti.TIME;
+
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
-import org.eclipse.mosaic.rti.TIME;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/RegistrationSubscriptionTypes.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/RegistrationSubscriptionTypes.java
@@ -15,13 +15,14 @@
 
 package org.eclipse.mosaic.fed.output.ambassador;
 
-import com.google.common.collect.Sets;
 import org.eclipse.mosaic.interactions.mapping.RsuRegistration;
 import org.eclipse.mosaic.interactions.mapping.ServerRegistration;
 import org.eclipse.mosaic.interactions.mapping.TmcRegistration;
 import org.eclipse.mosaic.interactions.mapping.TrafficLightRegistration;
 import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.interactions.trafficsigns.TrafficSignRegistration;
+
+import com.google.common.collect.Sets;
 
 import java.util.Collections;
 import java.util.Set;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutput.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutput.java
@@ -13,18 +13,18 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file;
+package org.eclipse.mosaic.fed.output.generator.file;
 
 import org.eclipse.mosaic.fed.output.ambassador.AbstractOutputGenerator;
 import org.eclipse.mosaic.fed.output.ambassador.Handle;
 import org.eclipse.mosaic.fed.output.generator.file.format.ExtendedMethodSet;
 import org.eclipse.mosaic.fed.output.generator.file.format.InteractionFormatter;
 import org.eclipse.mosaic.fed.output.generator.file.write.Write;
-
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mosaic.interactions.communication.V2xMessageRemoval;
 import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
 import org.eclipse.mosaic.rti.api.Interaction;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class FileOutput extends AbstractOutputGenerator {
     /**
      * Construct FileVisualizer with a writer and a message formatter.
      *
-     * @param writer       the writer visualizes the formatted message into file
+     * @param writer               the writer visualizes the formatted message into file
      * @param interactionFormatter the message formatter transfers the messages in a format defined in the configuration file
      */
     public FileOutput(Write writer, InteractionFormatter interactionFormatter) {

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
@@ -46,6 +46,7 @@ public class FileOutputLoader extends OutputGeneratorLoader {
     private static final String FILE_NAME = "filename";
     private static final String DIR = "directory";
     private static final String SEPARATOR = "separator";
+    private static final String DECIMAL_SEPARATOR = "decimalSeparator";
     private static final String WRITE = "write";
     private static final String APPEND = "append";
 
@@ -72,7 +73,16 @@ public class FileOutputLoader extends OutputGeneratorLoader {
     private InteractionFormatter createInteractionFormatter(HierarchicalConfiguration<ImmutableNode> sub)
             throws SecurityException, NoSuchMethodException, ClassNotFoundException, IllegalArgumentException {
 
-        String sep = sub.getString(SEPARATOR);
+        String separator = sub.getString(SEPARATOR);
+        String decimalSeparatorInput = sub.getString(DECIMAL_SEPARATOR);
+        Character decimalSeparator = null;
+        if (decimalSeparatorInput.length() == 1) {
+            decimalSeparator = decimalSeparatorInput.charAt(0);
+        } else {
+            log.warn("decimalSeparator is required to be one character, defaulting to locale separator");
+        }
+
+
         Map<String, List<List<String>>> interactionDefs = new HashMap<>();
 
         List<HierarchicalConfiguration<ImmutableNode>> interactionList = sub.configurationsAt("subscriptions.subscription");
@@ -89,7 +99,7 @@ public class FileOutputLoader extends OutputGeneratorLoader {
                     .add(entries);
         }
 
-        return new InteractionFormatter(sep, interactionDefs);
+        return new InteractionFormatter(separator, decimalSeparator, interactionDefs);
     }
 
     /**

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
@@ -40,8 +40,9 @@ import java.util.stream.Collectors;
 
 public class FileOutputLoader extends OutputGeneratorLoader {
 
-    private final static Logger log = LoggerFactory.getLogger(FileOutputLoader.class);
-
+    private static final Logger log = LoggerFactory.getLogger(FileOutputLoader.class);
+    private static final char DEFAULT_SEPARATOR = ';';
+    private static final char DEFAULT_DECIMAL_SEPARATOR = '.';
     /* Configuration properties */
     private static final String FILE_NAME = "filename";
     private static final String DIR = "directory";
@@ -72,14 +73,19 @@ public class FileOutputLoader extends OutputGeneratorLoader {
 
     private InteractionFormatter createInteractionFormatter(HierarchicalConfiguration<ImmutableNode> sub)
             throws SecurityException, NoSuchMethodException, ClassNotFoundException, IllegalArgumentException {
-
-        String separator = sub.getString(SEPARATOR);
-        String decimalSeparatorInput = sub.getString(DECIMAL_SEPARATOR);
-        Character decimalSeparator = null;
-        if (decimalSeparatorInput != null && decimalSeparatorInput.length() == 1) {
-            decimalSeparator = decimalSeparatorInput.charAt(0);
+        String separatorInput = sub.getString(SEPARATOR);
+        char separator = DEFAULT_SEPARATOR;
+        if (separatorInput == null || separatorInput.length() != 1) {
+            log.warn("separator is required to be one character, defaulting to '{}' as entry separator.", DEFAULT_SEPARATOR);
         } else {
-            log.warn("decimalSeparator is required to be one character, defaulting to locale separator");
+            separator = separatorInput.charAt(0);
+        }
+        String decimalSeparatorInput = sub.getString(DECIMAL_SEPARATOR);
+        char decimalSeparator = DEFAULT_DECIMAL_SEPARATOR;
+        if (decimalSeparatorInput == null || decimalSeparatorInput.length() != 1) {
+            log.warn("decimalSeparator is required to be one character, defaulting to '{}' as decimal separator.", DEFAULT_DECIMAL_SEPARATOR);
+        } else {
+            decimalSeparator = decimalSeparatorInput.charAt(0);
         }
 
         Map<String, List<List<String>>> interactionDefs = new HashMap<>();

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file;
+package org.eclipse.mosaic.fed.output.generator.file;
 
 import org.eclipse.mosaic.fed.output.ambassador.AbstractOutputGenerator;
 import org.eclipse.mosaic.fed.output.ambassador.ConfigHelper;
@@ -76,12 +76,11 @@ public class FileOutputLoader extends OutputGeneratorLoader {
         String separator = sub.getString(SEPARATOR);
         String decimalSeparatorInput = sub.getString(DECIMAL_SEPARATOR);
         Character decimalSeparator = null;
-        if (decimalSeparatorInput.length() == 1) {
+        if (decimalSeparatorInput != null && decimalSeparatorInput.length() == 1) {
             decimalSeparator = decimalSeparatorInput.charAt(0);
         } else {
             log.warn("decimalSeparator is required to be one character, defaulting to locale separator");
         }
-
 
         Map<String, List<List<String>>> interactionDefs = new HashMap<>();
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/EqualsFilter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/EqualsFilter.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.filter;
+package org.eclipse.mosaic.fed.output.generator.file.filter;
 
 import java.lang.reflect.Method;
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/Filter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/Filter.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.filter;
+package org.eclipse.mosaic.fed.output.generator.file.filter;
 
 import org.eclipse.mosaic.fed.output.generator.file.format.ExtendedMethodSet;
 
@@ -26,7 +26,7 @@ public abstract class Filter {
 
     private static final Logger log = LoggerFactory.getLogger(Filter.class);
 
-    private Method method;
+    private final Method method;
 
     protected Filter(Method method) {
         this.method = method;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/FilterFactory.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/FilterFactory.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.filter;
+package org.eclipse.mosaic.fed.output.generator.file.filter;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/MaxFilter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/MaxFilter.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.filter;
+package org.eclipse.mosaic.fed.output.generator.file.filter;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/MinFilter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/MinFilter.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.filter;
+package org.eclipse.mosaic.fed.output.generator.file.filter;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/RegexFilter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/filter/RegexFilter.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.filter;
+package org.eclipse.mosaic.fed.output.generator.file.filter;
 
 import java.lang.reflect.Method;
 import java.util.regex.Pattern;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.format;
+package org.eclipse.mosaic.fed.output.generator.file.format;
 
 import org.eclipse.mosaic.interactions.communication.V2xMessageReception;
 import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatter.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import javax.annotation.Nullable;
 
 public class InteractionFormatter {
 
@@ -43,7 +42,7 @@ public class InteractionFormatter {
      * @param decimalSeparator       separator for floating-point numbers
      * @param interactionDefinitions message definitions
      */
-    public InteractionFormatter(String separator, @Nullable Character decimalSeparator, Map<String,
+    public InteractionFormatter(char separator, char decimalSeparator, Map<String,
             List<List<String>>> interactionDefinitions)
             throws SecurityException, NoSuchMethodException, ClassNotFoundException, IllegalArgumentException {
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatter.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatter.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.format;
+package org.eclipse.mosaic.fed.output.generator.file.format;
 
 import org.eclipse.mosaic.lib.util.InteractionUtils;
 import org.eclipse.mosaic.rti.api.Interaction;
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nullable;
 
 public class InteractionFormatter {
 
@@ -38,20 +39,19 @@ public class InteractionFormatter {
      * message types and their definitions. The definition for all interaction types
      * are composed of a list of method definitions for each column in the interaction.
      *
-     * @param separator          string separator
+     * @param separator              string separator
+     * @param decimalSeparator       separator for floating-point numbers
      * @param interactionDefinitions message definitions
      */
-    public InteractionFormatter(String separator, Map<String, List<List<String>>> interactionDefinitions)
+    public InteractionFormatter(String separator, @Nullable Character decimalSeparator, Map<String,
+            List<List<String>>> interactionDefinitions)
             throws SecurityException, NoSuchMethodException, ClassNotFoundException, IllegalArgumentException {
 
         this.methodManagers = new HashMap<>();
 
-        Map<String, Class<?>> interactionClasses = InteractionUtils.getAllSupportedInteractions(
-                "com.dcaiti.mosaic"
-        );
+        Map<String, Class<?>> interactionClasses = InteractionUtils.getAllSupportedInteractions("com.dcaiti.mosaic");
 
         for (Entry<String, List<List<String>>> e : interactionDefinitions.entrySet()) {
-
             String interactionId = e.getKey();
 
             this.methodManagers.putIfAbsent(interactionId, new ArrayList<>());
@@ -61,7 +61,8 @@ public class InteractionFormatter {
 
                 for (List<String> interactionDef : interactionDefList) {
                     // create method manager for this definition
-                    MethodManager methodMgr = new MethodManager(separator, interactionDef, interactionClasses.get(interactionId));
+                    MethodManager methodMgr =
+                            new MethodManager(separator, decimalSeparator, interactionDef, interactionClasses.get(interactionId));
 
                     this.methodManagers.get(interactionId).add(methodMgr);
                 }

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodElement.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodElement.java
@@ -31,10 +31,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A MethodElement defines a specific method, including the name
+ * A {@link MethodElement} defines a specific method, including the name
  * of the method to be called and from which level of the iterate
- * structure(That means, within an iterate, there can be another
- * embedded iterate.)comes the object, to which the method belongs.
+ * structure (That means, within an iterate, there can be another
+ * embedded iterate.) comes the object, to which the method belongs.
  */
 class MethodElement {
 
@@ -75,7 +75,7 @@ class MethodElement {
     }
 
     /**
-     * create a static method list. Thus, we don't parse the method definition any more.
+     * create a static method list. Thus, we don't parse the method definition anymore.
      *
      * @param declare class
      * @param methods methods list

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodElement.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodElement.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.format;
+package org.eclipse.mosaic.fed.output.generator.file.format;
 
 import org.eclipse.mosaic.fed.output.generator.file.FileOutputLoader;
 import org.eclipse.mosaic.fed.output.generator.file.filter.Filter;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodManager.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodManager.java
@@ -13,14 +13,18 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.format;
+package org.eclipse.mosaic.fed.output.generator.file.format;
 
 import org.eclipse.mosaic.rti.api.Interaction;
 
 import java.lang.reflect.InvocationTargetException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
+import javax.annotation.Nullable;
 
 /**
  * A MethodManager saves the methods to be used for visualizing interactions
@@ -33,51 +37,61 @@ class MethodManager {
 
     private final String separator;
 
+    private final DecimalFormat decimalFormat;
     /**
-     * an iteration method returns a collection, which will be iterated when visualizing. *
+     * An iteration method returns a collection, which will be iterated when visualizing.
      */
     private final List<MethodElement> iterationMethods = new ArrayList<>();
 
     /**
-     * an output method returns a string, which will be written in file. *
+     * An output method returns a string, which will be written in file.
      */
     private final List<MethodElement> outputMethods = new ArrayList<>();
 
     /**
      * Constructs a MethodManager.
      *
-     * @param separator  separator
+     * @param separator          separator
+     * @param decimalSeparator   separator for floating-point numbers
      * @param methodsDefinitions method definitions
      * @param interactionClass   interaction class
      */
-    MethodManager(String separator, List<String> methodsDefinitions, Class<?> interactionClass)
+    MethodManager(String separator, @Nullable Character decimalSeparator, List<String> methodsDefinitions, Class<?> interactionClass)
             throws SecurityException, NoSuchMethodException, IllegalArgumentException {
         this.separator = separator;
+        String formatString = "#0.0##############"; // maximum of 15 decimal digits
+        if (decimalSeparator == null) {
+            this.decimalFormat = new DecimalFormat(formatString, new DecimalFormatSymbols(Locale.US)); // US is default Locale
+        } else {
+            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+            decimalFormatSymbols.setDecimalSeparator(decimalSeparator);
+            this.decimalFormat = new DecimalFormat(formatString, decimalFormatSymbols);
+        }
+        decimalFormat.setGroupingUsed(false); // disable grouping when using custom separator to prevent issues
 
         final List<String> methods = new ArrayList<>(methodsDefinitions);
 
         final List<Integer> objLevels = new ArrayList<>();
         final List<Class<?>> objClasses = new ArrayList<>();
 
-        // when initialize, set all methods to the root level of iteration
-        // and all the declare class to msgClass
+        // when initialized, set all methods to the root level of iteration and all the declare-classes to interactionClass
         for (int i = 0; i < methods.size(); i++) {
             objLevels.add(i, 0);
             objClasses.add(i, interactionClass);
         }
 
-        int itMetIdx;
+        int iterationMethodIndex;
 
         // initialize iteration methods
-        for (int level = 1; (itMetIdx = findIterationMethod(methods)) != -1; level++) {
+        for (int level = 1; (iterationMethodIndex = findIterationMethod(methods)) != -1; level++) {
             // what is the name of this iteration method, without "get"
-            String methodName = getIterationMethodName(methods.get(itMetIdx));
+            String methodName = getIterationMethodName(methods.get(iterationMethodIndex));
 
             // which class declares this iteration method
-            Class<?> declare = objClasses.get(itMetIdx);
+            Class<?> declare = objClasses.get(iterationMethodIndex);
 
             // what is the level of the object, that calls the iteration method
-            int objLevel = objLevels.get(itMetIdx);
+            int objLevel = objLevels.get(iterationMethodIndex);
 
             MethodElement me = new MethodElement(objLevel, declare, methodName);
 
@@ -93,7 +107,7 @@ class MethodManager {
             // set all the methods iterated by this iteration method in a level
             // deeper than the given level
             // and also its iterated object class
-            for (int i = itMetIdx; i < methods.size(); i++) {
+            for (int i = iterationMethodIndex; i < methods.size(); i++) {
                 String method = methods.get(i);
 
                 if (!method.startsWith(methodName)) {
@@ -117,8 +131,7 @@ class MethodManager {
             // which class declares this iteration method
             Class<?> declaredClass = objClasses.get(i);
 
-            this.outputMethods.add(
-                    new MethodElement(objLevel, declaredClass, methods.get(i))
+            this.outputMethods.add(new MethodElement(objLevel, declaredClass, methods.get(i))
             );
         }
     }
@@ -130,14 +143,22 @@ class MethodManager {
     }
 
     private String format(List<Object> itObjects, int level) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException {
-        StringBuilder res = new StringBuilder();
+        StringBuilder result = new StringBuilder();
 
         if (level == this.iterationMethods.size()) {
             // output method
             MethodElement outputMethod;
             for (int i = 0; i < this.outputMethods.size(); i++) {
                 outputMethod = this.outputMethods.get(i);
-                res.append(outputMethod.invoke(itObjects)).append((i == this.outputMethods.size() - 1 ? "\n" : this.separator));
+                Object methodInvocationResult = outputMethod.invoke(itObjects);
+                // if result of method invocation is float or double use defined decimal format
+                if (methodInvocationResult instanceof Double || methodInvocationResult instanceof Float) {
+                    String invocationResultString = decimalFormat.format(methodInvocationResult);
+                    result.append(invocationResultString);
+                } else {
+                    result.append(methodInvocationResult);
+                }
+                result.append(i == this.outputMethods.size() - 1 ? "\n" : this.separator); // add separator or linebreak
                 if (!outputMethod.isAcceptedByFilter(itObjects)) {
                     return "";
                 }
@@ -150,17 +171,17 @@ class MethodManager {
 
             if (c == null) {
                 itObjects.set(level + 1, null);
-                res.append(format(itObjects, level + 1));
+                result.append(format(itObjects, level + 1));
             } else {
                 for (Object element : c) {
                     itObjects.set(level + 1, element);
-                    res.append(format(itObjects, level + 1));
+                    result.append(format(itObjects, level + 1));
                 }
             }
             itObjects.remove(level);
         }
 
-        return res.toString();
+        return result.toString();
     }
 
     private String getIterationMethodName(String method) {

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodManager.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodManager.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import javax.annotation.Nullable;
 
 /**
  * A MethodManager saves the methods to be used for visualizing interactions
@@ -35,7 +34,7 @@ import javax.annotation.Nullable;
  */
 class MethodManager {
 
-    private final String separator;
+    private final char separator;
 
     private final DecimalFormat decimalFormat;
     /**
@@ -56,17 +55,14 @@ class MethodManager {
      * @param methodsDefinitions method definitions
      * @param interactionClass   interaction class
      */
-    MethodManager(String separator, @Nullable Character decimalSeparator, List<String> methodsDefinitions, Class<?> interactionClass)
+    MethodManager(char separator, char decimalSeparator, List<String> methodsDefinitions, Class<?> interactionClass)
             throws SecurityException, NoSuchMethodException, IllegalArgumentException {
         this.separator = separator;
         String formatString = "#0.0##############"; // maximum of 15 decimal digits
-        if (decimalSeparator == null) {
-            this.decimalFormat = new DecimalFormat(formatString, new DecimalFormatSymbols(Locale.US)); // US is default Locale
-        } else {
-            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
-            decimalFormatSymbols.setDecimalSeparator(decimalSeparator);
-            this.decimalFormat = new DecimalFormat(formatString, decimalFormatSymbols);
-        }
+        DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols(Locale.ENGLISH);
+        decimalFormatSymbols.setDecimalSeparator(decimalSeparator);
+        this.decimalFormat = new DecimalFormat(formatString, decimalFormatSymbols);
+
         decimalFormat.setGroupingUsed(false); // disable grouping when using custom separator to prevent issues
 
         final List<String> methods = new ArrayList<>(methodsDefinitions);

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodManager.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/MethodManager.java
@@ -34,8 +34,8 @@ import java.util.Locale;
  */
 class MethodManager {
 
+    public static final String LINE_SEPARATOR = "\n";
     private final char separator;
-
     private final DecimalFormat decimalFormat;
     /**
      * An iteration method returns a collection, which will be iterated when visualizing.
@@ -154,7 +154,7 @@ class MethodManager {
                 } else {
                     result.append(methodInvocationResult);
                 }
-                result.append(i == this.outputMethods.size() - 1 ? "\n" : this.separator); // add separator or linebreak
+                result.append(i == this.outputMethods.size() - 1 ? LINE_SEPARATOR : this.separator); // add separator or linebreak
                 if (!outputMethod.isAcceptedByFilter(itObjects)) {
                     return "";
                 }

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/Write.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/Write.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.write;
+package org.eclipse.mosaic.fed.output.generator.file.write;
 
 import java.io.IOException;
 

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/WriteByFile.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/WriteByFile.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.write;
+package org.eclipse.mosaic.fed.output.generator.file.write;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/WriteByFileCompress.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/WriteByFileCompress.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.write;
+package org.eclipse.mosaic.fed.output.generator.file.write;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/WriteByLog.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/write/WriteByLog.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.write;
+package org.eclipse.mosaic.fed.output.generator.file.write;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/websocket/WebsocketVisualizer.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/websocket/WebsocketVisualizer.java
@@ -13,11 +13,10 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.websocket;
+package org.eclipse.mosaic.fed.output.generator.websocket;
 
 import org.eclipse.mosaic.fed.output.ambassador.AbstractOutputGenerator;
 import org.eclipse.mosaic.fed.output.ambassador.Handle;
-
 import org.eclipse.mosaic.interactions.communication.V2xMessageReception;
 import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
 import org.eclipse.mosaic.interactions.electricity.ChargingStationUpdate;

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/websocket/WebsocketVisualizerLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/websocket/WebsocketVisualizerLoader.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.websocket;
+package org.eclipse.mosaic.fed.output.generator.websocket;
 
 import org.eclipse.mosaic.fed.output.ambassador.AbstractOutputGenerator;
 import org.eclipse.mosaic.fed.output.ambassador.OutputGeneratorLoader;

--- a/fed/mosaic-output/src/main/resources/output_config.xsd
+++ b/fed/mosaic-output/src/main/resources/output_config.xsd
@@ -18,6 +18,7 @@
                         <xs:element minOccurs="0" ref="filename" />
                         <xs:element ref="directory" />
                         <xs:element ref="separator" />
+                        <xs:element minOccurs="0" ref="decimalSeperator" />
                     </xs:sequence>
                     <xs:sequence>
                         <xs:element ref="synchronized" />
@@ -84,6 +85,13 @@
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 The delimiter [.] can be escaped by a backslash [\.].
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="decimalSeperator" type="xs:string">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The seperator for floating-point numbers.
             </xs:documentation>
         </xs:annotation>
     </xs:element>

--- a/fed/mosaic-output/src/test/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatterTest.java
+++ b/fed/mosaic-output/src/test/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatterTest.java
@@ -142,7 +142,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Position.Latitude");
         vehicleUpdatesMethods.add("Updated:Position.Longitude");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
         String interaction = interactionFormatter.format(vehicleUpdates);
         String[] expected = {"Test;0;1;10.0;11.0\n", "Test;0;2;20.0;22.0\n"};
 
@@ -159,7 +159,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Position.Latitude");
         vehicleUpdatesMethods.add("Updated:Position.Longitude");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", ',', vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', ',', vehicleUpdatesDef);
         String interaction = interactionFormatter.format(vehicleUpdates);
         String[] expected = {"Test;0;1;10,0;11,0\n", "Test;0;2;20,0;22,0\n"};
 
@@ -174,7 +174,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Time[min=1200000000,max=1400000000]");
         vehicleUpdatesMethods.add("Updated:Name");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
 
         assertEquals("", interactionFormatter.format(vehicleUpdates));
         assertEquals("Test;1300000000;3\nTest;1300000000;4\n", interactionFormatter.format(moveUpdates2));
@@ -190,7 +190,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Time[max=1400000000]");
         vehicleUpdatesMethods.add("Updated:Name[eq=1]");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
 
         assertEquals("Test;0;1\n", interactionFormatter.format(vehicleUpdates));
         assertEquals("", interactionFormatter.format(moveUpdates2));
@@ -206,7 +206,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Time");
         vehicleUpdatesMethods.add("Updated:Name[regex=[1-2]{1}]");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
 
         assertEquals("Test;0;1\nTest;0;2\n", interactionFormatter.format(vehicleUpdates));
         assertEquals("", interactionFormatter.format(moveUpdates2));
@@ -223,7 +223,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Name");
         vehicleUpdatesMethods.add("Added:Name");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
 
         String[] expected = {"Test;1;3\n", "Test;1;4\n", "Test;2;3\n", "Test;2;4\n"};
 
@@ -245,7 +245,7 @@ public class InteractionFormatterTest {
 
         interactionDef.put("MyInteraction", list);
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, interactionDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', interactionDef);
 
         String[] expected = {"1\n", "2\n", "3\n", "4\n"};
 
@@ -268,7 +268,7 @@ public class InteractionFormatterTest {
 
         recvInteractiongDef.put("V2xMessageReception", list);
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, recvInteractiongDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', recvInteractiongDef);
 
         String[] expected = {"RECV;5\n"};
 
@@ -284,32 +284,32 @@ public class InteractionFormatterTest {
         list.add(methods);
 
         interactionDef.put("VehicleUpdates", list);
-        new InteractionFormatter(";", null, interactionDef);
+        new InteractionFormatter(';', '.', interactionDef);
         interactionDef.clear();
 
         interactionDef.put("V2xMessageReception", list);
-        new InteractionFormatter(";", null, interactionDef);
+        new InteractionFormatter(';', '.', interactionDef);
         interactionDef.clear();
 
         interactionDef.put("V2xMessageTransmission", list);
-        new InteractionFormatter(";", null, interactionDef);
+        new InteractionFormatter(';', '.', interactionDef);
         interactionDef.clear();
 
         interactionDef.put("TrafficLightRegistration", list);
-        new InteractionFormatter(";", null, interactionDef);
+        new InteractionFormatter(';', '.', interactionDef);
         interactionDef.clear();
 
         interactionDef.put("RsuRegistration", list);
-        new InteractionFormatter(";", null, interactionDef);
+        new InteractionFormatter(';', '.', interactionDef);
         interactionDef.clear();
 
         interactionDef.put("VehicleRegistration", list);
-        new InteractionFormatter(";", null, interactionDef);
+        new InteractionFormatter(';', '.', interactionDef);
         interactionDef.clear();
 
         try {
             interactionDef.put("Interaction", list);
-            new InteractionFormatter(";", null, interactionDef);
+            new InteractionFormatter(';', '.', interactionDef);
             fail();
         } catch (ClassNotFoundException e) {
             assertEquals("Interaction is an unknown parameter in the visualizeMessage method set.", e.getMessage());
@@ -322,7 +322,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("");
         try {
-            new InteractionFormatter(";", null, vehicleUpdatesDef);
+            new InteractionFormatter(';', '.', vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method() is not supported "
@@ -333,7 +333,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Time.ID");
         try {
-            new InteractionFormatter(";", null, vehicleUpdatesDef);
+            new InteractionFormatter(';', '.', vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method(ID) is not supported "
@@ -344,7 +344,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Time.");
         try {
-            new InteractionFormatter(";", null, vehicleUpdatesDef);
+            new InteractionFormatter(';', '.', vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method() is not supported "
@@ -355,7 +355,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Updated:What");
         try {
-            new InteractionFormatter(";", null, vehicleUpdatesDef);
+            new InteractionFormatter(';', '.', vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method(What) is not supported"
@@ -366,7 +366,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Updated:Position:Latitude");
         try {
-            new InteractionFormatter(";", null, vehicleUpdatesDef);
+            new InteractionFormatter(';', '.', vehicleUpdatesDef);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("Method defined by (Position) does not return a Collection.", e.getMessage());
@@ -383,7 +383,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Position.Latitude");
         vehicleUpdatesMethods.add("Updated:Position.Longitude");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
 
         String[] expected = {"Test;1600000000;null;null;null\n",
                 "Test;1700000000;6;null;null\n",
@@ -401,7 +401,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Added:Position.Latitude");
         vehicleUpdatesMethods.add("Added:Position.Longitude");
 
-        interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
+        interactionFormatter = new InteractionFormatter(';', '.', vehicleUpdatesDef);
 
         assertEquals(expected[1] + expected[3], interactionFormatter.format(vehicleUpdatesNull2));
 

--- a/fed/mosaic-output/src/test/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatterTest.java
+++ b/fed/mosaic-output/src/test/java/org/eclipse/mosaic/fed/output/generator/file/format/InteractionFormatterTest.java
@@ -13,7 +13,7 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org. eclipse.mosaic.fed.output.generator.file.format;
+package org.eclipse.mosaic.fed.output.generator.file.format;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -65,7 +65,6 @@ public class InteractionFormatterTest {
 
     @Before
     public void setUp() {
-        // ======================================================
         v1 = new VehicleData.Builder(111, "1").position(GeoPoint.lonLat(11, 10), null).create();
         v2 = new VehicleData.Builder(222, "2").position(GeoPoint.lonLat(22, 20), null).create();
         v3 = new VehicleData.Builder(333, "3").position(GeoPoint.lonLat(33, 30), null).create();
@@ -115,7 +114,6 @@ public class InteractionFormatterTest {
         // ======================================================
 
         List<VehicleUpdates> interactions = new ArrayList<>();
-
         interactions.add(vehicleUpdates);
         interactions.add(moveUpdates2);
 
@@ -132,8 +130,6 @@ public class InteractionFormatterTest {
         list.add(vehicleUpdatesMethods);
 
         vehicleUpdatesDef.put("VehicleUpdates", list);
-
-
     }
 
     @Test
@@ -146,9 +142,26 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Position.Latitude");
         vehicleUpdatesMethods.add("Updated:Position.Longitude");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
         String interaction = interactionFormatter.format(vehicleUpdates);
         String[] expected = {"Test;0;1;10.0;11.0\n", "Test;0;2;20.0;22.0\n"};
+
+        assertEquals(expected[0] + expected[1], interaction);
+    }
+
+    @Test
+    public void testNormalIterationDifferentDecimalSeperator() throws Exception {
+
+        vehicleUpdatesMethods.clear();
+        vehicleUpdatesMethods.add("\"Test\"");
+        vehicleUpdatesMethods.add("Time");
+        vehicleUpdatesMethods.add("Updated:Name");
+        vehicleUpdatesMethods.add("Updated:Position.Latitude");
+        vehicleUpdatesMethods.add("Updated:Position.Longitude");
+
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", ',', vehicleUpdatesDef);
+        String interaction = interactionFormatter.format(vehicleUpdates);
+        String[] expected = {"Test;0;1;10,0;11,0\n", "Test;0;2;20,0;22,0\n"};
 
         assertEquals(expected[0] + expected[1], interaction);
     }
@@ -161,7 +174,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Time[min=1200000000,max=1400000000]");
         vehicleUpdatesMethods.add("Updated:Name");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
 
         assertEquals("", interactionFormatter.format(vehicleUpdates));
         assertEquals("Test;1300000000;3\nTest;1300000000;4\n", interactionFormatter.format(moveUpdates2));
@@ -177,7 +190,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Time[max=1400000000]");
         vehicleUpdatesMethods.add("Updated:Name[eq=1]");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
 
         assertEquals("Test;0;1\n", interactionFormatter.format(vehicleUpdates));
         assertEquals("", interactionFormatter.format(moveUpdates2));
@@ -193,7 +206,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Time");
         vehicleUpdatesMethods.add("Updated:Name[regex=[1-2]{1}]");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
 
         assertEquals("Test;0;1\nTest;0;2\n", interactionFormatter.format(vehicleUpdates));
         assertEquals("", interactionFormatter.format(moveUpdates2));
@@ -210,7 +223,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Name");
         vehicleUpdatesMethods.add("Added:Name");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
 
         String[] expected = {"Test;1;3\n", "Test;1;4\n", "Test;2;3\n", "Test;2;4\n"};
 
@@ -232,7 +245,7 @@ public class InteractionFormatterTest {
 
         interactionDef.put("MyInteraction", list);
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", interactionDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, interactionDef);
 
         String[] expected = {"1\n", "2\n", "3\n", "4\n"};
 
@@ -255,7 +268,7 @@ public class InteractionFormatterTest {
 
         recvInteractiongDef.put("V2xMessageReception", list);
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", recvInteractiongDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, recvInteractiongDef);
 
         String[] expected = {"RECV;5\n"};
 
@@ -271,32 +284,32 @@ public class InteractionFormatterTest {
         list.add(methods);
 
         interactionDef.put("VehicleUpdates", list);
-        new InteractionFormatter(";", interactionDef);
+        new InteractionFormatter(";", null, interactionDef);
         interactionDef.clear();
 
         interactionDef.put("V2xMessageReception", list);
-        new InteractionFormatter(";", interactionDef);
+        new InteractionFormatter(";", null, interactionDef);
         interactionDef.clear();
 
         interactionDef.put("V2xMessageTransmission", list);
-        new InteractionFormatter(";", interactionDef);
+        new InteractionFormatter(";", null, interactionDef);
         interactionDef.clear();
 
         interactionDef.put("TrafficLightRegistration", list);
-        new InteractionFormatter(";", interactionDef);
+        new InteractionFormatter(";", null, interactionDef);
         interactionDef.clear();
 
         interactionDef.put("RsuRegistration", list);
-        new InteractionFormatter(";", interactionDef);
+        new InteractionFormatter(";", null, interactionDef);
         interactionDef.clear();
 
         interactionDef.put("VehicleRegistration", list);
-        new InteractionFormatter(";", interactionDef);
+        new InteractionFormatter(";", null, interactionDef);
         interactionDef.clear();
 
         try {
             interactionDef.put("Interaction", list);
-            new InteractionFormatter(";", interactionDef);
+            new InteractionFormatter(";", null, interactionDef);
             fail();
         } catch (ClassNotFoundException e) {
             assertEquals("Interaction is an unknown parameter in the visualizeMessage method set.", e.getMessage());
@@ -309,7 +322,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("");
         try {
-            new InteractionFormatter(";", vehicleUpdatesDef);
+            new InteractionFormatter(";", null, vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method() is not supported "
@@ -320,7 +333,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Time.ID");
         try {
-            new InteractionFormatter(";", vehicleUpdatesDef);
+            new InteractionFormatter(";", null, vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method(ID) is not supported "
@@ -331,7 +344,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Time.");
         try {
-            new InteractionFormatter(";", vehicleUpdatesDef);
+            new InteractionFormatter(";", null, vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method() is not supported "
@@ -342,7 +355,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Updated:What");
         try {
-            new InteractionFormatter(";", vehicleUpdatesDef);
+            new InteractionFormatter(";", null, vehicleUpdatesDef);
             fail();
         } catch (NoSuchMethodException e) {
             assertEquals("Method(What) is not supported"
@@ -353,7 +366,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.clear();
         vehicleUpdatesMethods.add("Updated:Position:Latitude");
         try {
-            new InteractionFormatter(";", vehicleUpdatesDef);
+            new InteractionFormatter(";", null, vehicleUpdatesDef);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("Method defined by (Position) does not return a Collection.", e.getMessage());
@@ -370,7 +383,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Updated:Position.Latitude");
         vehicleUpdatesMethods.add("Updated:Position.Longitude");
 
-        InteractionFormatter interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        InteractionFormatter interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
 
         String[] expected = {"Test;1600000000;null;null;null\n",
                 "Test;1700000000;6;null;null\n",
@@ -388,7 +401,7 @@ public class InteractionFormatterTest {
         vehicleUpdatesMethods.add("Added:Position.Latitude");
         vehicleUpdatesMethods.add("Added:Position.Longitude");
 
-        interactionFormatter = new InteractionFormatter(";", vehicleUpdatesDef);
+        interactionFormatter = new InteractionFormatter(";", null, vehicleUpdatesDef);
 
         assertEquals(expected[1] + expected[3], interactionFormatter.format(vehicleUpdatesNull2));
 

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/InteractionUtils.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/InteractionUtils.java
@@ -48,7 +48,6 @@ public class InteractionUtils {
     @SuppressWarnings({"unchecked", "UnstableApiUsage"})
     public static Map<String, Class<?>> getAllSupportedInteractions(String... allowedPackages) {
         if (supportedInteractions.isEmpty()) {
-
             try {
                 ImmutableSet<ClassInfo> topLevelClassesRecursive = from(InteractionUtils.class.getClassLoader()).getAllClasses();
                 for (ClassInfo info : topLevelClassesRecursive) {


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

* with this PR the decimal separator for output CSV's can now be configured in the `output_config.xml`'s
* this was realized using `DecimalFormat` which also makes output more consistent over different systems
* some cleanup

## Issue(s) related to this PR

 * solves internal issue 454
 
## Affected parts of the online documentation

This enhancement needs to be documented on the website https://www.eclipse.org/mosaic/docs/visualization/filevis/

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

