### PR TITLE
fix(geomath): thread-safe initialization of geoCalculator

### DIFF
--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/transform/GeoProjection.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/transform/GeoProjection.java
@@ -48,7 +48,7 @@ public abstract class GeoProjection {
         GeoProjection.instance = geoProjection;
     }
 
-    private GeoCalculator geoCalculator = null;
+    private volatile GeoCalculator geoCalculator = null;
 
     public GeoProjection setGeoCalculator(GeoCalculator geoCalculator) {
         if (this.geoCalculator != null) {
@@ -60,7 +60,11 @@ public abstract class GeoProjection {
 
     public final GeoCalculator getGeoCalculator() {
         if (geoCalculator == null) {
-            setGeoCalculator(new SimpleGeoCalculator());
+            synchronized (this) {
+                if (geoCalculator == null) {
+                    setGeoCalculator(new SimpleGeoCalculator());
+                }
+            }
         }
         return geoCalculator;
     }


### PR DESCRIPTION
## Type of this PR 

- [x] Bug fix
- [ ] Enhancement

## Description

Previously, `GeoProjection.getGeoCalculator()` could throw an `IllegalStateException` when executed in a multi-threaded environment and geo-calculator has not been initialized before. This PR fixes that by making the check if geo-calculator is initialized thread safe.

## Issue(s) related to this PR

none
 
 
## Affected parts of the online documentation

none

## Definition of Done

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All commits are signed-off (`-s`) with your mail address of your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been observed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

none
