### PR TITLE
feat: added support for compilation with JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ Additional simulators and assessment features are provided by [Fraunhofer FOKUS]
 
 ## Related repositories
 
-* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.14.0`.
+* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.14.1`.
 * The coupling to [ns-3](https://www.nsnam.org) is realized by a federate implementation which can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/ns3-federate). 
-  We currently support ns-3 version `3.34`. 
+  We currently support ns-3 version `3.36.1`. 
 * The coupling to [OMNeT++](https://omnetpp.org) is implemented in a very similar manner. The corresponding federate implementation can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/omnetpp-federate). 
   We currently support OMNeT++ version `5.5` in combination with the INET framework in version `4.1`.  
+* We created the [Berlin SUMO Traffic (BeST) scenario](https://github.com/mosaic-addons/best-scenario) which provides 2.2 million vehicle trips in 24h for Berlin, Germany. The scenario is fully compatible with the latest release of MOSAIC.
 
 ## Contact
 
@@ -59,8 +60,8 @@ For further questions we are available via mosaic@fokus.fraunhofer.de
 For a successful build you need the following software to be installed:
 
 * **Maven 3.1.x** or higher.
-* **Java 8 or 11** - We recommend using the [Adoptium OpenJDK (aka Eclipse Temurin)](https://adoptium.net/?variant=openjdk8).
-* **SUMO 1.14.0** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
+* **Java 8, 11, or 17** - We recommend using the [Adoptium OpenJDK (aka Eclipse Temurin)](https://adoptium.net/?variant=openjdk8).
+* **SUMO 1.14.1** - Additionally, the environment variable `SUMO_HOME` should be configured properly.
 
 ## Build
 

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
@@ -46,16 +46,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(MockitoJUnitRunner.class)
 public class PerceptionModifierTest {
     // FLag used for visualization purposes
     private final static boolean PRINT_POSITIONS =
@@ -68,15 +66,15 @@ public class PerceptionModifierTest {
     private final RandomNumberGenerator rng = new DefaultRandomNumberGenerator(1);
     private final EventManager eventManagerMock = mock(EventManager.class);
     private final CentralPerceptionComponent cpcMock = mock(CentralPerceptionComponent.class);
+    private final CentralNavigationComponent cncMock = mock(CentralNavigationComponent.class);
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
 
     @Mock
     public VehicleData egoVehicleData;
 
-    @Mock
-    private CentralNavigationComponent cncMock;
-
     @Rule
-    @InjectMocks
     public SimulationKernelRule simulationKernelRule = new SimulationKernelRule(eventManagerMock, null, cncMock, cpcMock);
 
     @Rule

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -41,9 +41,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -54,15 +55,15 @@ public class SimplePerceptionModuleTest {
 
     private final EventManager eventManagerMock = mock(EventManager.class);
     private final CentralPerceptionComponent cpcMock = mock(CentralPerceptionComponent.class);
+    private final CentralNavigationComponent cncMock = mock(CentralNavigationComponent.class);
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
 
     @Mock
     public VehicleData egoVehicleData;
 
-    @Mock
-    private CentralNavigationComponent cncMock;
-
     @Rule
-    @InjectMocks
     public SimulationKernelRule simulationKernelRule = new SimulationKernelRule(eventManagerMock, null, cncMock, cpcMock);
 
     @Rule

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
@@ -131,7 +131,7 @@ public class SumoTraciRule implements TestRule {
                 "--step-length", String.format(Locale.ENGLISH, "%.2f", (double) sumoConfig.updateInterval / 1000d));
         startArgs.addAll(Arrays.asList(StringUtils.split(sumoConfig.additionalSumoParameters.trim(), " ")));
 
-        sumoProcess = new ExecutableFederateExecutor(null,getSumoExecutable(sumoCmd), startArgs)
+        sumoProcess = new ExecutableFederateExecutor(null, getSumoExecutable(sumoCmd), startArgs)
                 .startLocalFederate(scenarioConfig.getParentFile());
 
         if (!GUI_DEBUG) {
@@ -205,7 +205,7 @@ public class SumoTraciRule implements TestRule {
                 outputLoggingThread = null;
             }
         } catch (Exception e) {
-            log.error("Could not close Logging Thread", e);
+            log.error("Could not close Output Logging Thread", e);
         }
 
         try {
@@ -215,7 +215,7 @@ public class SumoTraciRule implements TestRule {
                 errorLoggingThread = null;
             }
         } catch (Exception e) {
-            log.error("Could not close Logging Thread", e);
+            log.error("Could not close Error Logging Thread", e);
         }
 
         try {

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -80,8 +81,9 @@ public class SumoTraciRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                before();
                 try {
+                    before();
+
                     SinceTraci sinceTraci = description.getAnnotation(SinceTraci.class);
                     if (sinceTraci != null) {
                         SumoVersion currentVersion = SumoTraciRule.this.traci.getCurrentVersion();
@@ -129,10 +131,8 @@ public class SumoTraciRule implements TestRule {
                 "--step-length", String.format(Locale.ENGLISH, "%.2f", (double) sumoConfig.updateInterval / 1000d));
         startArgs.addAll(Arrays.asList(StringUtils.split(sumoConfig.additionalSumoParameters.trim(), " ")));
 
-        sumoProcess = new ExecutableFederateExecutor(
-                null,
-                getSumoExecutable(sumoCmd), startArgs).startLocalFederate(scenarioConfig.getParentFile()
-        );
+        sumoProcess = new ExecutableFederateExecutor(null,getSumoExecutable(sumoCmd), startArgs)
+                .startLocalFederate(scenarioConfig.getParentFile());
 
         if (!GUI_DEBUG) {
             // make sure to read until server is started, otherwise test will fail!
@@ -151,6 +151,8 @@ public class SumoTraciRule implements TestRule {
         assertNotEquals(0, port);
 
         redirectOutputToLog(); // this is necessary, otherwise TraCI will hang due to full output buffer
+
+        Thread.sleep(500); // wait a bit until TraCI server of SUMO is ready
 
         log.info("Connect to SUMO on port {}", port);
         final Socket socket = new Socket("localhost", port);
@@ -188,43 +190,44 @@ public class SumoTraciRule implements TestRule {
     private void after() {
         Bridge.VEHICLE_ID_TRANSFORMER.reset();
         try {
-            log.info("Close Traci Connection");
-            traci.close();
+            if (traci != null) {
+                log.info("Close Traci Connection");
+                traci.close();
+            }
         } catch (Exception e) {
             log.error("Could not close TraCI connection properly", e);
         }
 
         try {
-            log.info("Close SUMO process");
-            sumoProcess.waitFor();
-            sumoProcess.destroyForcibly().waitFor();
-            sumoProcess = null;
-        } catch (Exception e) {
-            log.error("Could not SUMO process", e);
-        }
-
-        try {
-            log.info("Close Output Logging Thread");
-            outputLoggingThread.close();
-            outputLoggingThread = null;
+            if (outputLoggingThread != null) {
+                log.info("Close Output Logging Thread");
+                outputLoggingThread.close();
+                outputLoggingThread = null;
+            }
         } catch (Exception e) {
             log.error("Could not close Logging Thread", e);
         }
 
         try {
-            log.info("Close Error Logging Thread");
-            errorLoggingThread.close();
-            errorLoggingThread = null;
+            if (errorLoggingThread != null) {
+                log.info("Close Error Logging Thread");
+                errorLoggingThread.close();
+                errorLoggingThread = null;
+            }
         } catch (Exception e) {
             log.error("Could not close Logging Thread", e);
         }
 
         try {
-            Thread.sleep(500);
+            if (sumoProcess != null) {
+                log.info("Close SUMO process");
+                sumoProcess.waitFor(5, TimeUnit.SECONDS);
+                sumoProcess.destroyForcibly().waitFor();
+                sumoProcess = null;
+            }
         } catch (Exception e) {
-            //
+            log.error("Could not stop SUMO process", e);
         }
-
     }
 
     public Bridge getTraciConnection() {

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <version.junit>4.13</version.junit><!-- 4.13 is approved in CQ21439 -->
         <version.justify>1.1.0</version.justify><!-- 1.1.0 is approved in CQ22341 -->
         <version.logback>1.2.3</version.logback><!-- 1.2.3 is approved in CQ16622 -->
-        <version.mockito>2.23.0</version.mockito><!-- 2.23.0 is approved in CQ17976 -->
+        <version.mockito>3.12.4</version.mockito><!-- approval not required, we do not ship this library -->
         <version.protobuf>3.8.0</version.protobuf><!-- 3.8.0 is approved in CQ20405 -->
         <version.slf4j>1.7.30</version.slf4j><!-- 1.7.30 is approved in CQ21339 -->
         <version.sqlite-jdbc>3.20.0</version.sqlite-jdbc><!-- 3.20.0 is approved in CQ14652 -->


### PR DESCRIPTION
## Type of this PR 

<!--- ( choose one ) -->

- [ ] Bug fix
- [x] Enhancement

## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

This PR allows Eclipse MOSAIC to be build using JDK 17. The following changes needed to be applied:

* Upgraded `mockito-core` to `3.12.4`. We do not need to check with Eclipse IP here since we do not ship mockito with our bundle.
* With the mockito upgrade, mocks annotated with `@Mock` are initialized later and could not be used in `@Rule` annotated object initializations. The required mocks are now initialized using `mock(MyClass.class)` instead.
* Fixed a bug in `SumoTraciRule` which would keep sumo processes alive if an initial connection has failed. 

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

Internal issue 468
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Yes, table with supported versions will be adjusted with next release.

## Definition of Done

<!--- ( to be checked by the author ) -->

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

