### PR TITLE
Release 22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Changelog Eclipse MOSAIC 22.1 (October 2022)
+
+* [A+] Perception module is now working with viewing angles larger than 180 degrees.
+* [A+] Introducing perception modifiers, such as occlusion or simple error models.
+* [A+] Improved API of vehicle operating system; action methods (e.g., change speed) now accept nanoseconds instead of milliseconds.
+* [M+] Improved handling of priorities when processing time advance requests.
+* [M+] Allow parallel execution of federates based on same Docker image (e.g., when running simulations in parallel).
+* [M+] Added configuration option to configure decimal separator in file output generator.
+* [C+] Upgraded ns-3 federate to support ns3-36.1.
+* [C+] Improved default logging of OMNeT++ and ns-3 simulations to be less verbose.
+* [C-] Fixed a bug in OMneT++ federate using the wrong `omnetpp.ini`.
+* [S+] Added import of building information from OSM, e.g., for wall occlusion in perception module.
+* [T+] Improved coupling of traffic simulator SUMO with vehicle simulators (e.g., PHABMACS or Carla).
+* [T+] Now supports SUMO 1.14.1
+* [T+] Released Berlin SUMO Traffic (BeST) scenario at https://github.com/mosaic-addons/best-scenario
+
 # Changelog Eclipse MOSAIC 22.0 (May 2022)
 
 * [A+] A perception module has been added. Vehicles can now perceive other vehicles in their field of view.

--- a/app/tutorials/example-applications/pom.xml
+++ b/app/tutorials/example-applications/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/app/tutorials/highway-management/pom.xml
+++ b/app/tutorials/highway-management/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/app/tutorials/traffic-light-communication/pom.xml
+++ b/app/tutorials/traffic-light-communication/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/app/tutorials/weather-warning/pom.xml
+++ b/app/tutorials/weather-warning/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
+++ b/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
@@ -69,7 +69,7 @@ ns3_scratch="${ns3_simulator_folder}/scratch"
 ns3_source="${ns3_simulator_folder}/src"
 
 ####### semi automatic parameters ########
-ns3_federate_url="https://github.com/mosaic-addons/ns3-federate/archive/refs/heads/main.zip"
+ns3_federate_url="https://github.com/mosaic-addons/ns3-federate/archive/refs/tags/22.1.zip"
 ns3_url="https://www.nsnam.org/releases/$ns3_version_affix.tar.bz2"
 
 ###### more automatic parameters #########

--- a/bundle/src/assembly/resources/fed/omnetpp/omnet_installer.sh
+++ b/bundle/src/assembly/resources/fed/omnetpp/omnet_installer.sh
@@ -46,7 +46,7 @@ check_shell
 required_programs=( unzip tar bison flex protoc gcc python )
 required_libraries=( "libprotobuf-dev >= 3.7.0" "libxml2-dev" )
 
-omnet_federate_url="https://github.com/mosaic-addons/omnetpp-federate/archive/refs/tags/22.0.zip"
+omnet_federate_url="https://github.com/mosaic-addons/omnetpp-federate/archive/refs/tags/22.1.zip"
 omnet_src_url="https://github.com/omnetpp/omnetpp/releases/download/omnetpp-5.5.1/omnetpp-5.5.1-src-linux.tgz"
 inet_src_url="https://github.com/inet-framework/inet/releases/download/v4.1.1/inet-4.1.1-src.tgz"
 

--- a/fed/mosaic-application/pom.xml
+++ b/fed/mosaic-application/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-cell/pom.xml
+++ b/fed/mosaic-cell/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-environment/pom.xml
+++ b/fed/mosaic-environment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-mapping/pom.xml
+++ b/fed/mosaic-mapping/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-ns3/pom.xml
+++ b/fed/mosaic-ns3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-omnetpp/pom.xml
+++ b/fed/mosaic-omnetpp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-output/pom.xml
+++ b/fed/mosaic-output/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-sns/pom.xml
+++ b/fed/mosaic-sns/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-sumo/pom.xml
+++ b/fed/mosaic-sumo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-communication/pom.xml
+++ b/lib/mosaic-communication/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-database/pom.xml
+++ b/lib/mosaic-database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-docker/pom.xml
+++ b/lib/mosaic-docker/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-geomath/pom.xml
+++ b/lib/mosaic-geomath/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-interactions/pom.xml
+++ b/lib/mosaic-interactions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-network/pom.xml
+++ b/lib/mosaic-network/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-objects/pom.xml
+++ b/lib/mosaic-objects/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-routing/pom.xml
+++ b/lib/mosaic-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-utils/pom.xml
+++ b/lib/mosaic-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.eclipse.mosaic</groupId>
     <artifactId>mosaic-parent</artifactId>
-    <version>22.1-SNAPSHOT</version>
+    <version>22.1</version>
     <packaging>pom</packaging>
 
     <name>Eclipse MOSAIC Parent</name>
@@ -79,7 +79,7 @@
     </modules>
 
     <properties>
-        <mosaic.version>22.1-SNAPSHOT</mosaic.version>
+        <mosaic.version>22.1</mosaic.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceTarget>1.8</project.build.sourceTarget>
         <skip.coverage>true</skip.coverage>

--- a/rti/mosaic-rti-api/pom.xml
+++ b/rti/mosaic-rti-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/rti/mosaic-rti-core/pom.xml
+++ b/rti/mosaic-rti-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/rti/mosaic-starter/pom.xml
+++ b/rti/mosaic-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test/mosaic-integration-tests/pom.xml
+++ b/test/mosaic-integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>22.1-SNAPSHOT</version>
+        <version>22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Sets the version to 22.1 as preparation for the next release of Eclipse MOSAIC.

* [A+] Perception module is now working with viewing angles larger than 180 degrees.
* [A+] Introducing perception modifiers, such as occlusion or simple error models.
* [A+] Improved API of vehicle operating system; action methods (e.g., change speed) now accept nanoseconds instead of milliseconds.
* [M+] Improved handling of priorities when processing time advance requests.
* [M+] Allow parallel execution of federates based on same Docker image (e.g., when running simulations in parallel).
* [M+] Added configuration option to configure decimal separator in file output generator.
* [C+] Upgraded ns-3 federate to support ns3-36.1.
* [C+] Improved default logging of OMNeT++ and ns-3 simulations to be less verbose.
* [C-] Fixed a bug in OMneT++ federate using the wrong `omnetpp.ini`.
* [S+] Added import of building information from OSM, e.g., for wall occlusion in perception module.
* [T+] Improved coupling of traffic simulator SUMO with vehicle simulators (e.g., PHABMACS or Carla).
* [T+] Now supports SUMO 1.14.1
* [T+] Released Berlin SUMO Traffic (BeST) scenario at https://github.com/mosaic-addons/best-scenario