### PR TITLE
feat(sumo): upgrade to SUMO 1.15.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.14.0
+    image: eclipsemosaic/mosaic-ci:jdk8-sumo-1.15.0
     command:
     - cat
     tty: true

--- a/bundle/src/assembly/resources/scenarios/Highway/sumo/highway.add.xml
+++ b/bundle/src/assembly/resources/scenarios/Highway/sumo/highway.add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<additionals xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
+<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
     <e1Detector id="detector_0" lane="319292433_3257049721_1288275815_0" pos="700" freq="100.00" file="detectors.txt" friendlyPos="0"/>
     <e1Detector id="detector_1" lane="319292433_3257049721_1288275815_1" pos="700" freq="100.00" file="detectors.txt" friendlyPos="0"/>
     <e1Detector id="detector_2" lane="319292433_3257049721_1288275815_2" pos="700" freq="100.00" file="detectors.txt" friendlyPos="0"/>
-</additionals>
+</additional>

--- a/bundle/src/assembly/resources/scenarios/Highway/sumo/highway.add.xml
+++ b/bundle/src/assembly/resources/scenarios/Highway/sumo/highway.add.xml
@@ -1,4 +1,5 @@
-<additionals>
+<?xml version="1.0" encoding="UTF-8"?>
+<additionals xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
     <e1Detector id="detector_0" lane="319292433_3257049721_1288275815_0" pos="700" freq="100.00" file="detectors.txt" friendlyPos="0"/>
     <e1Detector id="detector_1" lane="319292433_3257049721_1288275815_1" pos="700" freq="100.00" file="detectors.txt" friendlyPos="0"/>
     <e1Detector id="detector_2" lane="319292433_3257049721_1288275815_2" pos="700" freq="100.00" file="detectors.txt" friendlyPos="0"/>

--- a/bundle/src/assembly/resources/scenarios/Sievekingplatz/sumo/sievekingplatz.bus.add.xml
+++ b/bundle/src/assembly/resources/scenarios/Sievekingplatz/sumo/sievekingplatz.bus.add.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
     <busStop id="busstop" lane="139083727#2_0" startPos="5" endPos="30"/>
 </additional>

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
@@ -1425,7 +1425,7 @@ public abstract class AbstractSumoAmbassador extends AbstractFederateAmbassador 
 
         // if SUMO_HOME is not set, the XML input validation in SUMO might fail as no XSDs are available.
         // Therefore, we disable XML validation if SUMO_HOME is not set.
-        if (!sumoConfig.validateSumoFiles || StringUtils.isBlank(System.getenv("SUMO_HOME"))) {
+        if (StringUtils.isBlank(System.getenv("SUMO_HOME"))) {
             args.add("--xml-validation");
             args.add("never");
         }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
@@ -39,6 +39,7 @@ public enum SumoVersion {
     SUMO_1_12_x("1.12.*", TraciVersion.API_20),
     SUMO_1_13_x("1.13.*", TraciVersion.API_20),
     SUMO_1_14_x("1.14.*", TraciVersion.API_20),
+    SUMO_1_15_x("1.15.*", TraciVersion.API_20),
 
     /**
      * the lowest version supported by this client.
@@ -48,7 +49,7 @@ public enum SumoVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(SUMO_1_14_x.sumoVersion, SUMO_1_14_x.traciVersion);
+    HIGHEST(SUMO_1_15_x.sumoVersion, SUMO_1_15_x.traciVersion);
 
     private final String sumoVersion;
     private final TraciVersion traciVersion;

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/config/CSumo.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/config/CSumo.java
@@ -68,12 +68,6 @@ public class CSumo implements Serializable {
     public String additionalSumoParameters = "--time-to-teleport 0 --seed 100000";
 
     /**
-     * Per default, SUMO will validate all input files for correctness. To disable
-     * this behavior, this field can be set to {@code false}.
-     */
-    public boolean validateSumoFiles = true;
-
-    /**
      * Defines the time window in seconds in which vehicle counts on induction loops
      * should be aggregated to traffic flow (veh/h).
      */

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/config/CSumo.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/config/CSumo.java
@@ -65,7 +65,13 @@ public class CSumo implements Serializable {
      * setting time-to-teleport to 0. This avoid unmoved "vehicles" (in our case
      * also RSUs) being removed from simulation.
      */
-    public String additionalSumoParameters = "--time-to-teleport 0 --seed 100000 --xml-validation always";
+    public String additionalSumoParameters = "--time-to-teleport 0 --seed 100000";
+
+    /**
+     * Per default, SUMO will validate all input files for correctness. To disable
+     * this behavior, this field can be set to {@code false}.
+     */
+    public boolean validateSumoFiles = true;
 
     /**
      * Defines the time window in seconds in which vehicle counts on induction loops

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/config/CSumo.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/config/CSumo.java
@@ -65,7 +65,7 @@ public class CSumo implements Serializable {
      * setting time-to-teleport to 0. This avoid unmoved "vehicles" (in our case
      * also RSUs) being removed from simulation.
      */
-    public String additionalSumoParameters = " --time-to-teleport 0  --seed 100000";
+    public String additionalSumoParameters = "--time-to-teleport 0 --seed 100000 --xml-validation always";
 
     /**
      * Defines the time window in seconds in which vehicle counts on induction loops

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
@@ -53,7 +53,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,7 +67,14 @@ public class TraciTest {
 
     private final File scenarioConfig = FileUtils.toFile(getClass().getResource("/sumo-test-scenario/scenario.sumocfg"));
 
-    private final CSumo sumoConfig = new CSumo();
+    private final CSumo sumoConfig = createSumoConfig();
+
+    private static CSumo createSumoConfig() {
+        CSumo config = new CSumo();
+        config.subscriptions =
+                Lists.newArrayList(SUBSCRIPTION_ROAD_POSITION, SUBSCRIPTION_SIGNALS, SUBSCRIPTION_EMISSIONS, SUBSCRIPTION_LEADER);
+        return config;
+    }
 
     private final static double MAX_SPEED = 30d;
     private final static double REACTION_TIME = 1.4d;
@@ -86,12 +92,6 @@ public class TraciTest {
     public GeoProjectionRule coordinateTransformationRule = new GeoProjectionRule(
             UtmPoint.eastNorth(UtmZone.from(GeoPoint.lonLat(13.0, 52.0)), -385281.94, 5817994.50)
     );
-
-    @Before
-    public void setup() {
-        sumoConfig.subscriptions =
-                Lists.newArrayList(SUBSCRIPTION_ROAD_POSITION, SUBSCRIPTION_SIGNALS, SUBSCRIPTION_EMISSIONS, SUBSCRIPTION_LEADER);
-    }
 
     @Test
     public void addVehicles() throws Exception {

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
@@ -133,7 +133,7 @@ public class SumoTraciRule implements TestRule {
         final List<String> startArgs = Lists.newArrayList("-c", scenarioConfig.getName(),
                 "-v", "--remote-port", Integer.toString(port),
                 "--step-length", String.format(Locale.ENGLISH, "%.2f", (double) sumoConfig.updateInterval / 1000d),
-                "--xml-validation", "never"
+                "--xml-validation", "always"
         );
         startArgs.addAll(Arrays.asList(StringUtils.split(sumoConfig.additionalSumoParameters.trim(), " ")));
 

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/junit/SumoTraciRule.java
@@ -57,6 +57,7 @@ public class SumoTraciRule implements TestRule {
     private static final SumoVersion MINIMUM_VERSION_TESTED = SumoVersion.SUMO_1_0_x;
 
     private static final int MAX_CONNECTION_TRIES = 10;
+    private static final int CONNECTION_RETRY_TIME_MS = 500;
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -163,7 +164,7 @@ public class SumoTraciRule implements TestRule {
         int tries = 0;
         while (tries++ < MAX_CONNECTION_TRIES && socket == null) {
             try {
-                Thread.sleep(500);
+                Thread.sleep(CONNECTION_RETRY_TIME_MS);
                 socket = new Socket("localhost", port);
                 socket.setPerformancePreferences(0, 100, 10);
                 socket.setTcpNoDelay(true);

--- a/fed/mosaic-sumo/src/test/resources/density-flow-scenario/density_flow.detector.xml
+++ b/fed/mosaic-sumo/src/test/resources/density-flow-scenario/density_flow.detector.xml
@@ -1,4 +1,5 @@
-<additional>
+<?xml version="1.0" encoding="UTF-8"?>
+<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
     <inductionLoop id="area_entry_0" lane="1_1_2_1_0" pos="300" freq="300" file="out.xml" friendlyPos="true"/>
     <inductionLoop id="area_entry_1" lane="1_1_2_1_1" pos="300" freq="300" file="out.xml" friendlyPos="true"/>
     

--- a/fed/mosaic-sumo/src/test/resources/density-flow-scenario/density_flow.rou.xml
+++ b/fed/mosaic-sumo/src/test/resources/density-flow-scenario/density_flow.rou.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0"?>
-
-<routes>
-    <vType model="IDMM" id="PKW" accel="1.5" decel="4.5" sigma="0.5" length="5.0" maxspeed="50.0" tau="1.0" speedDev="0.1" emissionClass="HBEFA3/PC_G_EU4" speedFactor="1.0"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vType carFollowModel="IDMM" id="PKW" accel="1.5" decel="4.5" sigma="0.5" length="5.0" maxSpeed="50.0" tau="1.0" speedDev="0.1" emissionClass="HBEFA3/PC_G_EU4" speedFactor="1.0"/>
     <route id="1" edges="1_1_2_1 1_2_3_2 1_3_4_3"/>
     <flow id="1" route="1" type="PKW" begin="0" end="300" period="3" departLane="best" departSpeed="max"/>
 </routes>

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/parking.add.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/parking.add.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
+<additional>
     <parkingArea id="parkingArea_1_1_2_0_0" lane="1_1_2_0" startPos="354.46" endPos="364.46">
         <space x="22.19" y="355.71" angle="90.00"/>
     </parkingArea>

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/parking.add.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/parking.add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<additional>
+<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
     <parkingArea id="parkingArea_1_1_2_0_0" lane="1_1_2_0" startPos="354.46" endPos="364.46">
         <space x="22.19" y="355.71" angle="90.00"/>
     </parkingArea>

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/parking.add.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/parking.add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
+<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://sumo.dlr.de/xsd/additional_file.xsd">
     <parkingArea id="parkingArea_1_1_2_0_0" lane="1_1_2_0" startPos="354.46" endPos="364.46">
         <space x="22.19" y="355.71" angle="90.00"/>
     </parkingArea>

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.detector.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.detector.xml
@@ -1,4 +1,5 @@
-<additional>
+<?xml version="1.0" encoding="UTF-8"?>
+<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://sumo.dlr.de/xsd/additional_file.xsd">
     <inductionLoop id="induction_loop_1" lane="1_1_2_0" pos="70" freq="300" file="induction_loop_1.xml" friendlyPos="true"/>
     <inductionLoop id="induction_loop_2" lane="1_1_2_1" pos="70" freq="300" file="induction_loop_2.xml" friendlyPos="true"/>
 

--- a/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.rou.xml
+++ b/fed/mosaic-sumo/src/test/resources/sumo-test-scenario/scenario.rou.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0"?>
-
-<routes>
-    <vType carFollowModel="Krauss" id="PKW" accel="1.5" decel="4.5" sigma="0.5" length="5.0" maxspeed="50.0" tau="1.0" emissionClass="HBEFA3/PC_G_EU4" speedFactor="1.0" speedDev="0.0"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vType carFollowModel="Krauss" id="PKW" accel="1.5" decel="4.5" sigma="0.5" length="5.0" maxSpeed="50.0" tau="1.0" emissionClass="HBEFA3/PC_G_EU4" speedFactor="1.0" speedDev="0.0"/>
     <route id="0" edges="1_1_2 1_2_3 1_3_4"/>
     <route id="1" edges="1_1_2 2_2_5 2_5_6 2_6_3 1_3_4"/>
-    <vehicle id="1" type="PKW" route="1" depart="2" repno="1" period="8"/>
-    <vehicle id="0" type="PKW" route="0" depart="5" repno="1" period="3"/>
+    <vehicle id="1" type="PKW" route="1" depart="2"/>
+    <vehicle id="0" type="PKW" route="0" depart="5"/>
 </routes>

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
@@ -22,23 +22,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
 
 public class ProcessLoggingThread extends Thread {
 
-    public enum Level { Error, Info, Debug, Trace }
-
+    private final String processName;
+    private final Consumer<String> lineConsumer;
     private final InputStream stream;
-    private final org.slf4j.Logger log;
-    private final String id;
-    private final Level level;
     private boolean running = true;
 
-    public ProcessLoggingThread(org.slf4j.Logger log, InputStream stream, String identifier, Level level) {
+    public ProcessLoggingThread(String processName, InputStream stream, Consumer<String> lineConsumer) {
+        this.processName = processName;
         this.stream = stream;
-        this.log = log;
-
-        this.id = identifier;
-        this.level = level;
+        this.lineConsumer = lineConsumer;
     }
 
     public void close() {
@@ -63,36 +59,8 @@ public class ProcessLoggingThread extends Thread {
 
             String line;
             while (running) {
-
                 if ((line = bufferedReader.readLine()) != null) {
-                    if (this.level.equals(Level.Error)) {
-                        if (id == null || id.length() == 0) {
-                            this.log.error(line);
-                        } else {
-                            this.log.error("Process {} : {}", this.id, line);
-                        }
-                    }
-                    if (this.level.equals(Level.Info)) {
-                        if (id == null || id.length() == 0) {
-                            this.log.info(line);
-                        } else {
-                            this.log.info("Process {} : {}", this.id, line);
-                        }
-                    }
-                    if (this.level.equals(Level.Debug)) {
-                        if (id == null || id.length() == 0) {
-                            this.log.debug(line);
-                        } else {
-                            this.log.debug("Process {} : {}", this.id, line);
-                        }
-                    }
-                    if (this.level.equals(Level.Trace)) {
-                        if (id == null || id.length() == 0) {
-                            this.log.trace(line);
-                        } else {
-                            this.log.trace("Process {} : {}", this.id, line);
-                        }
-                    }
+                    lineConsumer.accept("Process " + processName + ": " + line);
                 }
             }
 

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/ProcessLoggingThread.java
@@ -18,7 +18,6 @@ package org.eclipse.mosaic.lib.util;
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -54,12 +53,11 @@ public class ProcessLoggingThread extends Thread {
     @SuppressWarnings(value = "REC_CATCH_EXCEPTION",
             justification = "Read exception will always occur if something goes wrong and the process we monitor is dead.")
     private void flushLog(InputStream stream) {
-        try {
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))){
 
             String line;
             while (running) {
-                if ((line = bufferedReader.readLine()) != null) {
+                if ((line = reader.readLine()) != null) {
                     lineConsumer.accept("Process " + processName + ": " + line);
                 }
             }
@@ -68,13 +66,6 @@ public class ProcessLoggingThread extends Thread {
             /* Read exception will always occur, if something goes wrong and the process we monitor is dead.
              * Therefore it is a normal behavior and it is safe to ignore them.
              */
-        } finally {
-            try {
-                stream.close();
-            } catch (IOException e) {
-                // quiet
-            }
-
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,9 @@
         <version.sqlite-jdbc>3.20.0</version.sqlite-jdbc><!-- 3.20.0 is approved in CQ14652 -->
         <version.stax2-api>4.1</version.stax2-api><!-- 4.1 is approved in CQ17826 -->
         <version.woodstox-core>5.1.0</version.woodstox-core><!-- 5.1.0 is approved in CQ17827 -->
-        <version.libsumo>1.14.0</version.libsumo><!-- no newer version available in maven repository -->
+        <!-- FIXME this should be updated to the latest SUMO version, but currently no newer version is available in maven repository -->
+        <!-- note, when upgrading, the field LibSumoAmbassador#VALID_LIBSUMO_VERSIONS needs to be changed too -->
+        <version.libsumo>1.14.0</version.libsumo>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.sqlite-jdbc>3.20.0</version.sqlite-jdbc><!-- 3.20.0 is approved in CQ14652 -->
         <version.stax2-api>4.1</version.stax2-api><!-- 4.1 is approved in CQ17826 -->
         <version.woodstox-core>5.1.0</version.woodstox-core><!-- 5.1.0 is approved in CQ17827 -->
-        <version.libsumo>1.14.0</version.libsumo>
+        <version.libsumo>1.14.0</version.libsumo><!-- no newer version available in maven repository -->
     </properties>
 
     <dependencies>

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
@@ -25,6 +25,8 @@ import org.eclipse.mosaic.rti.api.WatchDog;
 import org.eclipse.mosaic.rti.api.parameters.FederateDescriptor;
 
 import ch.qos.logback.classic.LoggerContext;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This implementation of <code>FederationManagement</code> allows local
@@ -64,12 +67,14 @@ public class LocalFederationManagement implements FederationManagement {
     /**
      * Mapping between federation id and federation descriptors.
      */
-    protected final HashMap<String, FederateDescriptor> federateDescriptors = new HashMap<>();
+    protected final Map<String, FederateDescriptor> federateDescriptors = new HashMap<>();
 
     /**
      * Mapping between federation id and federation ambassador instances.
      */
-    protected final HashMap<String, FederateAmbassador> federateAmbassadors = new HashMap<>();
+    protected final Map<String, FederateAmbassador> federateAmbassadors = new HashMap<>();
+
+    protected final Multimap<String, ProcessLoggingThread> loggingThreads = HashMultimap.create();
 
     protected WatchDog watchDog;
 
@@ -256,6 +261,7 @@ public class LocalFederationManagement implements FederationManagement {
                 federateName, p.getErrorStream(), LoggerFactory.getLogger(federateName + "Error")::error
         );
         errorLoggingThread.start();
+        loggingThreads.put(handle.getId(), errorLoggingThread);
 
         // call connectToFederateMethod of the current federate an extract
         // possible output from the federates' output stream (e.g. port number...)
@@ -264,9 +270,10 @@ public class LocalFederationManagement implements FederationManagement {
 
         // read the federates stdout in an extra thread and add this to our logging instance
         ProcessLoggingThread outputLoggingThread = new ProcessLoggingThread(
-                federateName, p.getInputStream(), LoggerFactory.getLogger(federateName + "Output")::error
+                federateName, p.getInputStream(), LoggerFactory.getLogger(federateName + "Output")::info
         );
         outputLoggingThread.start();
+        loggingThreads.put(handle.getId(), outputLoggingThread);
     }
 
     /**
@@ -278,6 +285,8 @@ public class LocalFederationManagement implements FederationManagement {
     protected void stopFederate(FederateDescriptor handle, boolean forceStop) throws Exception {
         if (handle.getFederateExecutor() != null) {
             handle.getFederateExecutor().stopLocalFederate();
+
+            loggingThreads.get(handle.getId()).forEach(ProcessLoggingThread::close);
         }
     }
 

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/federation/LocalFederationManagement.java
@@ -15,8 +15,6 @@
 
 package org.eclipse.mosaic.rti.federation;
 
-import ch.qos.logback.classic.LoggerContext;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.mosaic.lib.util.ProcessLoggingThread;
 import org.eclipse.mosaic.rti.api.ComponentProvider;
 import org.eclipse.mosaic.rti.api.FederateAmbassador;
@@ -25,6 +23,9 @@ import org.eclipse.mosaic.rti.api.FederationManagement;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.WatchDog;
 import org.eclipse.mosaic.rti.api.parameters.FederateDescriptor;
+
+import ch.qos.logback.classic.LoggerContext;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,10 +253,7 @@ public class LocalFederationManagement implements FederationManagement {
 
         // read error output of process in an extra thread
         ProcessLoggingThread errorLoggingThread = new ProcessLoggingThread(
-                LoggerFactory.getLogger(federateName + "Error"),
-                p.getErrorStream(),
-                federateName,
-                ProcessLoggingThread.Level.Error
+                federateName, p.getErrorStream(), LoggerFactory.getLogger(federateName + "Error")::error
         );
         errorLoggingThread.start();
 
@@ -266,10 +264,7 @@ public class LocalFederationManagement implements FederationManagement {
 
         // read the federates stdout in an extra thread and add this to our logging instance
         ProcessLoggingThread outputLoggingThread = new ProcessLoggingThread(
-                LoggerFactory.getLogger(federateName + "Output"),
-                p.getInputStream(),
-                federateName,
-                ProcessLoggingThread.Level.Info
+                federateName, p.getInputStream(), LoggerFactory.getLogger(federateName + "Output")::error
         );
         outputLoggingThread.start();
     }

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -3,6 +3,7 @@ FROM maven:3.6.3-adoptopenjdk-8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV USER_NAME=jenkins
 ENV HOME=/home/jenkins
+ENV SUMO_HOME=/usr/share/sumo
 WORKDIR /home/jenkins
 
 RUN apt-get update &&  \

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -8,6 +8,6 @@ WORKDIR /home/jenkins
 RUN apt-get update &&  \
     apt-get install -y --allow-unauthenticated software-properties-common && \
     # adjust this output string to bypass potentiall caches
-    echo "Installing SUMO 1.14.0" && \
+    echo "Installing SUMO 1.15.0" && \
     add-apt-repository ppa:sumo/stable && \
     apt-get install -y sumo

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -10,9 +10,9 @@ build and tag the docker image with the latest SUMO version. This image should b
 and available in the PPA.
 
 ```shell script
-docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.14.0
+docker build . -t eclipsemosaic/mosaic-ci:jdk8-sumo-1.15.0
 docker login
-docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.14.0
+docker push eclipsemosaic/mosaic-ci:jdk8-sumo-1.15.0
 ```  
 
 Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/ReleaseHelloWorldIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/ReleaseHelloWorldIT.java
@@ -56,7 +56,7 @@ public class ReleaseHelloWorldIT {
 
     @Test
     public void allVehiclesLoaded() throws Exception {
-        LogAssert.contains(simulationRule, "Traffic.log", ".*sumo :  Inserted: 450.*");
+        LogAssert.contains(simulationRule, "Traffic.log", ".*sumo:  Inserted: 450.*");
     }
 
     @Test

--- a/test/scenarios/perception-module/sumo/square.rou.xml
+++ b/test/scenarios/perception-module/sumo/square.rou.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
   ~

--- a/test/scenarios/sumo-predefined-scenario-integration/sumo/tiergarten.rou.xml
+++ b/test/scenarios/sumo-predefined-scenario-integration/sumo/tiergarten.rou.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2020 Fraunhofer FOKUS and others. All rights reserved.
   ~


### PR DESCRIPTION
## Type of this PR 

<!--- ( choose one ) -->

- [ ] Bug fix
- [x] Enhancement

## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

Upgrades to support SUMO 1.15.0

SUMO 1.15.0 disabled XSD lookup if SUMO_HOME is not set. This results in failing validation during startup. To overcome this, we disable validation completely if SUMO_HOME is not set, by passing the parameter `--xml-validation never`. If SUMO_HOME is set, we keep the default behavior.

During debugging I already adjusted some XML files to be validated successfully. This is not really required, by we may keep this now.

Offtopic change:

* simplified/generalized use of ProcessLoggingThread 

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

Internal issue 491
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

We could update website on next release

## Definition of Done

<!--- ( to be checked by the author ) -->

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

