### PR TITLE
feat(mapping): Integrate DoubleTimeFieldAdapters

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Barnim/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Barnim/mapping/mapping_config.json
@@ -34,7 +34,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 5.0,
+            "startingTime": "5.0 s",
             "targetFlow": 1800,
             "maxNumberVehicles": 120,
             "pos": 1417,

--- a/bundle/src/assembly/resources/scenarios/HelloWorld/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/HelloWorld/mapping/mapping_config.json
@@ -14,7 +14,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1 s",
             "targetFlow": 6000,
             "maxNumberVehicles": 400,
             "route": "2",
@@ -32,7 +32,7 @@
             ]
         },
         {
-            "startingTime": 1.0,
+            "startingTime": "1.0 s",
             "targetFlow": 1000,
             "maxNumberVehicles": 50,
             "route": "1",

--- a/bundle/src/assembly/resources/scenarios/Highway/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Highway/mapping/mapping_config.json
@@ -26,7 +26,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1.0 s",
             "targetFlow": 6000,
             "maxNumberVehicles": 400,
             "route": "2",
@@ -38,7 +38,7 @@
             ]
         },
         {
-            "startingTime": 1.0,
+            "startingTime": "1.0 s",
             "targetFlow": 1000,
             "maxNumberVehicles": 50,
             "route": "1",

--- a/bundle/src/assembly/resources/scenarios/Sievekingplatz/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Sievekingplatz/mapping/mapping_config.json
@@ -19,7 +19,7 @@
     ],
     "vehicles": [
         {
-            "startingTime": 10.0,
+            "startingTime": "10.0 s",
             "route": "3",
             "targetFlow": 1200,
             "maxNumberVehicles": 3,

--- a/bundle/src/assembly/resources/scenarios/Tiergarten/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Tiergarten/mapping/mapping_config.json
@@ -60,25 +60,25 @@
     ],
     "vehicles": [
         {
-            "startingTime": 1.0,
+            "startingTime": "1.0 s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]
         },
         {
-            "startingTime": 5.0,
+            "startingTime": "5.0 s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]
         },
         {
-            "startingTime": 8.0,
+            "startingTime": "8.0 s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "TrafficLightCar" } ]
         },
         {
-            "startingTime": 10.0,
+            "startingTime": "10.0 s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "Car" } ]

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
@@ -16,6 +16,10 @@
 package org.eclipse.mosaic.fed.mapping.config;
 
 
+import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
+
+import com.google.gson.annotations.JsonAdapter;
+
 /**
  * Class that contains options for the parametrization of the Mapping.
  */
@@ -28,27 +32,29 @@ public class CMappingConfiguration {
     public double scaleTraffic = 1.0;
 
     /**
-     * Defines the point in time (in seconds) to start spawning vehicles. If not set (default),
-     * all vehicles will be spawned according to the vehicles configuration.
+     * Defines the point in time to start spawning vehicles. If not set (default),
+     * all vehicles will be spawned according to the vehicles configuration. [s]
      */
+    @JsonAdapter(TimeFieldAdapter.DoubleSecondsNullable.class)
     public Double start;
 
     /**
-     * Defines the point in time (in seconds) to end spawning vehicles. If not set (default),
-     * all vehicles will be spawned according to the vehicles configuration or until the simulation ends.
+     * Defines the point in time to end spawning vehicles. If not set (default),
+     * all vehicles will be spawned according to the vehicles configuration or until the simulation ends. [s]
      */
+    @JsonAdapter(TimeFieldAdapter.DoubleSecondsNullable.class)
     public Double end;
 
     /**
-     * If set to <code>true</code> and if the parameter <code>start</code> is set, the starting
+     * If set to {@code true} and if the parameter {@code start} is set, the starting
      * times of each spawner is adjusted accordingly, so that we shouldn't wait
      * in case that simulation starting time and spawner starting time are widely spread out.
-     * All spawners before <code>start</code> will be completely ignored then.
+     * All spawners before {@code start} will be completely ignored then.
      */
     public boolean adjustStartingTimes = false;
 
     /**
-     * If set to <code>true</code>, all flow definitions defined by vehicle spawners with more than 1 vehicle
+     * If set to {@code true}, all flow definitions defined by vehicle spawners with more than 1 vehicle
      * result in slightly randomized departure times. The specified `targetFlow` of the vehicle spawner is kept.
      */
     public boolean randomizeFlows = false;

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/COriginDestinationMatrixMapper.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/COriginDestinationMatrixMapper.java
@@ -18,6 +18,7 @@ package org.eclipse.mosaic.fed.mapping.config.units;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.lib.geo.GeoCircle;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture;
+import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -57,12 +58,14 @@ public class COriginDestinationMatrixMapper {
     /**
      * Time at which the first vehicle will be created.
      */
+    @JsonAdapter(TimeFieldAdapter.DoubleSeconds.class)
     public double startingTime = 0.0;
 
     /**
      * Simulation time in seconds at which no more vehicles will be created.
      */
     @SerializedName(value = "maxTime", alternate = {"endingTime"})
+    @JsonAdapter(TimeFieldAdapter.DoubleSecondsNullable.class)
     public Double maxTime;
 
     /**

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
@@ -20,6 +20,7 @@ import org.eclipse.mosaic.lib.geo.GeoCircle;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.DepartureSpeedMode;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleDeparture.LaneSelectionMode;
 import org.eclipse.mosaic.lib.util.gson.AbstractEnumDefaultValueTypeAdapter;
+import org.eclipse.mosaic.lib.util.gson.TimeFieldAdapter;
 import org.eclipse.mosaic.lib.util.gson.UnitFieldAdapter;
 
 import com.google.gson.annotations.JsonAdapter;
@@ -49,12 +50,14 @@ public class CVehicle implements Comparable<CVehicle> {
     /**
      * Time at which the first vehicle will be created.
      */
+    @JsonAdapter(TimeFieldAdapter.DoubleSeconds.class)
     public double startingTime = 0.0;
 
     /**
      * Simulation time in seconds at which no more vehicles will be created.
      */
     @SerializedName(value = "maxTime", alternate = {"endingTime"})
+    @JsonAdapter(TimeFieldAdapter.DoubleSecondsNullable.class)
     public Double maxTime;
 
     /**

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -61,13 +61,17 @@
             "properties": {
                 "start": {
                     "description": "Defines the point in time (in seconds) to start spawning vehicles. If not set (default), all vehicles will be spawned according to the vehicles configuration.",
-                    "type": "number",
-                    "minimum": 0
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "end": {
                     "description": "Defines the point in time (in seconds) to end spawning vehicles. If not set (default), all vehicles will be spawned according to the vehicles configuration or until the simulation ends.",
-                    "type": "number",
-                    "minimum": 0
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "scaleTraffic": {
                     "description": "Scales the traffic by the given factor. E.g. 2.0 would double the number of spawned vehicles",
@@ -273,15 +277,18 @@
             "type": "object",
             "properties": {
                 "startingTime": {
-                    "description": "Time at which the first vehicle will be created.",
-                    "type": "number",
-                    "minimum": 0,
-                    "default": 0.0
+                    "description": "Time in seconds at which the first vehicle will be created.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "maxTime": {
                     "description": "Simulation time in seconds at which no more vehicles will be created.",
-                    "type": "number",
-                    "minimum": 0
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "targetFlow": {
                     "description": "Density of vehicles per hour. Vehicles will be spawned uniformly.",
@@ -410,15 +417,18 @@
                     }
                 },
                 "startingTime": {
-                    "description": "Time at which the first vehicle will be created.",
-                    "type": "number",
-                    "minimum": 0,
-                    "default": 0.0
+                    "description": "Time in seconds at which the first vehicle will be created.",
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0, "default": 0.0 }
+                    ]
                 },
                 "maxTime": {
                     "description": "Simulation time in seconds at which no more vehicles will be created.",
-                    "type": "number",
-                    "minimum": 0
+                    "anyOf": [
+                        { "type": "string", "maxLength": 15 },
+                        { "type": "number", "minimum": 0 }
+                    ]
                 },
                 "departSpeedMode": {
                     "description": "The depart speed mode determines the vehicle's speed at insertion.",

--- a/fed/mosaic-mapping/src/test/resources/mapping/Tiergarten.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/Tiergarten.json
@@ -54,7 +54,7 @@
             "types": [ { "name": "PKW" } ]
         },
         {
-            "startingTime": 5.0,
+            "startingTime": "5.0 s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "PKW" } ]
@@ -66,7 +66,7 @@
             "types": [ { "name": "TLPKW" } ]
         },
         {
-            "startingTime": 10.0,
+            "startingTime": "10.0 s",
             "route": "0",
             "maxNumberVehicles": 1,
             "types": [ { "name": "PKW" } ]

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_scale.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_scale.json
@@ -1,51 +1,51 @@
 {
-	"prototypes":[
-		{
-			"name":"car"
-		}
-	],
-	"config" : {
-		"scaleTraffic": 1.3
-	},
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":923,
-			"maxNumberVehicles": 1,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app1"] }]
-		},
-		{
-			"startingTime": 10.0,
-			"targetFlow":923,
-			"maxNumberVehicles": 2,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app2"] }]
-		},
-		{
-			"startingTime": 20.0,
-			"targetFlow":554,
-			"maxNumberVehicles": 1,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app3"] }]
-		},
-		{
-			"startingTime": 30.0,
-			"targetFlow":923,
-			"maxNumberVehicles": 6,
-			"route":"1",
-			"types":[{ "name":"car", "applications":["app4"] }]
-		},
-		{
-			"startingTime": 46.0,
-			"targetFlow":923,
-			"route":"1",
-			"types":[
-				{
-					"name":"unlimitedCars",
-					"applications":["app5"]
-				}
-			]
-		}
-	]
+    "prototypes": [
+        {
+            "name": "car"
+        }
+    ],
+    "config": {
+        "scaleTraffic": 1.3
+    },
+    "vehicles": [
+        {
+            "startingTime": 5.0,
+            "targetFlow": 923,
+            "maxNumberVehicles": 1,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app1" ] } ]
+        },
+        {
+            "startingTime": 10.0,
+            "targetFlow": 923,
+            "maxNumberVehicles": 2,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app2" ] } ]
+        },
+        {
+            "startingTime": 20.0,
+            "targetFlow": 554,
+            "maxNumberVehicles": 1,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app3" ] } ]
+        },
+        {
+            "startingTime": 30.0,
+            "targetFlow": 923,
+            "maxNumberVehicles": 6,
+            "route": "1",
+            "types": [ { "name": "car", "applications": [ "app4" ] } ]
+        },
+        {
+            "startingTime": 46.0,
+            "targetFlow": 923,
+            "route": "1",
+            "types": [
+                {
+                    "name": "unlimitedCars",
+                    "applications": [ "app5" ]
+                }
+            ]
+        }
+    ]
 }

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_weights_in_prototype.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_weights_in_prototype.json
@@ -1,45 +1,45 @@
 {
-	"prototypes":[
-		{
-			"name":"Car1",
-			"applications":["Car1App"],
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":70.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1,
-			"weight": 20
-		},
-		{
-			"name":"Car2",
-			"vehicleClass": "ElectricVehicle",
-			"applications":["Car2App"],
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":40.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1,
-			"weight": 80
-		}
-	],
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 10,
-			"route":"1",
-			"types":[
-				{
-					"name":"Car1"
-				},
-				{
-					"name":"Car2"
-				}
-			]
-		}
-	]
+    "prototypes": [
+        {
+            "name": "Car1",
+            "applications": [ "Car1App" ],
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 70.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1,
+            "weight": 20
+        },
+        {
+            "name": "Car2",
+            "vehicleClass": "ElectricVehicle",
+            "applications": [ "Car2App" ],
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 40.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1,
+            "weight": 80
+        }
+    ],
+    "vehicles": [
+        {
+            "startingTime": 5.0,
+            "targetFlow": 1200,
+            "maxNumberVehicles": 10,
+            "route": "1",
+            "types": [
+                {
+                    "name": "Car1"
+                },
+                {
+                    "name": "Car2"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
## Type of this PR 

<!--- ( choose one ) -->

- [ ] Bug fix
- [x] Enhancement

## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->
* Integrated proposed `DoubleTimeFieldAdapter`s
* `startingTime`s, `endTime`s use these adapters 
* all bundled scenarios will now use starting time definitions in the form of "x.x s"
* additionally some occurrences in test mapping-configs now use a string definition

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

relates to internal issue 421
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Yes see internal website MR 67

## Definition of Done

<!--- ( to be checked by the author ) -->

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

