### PR TITLE
fix(rti): resolved racing condition in RTI

### DIFF
--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/time/ScheduledEvents.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/time/ScheduledEvents.java
@@ -85,10 +85,12 @@ class ScheduledEvents {
      * @return the maximum valid time
      */
     long getMaximumValidTime() {
-        if (this.lookahead.isEmpty()) {
-            return Long.MAX_VALUE;
-        } else {
-            return this.lookahead.peek();
+        synchronized (isEmptyMutex) {
+            if (this.lookahead.isEmpty()) {
+                return Long.MAX_VALUE;
+            } else {
+                return this.lookahead.peek();
+            }
         }
     }
 }


### PR DESCRIPTION
## Type of this PR 

<!--- ( choose one ) -->

- [x] Bug fix
- [ ] Enhancement

## Description

Multi-threaded time management tried to read and manipulate the lookahead queue in `ScheduledEvents` simultaneously. Occasionally, this could lead to NPE when `getMaximumValidTime()` tried to read the peek value of the lookahead queue but could request an empty queue when `ThreadWorker` removed the latest lookahead value from the queue in the mean time.

This PR includes a further synchronized block to avoid concurrent access on the lookahead queue. ThreadWorker already uses `isEmptyMutex` when removing the latest lookahead value; this mutex is now also used in `getMaximumValidTime()`.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

Internal issue 519 

## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

