### PR TITLE
cleanup(logging): Improved Logging related to simulation of external scenarios

### DIFF
--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -241,8 +241,7 @@ public class SpawningFramework {
         }
 
         if (mappingConfiguration.vehicles == null || !spawnersExist) {
-            LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
-                    .warn("You didn't define any spawners in your mapping config. Only external vehicles will be simulated.");
+            LOG.info("No vehicle spawners defined in mapping config. Only external vehicles will be simulated.");
         }
 
         // OD-Matrices

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/util/MosaicConformVehicleIdTransformer.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/util/MosaicConformVehicleIdTransformer.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Several components of Eclipse MOSAIC expect the identifier of the vehicles to
- * match the following expression: ^veh_[0-9]+$. However, predefined SUMO
+ * match the following expression: ^veh_[0-9]+$. However, predefined
  * scenarios usually come with custom vehicle ids which do not match this
  * pattern, so we need to transform them into the required format which is
  * accomplished by this class.
@@ -34,45 +34,44 @@ public class MosaicConformVehicleIdTransformer implements IdTransformer<String, 
 
     private final static Logger log = LoggerFactory.getLogger(MosaicConformVehicleIdTransformer.class);
 
-    private final BiMap<String, String> sumoToMosaicVehicleIdMap = HashBiMap.create(1024);
+    private final BiMap<String, String> vehicleIdMap = HashBiMap.create(1024);
 
     /**
-     * Takes a MOSAIC conform vehicle id (e.g. veh_1) and returns the saved SUMO id in {@link #sumoToMosaicVehicleIdMap}.
-     * If a new vehicle from MOSAIC has to be added to SUMO we use the same id.
+     * Takes a MOSAIC conform vehicle id (e.g. veh_1) and returns the saved external id in {@link #vehicleIdMap}.
+     * If a new vehicle from MOSAIC has to be added to an external simulator we use the same id.
      *
      * @param mosaicVehicleId the MOSAIC conform vehicle id
-     * @return the corresponding SUMO id
+     * @return the corresponding external id
      */
     @Override
     public String toExternalId(String mosaicVehicleId) {
-        String sumoVehicleId = sumoToMosaicVehicleIdMap.inverse().get(mosaicVehicleId);
-        if (sumoVehicleId == null) {
-            sumoToMosaicVehicleIdMap.inverse().put(mosaicVehicleId, mosaicVehicleId);
-            sumoVehicleId = mosaicVehicleId; // return incoming id
+        String externalVehicleId = vehicleIdMap.inverse().get(mosaicVehicleId);
+        if (externalVehicleId == null) {
+            vehicleIdMap.inverse().put(mosaicVehicleId, mosaicVehicleId);
+            externalVehicleId = mosaicVehicleId; // return incoming id
         }
-        return sumoVehicleId;
+        return externalVehicleId;
     }
 
     /**
-     * Takes a SUMO vehicle id and makes it known to the simulation by creating a
-     * MOSAIC conform vehicle id and adding it to {@link #sumoToMosaicVehicleIdMap}.
+     * Takes an external vehicle id, creates a MOSAIC-conform vehicle id and adds it to {@link #vehicleIdMap}.
      *
-     * @param sumoVehicleId the id from SUMO
+     * @param externalVehicleId the id from the external traffic/vehicle simulator
      * @return the created MOSAIC conform vehicle id
      */
     @Override
-    public String fromExternalId(String sumoVehicleId) {
-        String mosaicVehicleId = sumoToMosaicVehicleIdMap.get(sumoVehicleId);
+    public String fromExternalId(String externalVehicleId) {
+        String mosaicVehicleId = vehicleIdMap.get(externalVehicleId);
         if (mosaicVehicleId == null) {
             mosaicVehicleId = UnitNameGenerator.nextVehicleName();
-            sumoToMosaicVehicleIdMap.put(sumoVehicleId, mosaicVehicleId);
-            log.debug("Assigned vehicle id {} to vehicle {}", mosaicVehicleId, sumoVehicleId);
+            vehicleIdMap.put(externalVehicleId, mosaicVehicleId);
+            log.info("Assigned vehicle MOSAIC-ID: \"{}\" to external vehicle: \"{}\"", mosaicVehicleId, externalVehicleId);
         }
         return mosaicVehicleId;
     }
 
     @Override
     public void reset() {
-        sumoToMosaicVehicleIdMap.clear();
+        vehicleIdMap.clear();
     }
 }


### PR DESCRIPTION
## Type of this PR 

<!--- ( choose one ) -->

- [ ] Bug fix
- [x] Enhancement

## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->
* The following warning has been moved from the root-logger to the `SpawningFramework`-logger and can now be found in the `mapping.log`
    * additionally, the level has been changed to "INFO" as this behavior is most likely intentional
    * also the log message has been adjusted for better clarity
```
WARN  ROOT - You didn't define any spawners in your mapping config. Only external vehicles will be simulated.
```

* When simulating external scenarios the assigned MOSAIC vehicle ID's where only retraceable when log-level `DEBUG` was set, however this information is often relevant and has been moved to `INFO`
    * this change is made in `MosaicConformIdTransformer`
    * furthermore, the message has been adjusted for better clarity
## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

relates to internal issue 523
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->
None

## Definition of Done

<!--- ( to be checked by the author ) -->

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.
- [x] `origin/main` has been merged into your Fork.
- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] There are no new SpotBugs warnings. 
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All tests pass.

## Special notes to reviewer

