### PR TITLE
feat(app): Provide group value defined in mapping in applications

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/UnitSimulator.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/UnitSimulator.java
@@ -161,7 +161,7 @@ public enum UnitSimulator implements EventProcessor {
     /**
      * Use this method to put the unit in the specific maps.
      *
-     * @param unit The unit to add.
+     * @param unit         The unit to add.
      */
     private void addSimulationUnit(final AbstractSimulationUnit unit) {
         if (allUnits.containsKey(unit.getId())) {
@@ -270,8 +270,12 @@ public enum UnitSimulator implements EventProcessor {
         }
         String rsuName = rsuRegistration.getMapping().getName();
         GeoPoint rsuPosition = rsuRegistration.getMapping().getPosition();
+
         final RoadSideUnit roadSideUnit = new RoadSideUnit(rsuName, rsuPosition);
+        roadSideUnit.setGroup(rsuRegistration.getMapping().getGroup());
+
         addSimulationUnit(roadSideUnit);
+
         doSensorRegistration(rsuRegistration.getTime(), roadSideUnit.getId());
 
         final Event event = new Event(
@@ -294,6 +298,8 @@ public enum UnitSimulator implements EventProcessor {
             return;
         }
         final TrafficManagementCenterUnit tmc = new TrafficManagementCenterUnit(tmcRegistration.getMapping());
+        tmc.setGroup(tmcRegistration.getMapping().getGroup());
+
         addSimulationUnit(tmc);
         // doSensorRegistration(tmcRegistration.getTime(), tmc.getId());
 
@@ -315,6 +321,8 @@ public enum UnitSimulator implements EventProcessor {
             return;
         }
         final ServerUnit server = new ServerUnit(serverRegistration.getMapping());
+        server.setGroup(serverRegistration.getMapping().getGroup());
+
         addSimulationUnit(server);
 
         final Event event = new Event(
@@ -337,7 +345,10 @@ public enum UnitSimulator implements EventProcessor {
         }
         String name = chargingStationRegistration.getMapping().getName();
         GeoPoint position = chargingStationRegistration.getMapping().getPosition();
+
         final ChargingStationUnit chargingStationUnit = new ChargingStationUnit(name, position);
+        chargingStationUnit.setGroup(chargingStationRegistration.getMapping().getGroup());
+
         addSimulationUnit(chargingStationUnit);
         doSensorRegistration(chargingStationRegistration.getTime(), chargingStationUnit.getId());
 
@@ -359,11 +370,14 @@ public enum UnitSimulator implements EventProcessor {
         if (!trafficLightRegistration.getMapping().hasApplication()) {
             return;
         }
+
         final TrafficLightGroupUnit trafficLightGroupUnit = new TrafficLightGroupUnit(
                 trafficLightRegistration.getMapping().getName(),
                 trafficLightRegistration.getMapping().getPosition(),
                 trafficLightRegistration.getTrafficLightGroup()
         );
+        trafficLightGroupUnit.setGroup(trafficLightRegistration.getMapping().getGroup());
+
         addSimulationUnit(trafficLightGroupUnit);
         doSensorRegistration(trafficLightRegistration.getTime(), trafficLightGroupUnit.getId());
 
@@ -397,11 +411,13 @@ public enum UnitSimulator implements EventProcessor {
         final VehicleUnit vehicle;
         String vehicleName = vehicleRegistration.getMapping().getName();
         VehicleType vehicleType = vehicleRegistration.getMapping().getVehicleType();
+
         if (vehicleRegistration.getMapping().getVehicleType().getVehicleClass().equals(VehicleClass.ElectricVehicle)) {
             vehicle = new ElectricVehicleUnit(vehicleName, vehicleType, initialPosition);
         } else {
             vehicle = new VehicleUnit(vehicleName, vehicleType, initialPosition);
         }
+        vehicle.setGroup(vehicleRegistration.getMapping().getGroup());
 
         addSimulationUnit(vehicle);
         doSensorRegistration(time, vehicle.getId());

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/AbstractSimulationUnit.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/AbstractSimulationUnit.java
@@ -80,6 +80,8 @@ public abstract class AbstractSimulationUnit implements EventProcessor, Operatin
     @Nonnull
     private final String id;
 
+    private String group;
+
     /**
      * Position of the unit.
      */
@@ -128,6 +130,11 @@ public abstract class AbstractSimulationUnit implements EventProcessor, Operatin
         this.adhocModule = new AdHocModule(this, messageSequenceNumberGenerator, getOsLog());
         this.cellModule = new CellModule(this, messageSequenceNumberGenerator, getOsLog());
         this.initialPosition = initialPosition;
+    }
+
+    public AbstractSimulationUnit setGroup(String vehicleGroup) {
+        this.group = vehicleGroup;
+        return this;
     }
 
     @Nonnull
@@ -489,5 +496,10 @@ public abstract class AbstractSimulationUnit implements EventProcessor, Operatin
 
     public boolean canProcessEvent() {
         return true;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
     }
 }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/app/api/os/OperatingSystem.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/app/api/os/OperatingSystem.java
@@ -143,4 +143,6 @@ public interface OperatingSystem extends CommunicationModuleOwner {
      * @return the list containing all applications.
      */
     <A extends Application> Iterable<A> getApplicationsIterator(Class<A> applicationClass);
+
+    String getGroup();
 }


### PR DESCRIPTION
## Type of this PR 

<!--- ( choose one ) -->

- Enhancement

## Description

* Provide `getGroup` Method in `OperatingSystem` Interface and `AbstractSimulationUnit`. Adds a `setGroup` Method in `AbstractSimulationUnit` which is used to set the group value read from *Unit*Registration message for each simulation object added to the simulation. This happens in each register*Unit* method in the UnitSimulator class. That way one can access the group value in any application.


What is this PR about?

## Issue(s) related to this PR

Internal issue 284
  
## Affected parts of the online documentation
--

Changes in the documentation required?

## Definition of Done

<!--- ( to be checked by the author ) -->

- [ ] You have read CONTRIBUTING.md carefully.
- [ ] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] Your GitHub user id is linked with your Eclipse Account.
- [ ] `origin/main` has been merged into your Fork.
- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] There are no new SpotBugs warnings. 
- [ ] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All tests pass.

## Special notes to reviewer

