### PR TITLE
cleanup(mapping): cleaned up some logging in mapping

### DIFF
--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -494,7 +494,7 @@ public class SpawningFramework {
                     time, name, group, apps, tlGroup,
                     scenarioTrafficLightRegistration.getLanesControlledByGroups().get(tlGroup.getGroupId())
             );
-            LOG.info("Creating Traffic Light Group: name={}, apps={}", tlGroup.getGroupId(), apps);
+            LOG.info("Creating Traffic Light Group: name={},tlGroupId={},apps={}", name, tlGroup.getGroupId(), apps);
             try {
                 rti.triggerInteraction(tlRegistration);
             } catch (IllegalValueException e) {

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -47,7 +47,6 @@ import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
 
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -358,23 +357,23 @@ public class SpawningFramework {
      */
     private void completeSpawnerDefinitions() {
         for (RoadSideUnitSpawner rsu : rsus) {
-            rsu.fillInPrototype(getPrototypeByName(rsu.getPrototype()));
+            rsu.fillInPrototype(getPrototypeByName(rsu.getPrototypeName()));
         }
 
         for (TrafficManagementCenterSpawner tmc : tmcs) {
-            tmc.fillInPrototype(getPrototypeByName(tmc.getPrototype()));
+            tmc.fillInPrototype(getPrototypeByName(tmc.getPrototypeName()));
         }
 
         for (ServerSpawner server : servers) {
-            server.fillInPrototype(getPrototypeByName(server.getPrototype()));
+            server.fillInPrototype(getPrototypeByName(server.getPrototypeName()));
         }
 
         for (TrafficLightSpawner tl : tls.values()) {
-            tl.fillInPrototype(getPrototypeByName(tl.getPrototype()));
+            tl.fillInPrototype(getPrototypeByName(tl.getPrototypeName()));
         }
 
         for (ChargingStationSpawner chargingStation : chargingStations) {
-            chargingStation.fillInPrototype(getPrototypeByName(chargingStation.getPrototype()));
+            chargingStation.fillInPrototype(getPrototypeByName(chargingStation.getPrototypeName()));
         }
 
         // If adjustStartingTimes is configured, only the end time is relevant for remaining spawners.
@@ -484,7 +483,7 @@ public class SpawningFramework {
             String name = UnitNameGenerator.nextTlName();
             String group;
             if (prototype != null) {
-                apps = prototype.getAppList();
+                apps = prototype.getApplications();
                 group = ObjectUtils.defaultIfNull(prototype.getGroup(), tlGroup.getGroupId());
             } else {
                 apps = new ArrayList<>();
@@ -495,11 +494,7 @@ public class SpawningFramework {
                     time, name, group, apps, tlGroup,
                     scenarioTrafficLightRegistration.getLanesControlledByGroups().get(tlGroup.getGroupId())
             );
-            if (prototype != null) {
-                LOG.info("Creating Traffic Light Group: name={}, apps=[{}]", tlGroup.getGroupId(), StringUtils.join(apps, ","));
-            } else {
-                LOG.info("Creating Traffic Light Group: name={}, apps=[]", tlGroup.getGroupId());
-            }
+            LOG.info("Creating Traffic Light Group: name={}, apps={}", tlGroup.getGroupId(), apps);
             try {
                 rti.triggerInteraction(tlRegistration);
             } catch (IllegalValueException e) {

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -74,7 +74,7 @@ public class VehicleFlowGenerator {
     private final LaneIndexSelector laneSelector;
     private final SpawningMode spawningMode;
     private final List<VehicleTypeSpawner> types;
-    private final int departureConnectionIndex;
+    private final int departConnectionIndex;
     private final int pos;
     private final String route;
     private final GeoCircle origin;
@@ -125,7 +125,7 @@ public class VehicleFlowGenerator {
         this.randomNumberGenerator = randomNumberGenerator;
 
         // set simple values
-        this.departureConnectionIndex = vehicleConfiguration.departConnectionIndex;
+        this.departConnectionIndex = vehicleConfiguration.departConnectionIndex;
         this.pos = vehicleConfiguration.pos;
         this.route = vehicleConfiguration.route;
         this.group = vehicleConfiguration.group;
@@ -418,29 +418,29 @@ public class VehicleFlowGenerator {
             return;
         }
         // if no group is defined in vehicle definition take group declared in prototype
-        group = ObjectUtils.defaultIfNull(group, type.getGroup());
+        String spawningGroup = ObjectUtils.defaultIfNull(group, type.getGroup());
 
         VehicleDeparture vehicleDeparture = new VehicleDeparture.Builder(route)
                 .departureLane(laneSelectionMode, lane, pos)
-                .departureConnection(departureConnectionIndex)
+                .departureConnection(departConnectionIndex)
                 .departureSpeed(departureSpeedMode, departSpeed)
                 .create();
 
         Interaction interaction;
         if (origin != null) {
             interaction = new RoutelessVehicleRegistration(
-                    framework.getTime(), name, group, type.getAppList(), vehicleDeparture, type.convertType(), odInfo
+                    framework.getTime(), name, spawningGroup, type.getAppList(), vehicleDeparture, type.convertType(), odInfo
             );
         } else {
-            interaction = new VehicleRegistration(framework.getTime(), name, group, type.getAppList(), vehicleDeparture,
+            interaction = new VehicleRegistration(framework.getTime(), name, spawningGroup, type.getAppList(), vehicleDeparture,
                     type.convertTypeAndVaryParameters(randomNumberGenerator)
             );
         }
 
         try {
-            LOG.info("Creating Vehicle. time={}, name={}, route={}, laneSelectionMode={}, lane={}, departureConnectionIndex{}, pos={}, "
-                            + "type={}, departSpeed={}, apps={}",
-                    framework.getTime(), name, route, laneSelectionMode, lane, departureConnectionIndex, pos, type, departSpeed, type.getAppList());
+            LOG.info("Creating Vehicle. time={}, name={}, route={}, laneSelectionMode={}, lane={}, departConnectionIndex={}, pos={}, type={}, departSpeed={}, apps={}",
+                    framework.getTime(), name, route, laneSelectionMode, lane,
+                    departConnectionIndex, pos, type.getPrototype(), departSpeed, type.getAppList());
             framework.getRti().triggerInteraction(interaction);
         } catch (IllegalValueException e) {
             LOG.error("Couldn't send an {} interaction in VehicleStreamGenerator.timeAdvance()", interaction.getTypeId(), e);
@@ -454,7 +454,7 @@ public class VehicleFlowGenerator {
                 .append("spawningMode", spawningMode)
                 .append("lanes", lanes)
                 .append("types", types)
-                .append("departureConnectionIndex", departureConnectionIndex)
+                .append("departConnectionIndex", departConnectionIndex)
                 .append("pos", pos)
                 .append("departSpeed", departSpeed)
                 .append("route", route)

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -158,7 +158,7 @@ public class VehicleFlowGenerator {
             this.odInfo = null;
         }
 
-        LOG.debug("New VehicleStreamGenerator created: " + this);
+        LOG.info("Creating VehicleFlowGenerator: {}", this);
     }
 
     private List<VehicleTypeSpawner> createPrototypes(CVehicle vehicleConfiguration) {
@@ -321,7 +321,7 @@ public class VehicleFlowGenerator {
 
     void fillInPrototype(SpawningFramework framework) {
         for (VehicleTypeSpawner vehicleTypeSpawner : types) {
-            CPrototype prototypeConfiguration = framework.getPrototypeByName(vehicleTypeSpawner.getPrototype());
+            CPrototype prototypeConfiguration = framework.getPrototypeByName(vehicleTypeSpawner.getPrototypeName());
             if (prototypeConfiguration == null) {
                 continue;
             }
@@ -331,16 +331,16 @@ public class VehicleFlowGenerator {
 
     void collectVehicleTypes(HashMap<String, VehicleType> types) {
         for (VehicleTypeSpawner vehicleTypeSpawner : this.types) {
-            String key = vehicleTypeSpawner.getPrototype();
+            String key = vehicleTypeSpawner.getPrototypeName();
             if (types.containsKey(key) && (vehicleTypeSpawner.convertType().equals(types.get(key)))) {
                 continue;
             }
             if ((key == null) || types.containsKey(key)) {
-                key = UnitNameGenerator.nextPrototypeName(vehicleTypeSpawner.getPrototype());
-                vehicleTypeSpawner.setPrototype(key);
+                key = UnitNameGenerator.nextPrototypeName(vehicleTypeSpawner.getPrototypeName());
+                vehicleTypeSpawner.setPrototypeName(key);
             }
             types.put(key, vehicleTypeSpawner.convertType());
-            LOG.trace("Registering Vehicle Type: " + key + ": " + types.get(key));
+            LOG.info("Registering Vehicle Type: {}", types.get(key));
         }
     }
 
@@ -353,7 +353,6 @@ public class VehicleFlowGenerator {
      */
     boolean timeAdvance(SpawningFramework framework) throws InternalFederateException {
         // to reduce load, first handle everything that might stop execution
-        // =================================================================
         if (!spawningMode.isSpawningActive(framework.getTime())) {
             return true;
         }
@@ -363,9 +362,7 @@ public class VehicleFlowGenerator {
             return true;
         }
         // now determine if a vehicle has to be spawned
-        // =================================================================
-        // init some variables on the first time advance
-        if (nextSpawnTime == -1) {
+        if (nextSpawnTime == -1) { // init some variables before the first time advance
             nextSpawnTime = spawningMode.getNextSpawningTime(framework.getTime());
             try {
                 framework.getRti().requestAdvanceTime(nextSpawnTime);
@@ -429,18 +426,18 @@ public class VehicleFlowGenerator {
         Interaction interaction;
         if (origin != null) {
             interaction = new RoutelessVehicleRegistration(
-                    framework.getTime(), name, spawningGroup, type.getAppList(), vehicleDeparture, type.convertType(), odInfo
+                    framework.getTime(), name, spawningGroup, type.getApplications(), vehicleDeparture, type.convertType(), odInfo
             );
         } else {
-            interaction = new VehicleRegistration(framework.getTime(), name, spawningGroup, type.getAppList(), vehicleDeparture,
+            interaction = new VehicleRegistration(framework.getTime(), name, spawningGroup, type.getApplications(), vehicleDeparture,
                     type.convertTypeAndVaryParameters(randomNumberGenerator)
             );
         }
 
         try {
-            LOG.info("Creating Vehicle. time={}, name={}, route={}, laneSelectionMode={}, lane={}, departConnectionIndex={}, pos={}, type={}, departSpeed={}, apps={}",
+            LOG.info("Creating Vehicle: time={},name={},route={},laneSelectionMode={},lane={},departConnectionIndex={},pos={},type={},departSpeed={},applications={}",
                     framework.getTime(), name, route, laneSelectionMode, lane,
-                    departConnectionIndex, pos, type.getPrototype(), departSpeed, type.getAppList());
+                    departConnectionIndex, pos, type.getPrototypeName(), departSpeed, type.getApplications());
             framework.getRti().triggerInteraction(interaction);
         } catch (IllegalValueException e) {
             LOG.error("Couldn't send an {} interaction in VehicleStreamGenerator.timeAdvance()", interaction.getTypeId(), e);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/ChargingStationSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/ChargingStationSpawner.java
@@ -26,11 +26,14 @@ import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Class responsible for configuring Charging Stations to be added to the simulation.
@@ -65,7 +68,7 @@ public class ChargingStationSpawner extends UnitSpawner implements Spawner {
 
     /**
      * Called by the {@link SpawningFramework} used to initialize the
-     * Road Side Units for the simulation.
+     * Charging Stations for the simulation.
      *
      * @param spawningFramework the framework handling the spawning
      * @throws InternalFederateException thrown if {@link ChargingStationRegistration} couldn't be handled by rti
@@ -83,9 +86,9 @@ public class ChargingStationSpawner extends UnitSpawner implements Spawner {
             id++;
         }
         ChargingStationRegistration chargingStationRegistration =
-                new ChargingStationRegistration(0, chargingStationName, group, getAppList(), position, chargingSpots);
+                new ChargingStationRegistration(0, chargingStationName, group, getApplications(), position, chargingSpots);
         try {
-            LOG.info("Creating Charging Station " + this);
+            LOG.info("Creating Charging Station: {}", this);
             spawningFramework.getRti().triggerInteraction(chargingStationRegistration);
         } catch (IllegalValueException e) {
             LOG.error("Exception while sending ChargingStationRegistration interaction in ChargingStationSpawner.init()");
@@ -96,33 +99,15 @@ public class ChargingStationSpawner extends UnitSpawner implements Spawner {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("@position: ")
-                .append(position)
-                .append(", charging spots: ");
-
-        String delimiter = "";
-        int id = 0;
-        for (CChargingSpot chargingSpotConfiguration : chargingSpotConfigurations) {
-            sb.append(delimiter)
-                    .append("[chargingSpotId: ")
-                    .append(id)
-                    .append(", chargingType: ")
-                    .append(chargingSpotConfiguration.chargingType)
-                    .append("]");
-            delimiter = ", ";
-            id++;
-        }
-
-        sb.append("] with apps: ");
-
-        delimiter = "";
-        for (String application : getAppList()) {
-            sb.append(delimiter).append(application);
-            delimiter = ", ";
-        }
-
-        return sb.toString();
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("position", position)
+                .append("chargingSpots",
+                        chargingSpotConfigurations.stream()
+                                .map(chargingSpot ->
+                                        "chargingSpot(" + chargingSpotConfigurations.indexOf(chargingSpot) + ")=" + chargingSpot.toString())
+                                .collect(Collectors.toList())
+                )
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/RoadSideUnitSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/RoadSideUnitSpawner.java
@@ -23,7 +23,8 @@ import org.eclipse.mosaic.lib.objects.UnitNameGenerator;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,9 +61,9 @@ public class RoadSideUnitSpawner extends UnitSpawner implements Spawner {
      */
     public void init(SpawningFramework spawningFramework) throws InternalFederateException {
         String name = UnitNameGenerator.nextRsuName();
-        RsuRegistration interaction = new RsuRegistration(0, name, group, getAppList(), this.position);
+        RsuRegistration interaction = new RsuRegistration(0, name, group, getApplications(), this.position);
         try {
-            LOG.info("Creating RSU " + this.toString());
+            LOG.info("Creating RSU: {}", this);
             spawningFramework.getRti().triggerInteraction(interaction);
         } catch (IllegalValueException e) {
             LOG.error("Exception while sending Interaction in RoadSideUnitSpawner.init()");
@@ -72,6 +73,9 @@ public class RoadSideUnitSpawner extends UnitSpawner implements Spawner {
 
     @Override
     public String toString() {
-        return "@" + position + " with apps: " + StringUtils.join(applications, ",");
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("position", position)
+                .append("applications", applications)
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/ServerSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/ServerSpawner.java
@@ -22,7 +22,8 @@ import org.eclipse.mosaic.lib.objects.UnitNameGenerator;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,7 @@ public class ServerSpawner extends UnitSpawner implements Spawner {
 
     /**
      * Constructor for {@link ServerSpawner} using configuration
-     * to construct spawning object used by specialized servers (e.g. TMCs
+     * to construct spawning object used by specialized servers (i.e., TMCs)
      *
      * @param applications list of applications
      * @param name         name of the unit
@@ -70,9 +71,9 @@ public class ServerSpawner extends UnitSpawner implements Spawner {
     @Override
     public void init(SpawningFramework spawningFramework) throws InternalFederateException {
         String name = UnitNameGenerator.nextServerName();
-        ServerRegistration interaction = new ServerRegistration(0, name, group, getAppList());
+        ServerRegistration interaction = new ServerRegistration(0, name, group, getApplications());
         try {
-            LOG.info("Creating Server " + this.toString());
+            LOG.info("Creating Server: {}", this);
             spawningFramework.getRti().triggerInteraction(interaction);
         } catch (IllegalValueException e) {
             LOG.error("Exception while sending Interaction in ServerSpawner.init()");
@@ -82,6 +83,8 @@ public class ServerSpawner extends UnitSpawner implements Spawner {
 
     @Override
     public String toString() {
-        return " with apps: " + StringUtils.join(applications, ",");
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("applications", applications)
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/TrafficManagementCenterSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/TrafficManagementCenterSpawner.java
@@ -22,6 +22,8 @@ import org.eclipse.mosaic.lib.objects.UnitNameGenerator;
 import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,9 +66,9 @@ public class TrafficManagementCenterSpawner extends ServerSpawner {
      */
     public void init(SpawningFramework spawningFramework) throws InternalFederateException {
         String name = UnitNameGenerator.nextTmcName();
-        TmcRegistration interaction = new TmcRegistration(0, name, group, getAppList(), getInductionLoopList(), getLaneAreaList());
+        TmcRegistration interaction = new TmcRegistration(0, name, group, getApplications(), getInductionLoopList(), getLaneAreaList());
         try {
-            LOG.info("Creating TMC " + this.toString());
+            LOG.info("Creating TMC: {}", this);
             spawningFramework.getRti().triggerInteraction(interaction);
         } catch (IllegalValueException e) {
             LOG.error("Exception while sending Interaction in TrafficManagementCenterSpawner.init()");
@@ -92,5 +94,14 @@ public class TrafficManagementCenterSpawner extends ServerSpawner {
      */
     private List<String> getLaneAreaList() {
         return laneAreaDetectors == null ? new ArrayList<>() : new ArrayList<>(laneAreaDetectors);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("inductionLoopDetectors", inductionLoopDetectors)
+                .append("laneAreaDetectors", laneAreaDetectors)
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/UnitSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/UnitSpawner.java
@@ -18,10 +18,14 @@ package org.eclipse.mosaic.fed.mapping.ambassador.spawning;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * This class is to be extended by all classes, that are supposed to
@@ -32,11 +36,11 @@ abstract class UnitSpawner {
     /**
      * All applications defined for a unit.
      */
-    List<String> applications;
+    List<String> applications = new ArrayList<>();
     /**
      * The prototype of the unit.
      */
-    String prototype;
+    String prototypeName;
     /**
      * The group of the unit.
      */
@@ -45,26 +49,34 @@ abstract class UnitSpawner {
     /**
      * Constructor for {@link UnitSpawner}.
      *
-     * @param applications String representation of all applications added to the unit
-     * @param prototype    the name of the prototype of the unit
-     * @param group        the name of the group the unit belongs to
+     * @param applications  String representation of all applications added to the unit
+     * @param prototypeName the name of the prototype of the unit
+     * @param group         the name of the group the unit belongs to
      */
-    UnitSpawner(List<String> applications, String prototype, String group) {
+    UnitSpawner(List<String> applications, String prototypeName, String group) {
         if (applications != null) {
             // add all applications, remove the ones that are null
-            this.applications = applications;
-            this.applications.removeAll(Collections.singleton(null));
+            this.applications.addAll(applications.stream().filter(Objects::nonNull).collect(Collectors.toList()));
         }
-        this.prototype = prototype;
+        this.prototypeName = prototypeName;
         this.group = group;
     }
 
-    public String getPrototype() {
-        return prototype;
+    public String getPrototypeName() {
+        return prototypeName;
     }
 
     public String getGroup() {
         return group;
+    }
+
+    /**
+     * This method provides a view of the applications.
+     *
+     * @return A view of {@link #applications}
+     */
+    public List<String> getApplications() {
+        return Collections.unmodifiableList(applications);
     }
 
     /**
@@ -80,26 +92,21 @@ abstract class UnitSpawner {
             return;
         }
 
-        if ((applications == null) && (prototypeConfiguration.applications != null)) {
+        if (applications.isEmpty() && prototypeConfiguration.applications != null) {
             // inherit applications from prototype, dismiss all applications set as null
-            applications = new ArrayList<>();
-            applications.addAll(prototypeConfiguration.applications);
-            applications.removeAll(Collections.singleton(null));
+            applications.addAll(prototypeConfiguration.applications.stream().filter(Objects::nonNull).collect(Collectors.toList()));
         }
 
         // No group name given, try to use the CPrototype group name
         group = ObjectUtils.defaultIfNull(group, prototypeConfiguration.group);
     }
 
-    /**
-     * This method makes sure the returned application list
-     * is never null and instead returns a new {@link ArrayList},
-     * also this method always returns a copy of the applications.
-     *
-     * @return empty {@link ArrayList} if {@link #applications} equals {@code null} else returns a new
-     * {@link ArrayList} with the content of {@link #applications}
-     */
-    public List<String> getAppList() {
-        return applications == null ? new ArrayList<>() : new ArrayList<>(applications);
+    @Override
+    public String toString() {
+        return new ToStringBuilder(ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("protoTypeName", prototypeName)
+                .append("group", group)
+                .append("applications", applications)
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/UnitSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/UnitSpawner.java
@@ -36,7 +36,7 @@ abstract class UnitSpawner {
     /**
      * All applications defined for a unit.
      */
-    List<String> applications = new ArrayList<>();
+    final List<String> applications = new ArrayList<>();
     /**
      * The prototype of the unit.
      */

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
@@ -26,9 +26,10 @@ import org.eclipse.mosaic.lib.enums.VehicleClass;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.Objects;
 
@@ -263,7 +264,10 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
 
     @Override
     public String toString() {
-        return "Vehicle: name=" + prototype + ", apps=" + StringUtils.join(applications, ",");
+        return new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE)
+                .append("name", prototype)
+                .append("apps", applications)
+                .build();
     }
 
     @Override

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
@@ -157,7 +157,7 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
         if (deviations == null) {
             return convertType();
         }
-        return new VehicleType(prototype,
+        return new VehicleType(prototypeName,
                 deviateWithBounds(random, length, deviations.length),
                 deviateWithBounds(random, width, deviations.width),
                 deviateWithBounds(random, height, deviations.height),
@@ -183,8 +183,8 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
         return mean;
     }
 
-    public void setPrototype(String prototype) {
-        this.prototype = prototype;
+    public void setPrototypeName(String prototypeName) {
+        this.prototypeName = prototypeName;
     }
 
     public double getWeight() {
@@ -202,7 +202,7 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
      */
     public VehicleType convertType() {
         return new VehicleType(
-                prototype,
+                prototypeName,
                 length,
                 width,
                 height,
@@ -265,7 +265,7 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE)
-                .append("name", prototype)
+                .append("name", prototypeName)
                 .append("apps", applications)
                 .build();
     }
@@ -273,7 +273,7 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
     @Override
     public int hashCode() {
         return new HashCodeBuilder(1, 31)
-                .append(prototype)
+                .append(prototypeName)
                 .append(applications)
                 .append(group)
                 .append(weight)
@@ -309,7 +309,7 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
         }
         VehicleTypeSpawner other = (VehicleTypeSpawner) obj;
         return new EqualsBuilder()
-                .append(prototype, other.prototype)
+                .append(prototypeName, other.prototypeName)
                 .append(applications, other.applications)
                 .append(group, other.group)
                 .append(weight, other.weight)

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/flow/ConstantSpawningMode.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/flow/ConstantSpawningMode.java
@@ -19,6 +19,9 @@ package org.eclipse.mosaic.fed.mapping.ambassador.spawning.flow;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.rti.TIME;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 /**
  * The default mode of spawning vehicles with constant time gaps
  * based on a given target flow.
@@ -58,4 +61,10 @@ public class ConstantSpawningMode extends AbstractSpawningMode {
         return maximumFlow;
     }
 
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("timeSpacing", timeSpacing)
+                .build();
+    }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/flow/GrowAndShrinkSpawningMode.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/flow/GrowAndShrinkSpawningMode.java
@@ -20,6 +20,9 @@ import static java.lang.Math.max;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.rti.TIME;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 /**
  * This implementation of {@link SpawningMode} spawns the vehicles in a
  * way where first the flow is increased, then it stays constant and afterwards
@@ -83,5 +86,14 @@ public class GrowAndShrinkSpawningMode implements SpawningMode {
             nextSpawningTime = decreaseMode.getNextSpawningTime(currentTime);
         }
         return max(nextSpawningTime, currentTime + 10 * TIME.MILLI_SECOND);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("endIncrease", endIncrease)
+                .append("endConstant", endConstant)
+                .append("endDecrease", endDecrease)
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/flow/PoissonSpawningMode.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/flow/PoissonSpawningMode.java
@@ -18,6 +18,9 @@ package org.eclipse.mosaic.fed.mapping.ambassador.spawning.flow;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.rti.TIME;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import javax.annotation.Nullable;
 
 /**
@@ -61,5 +64,13 @@ public class PoissonSpawningMode implements SpawningMode {
         long step = (long) (Math.log(1 - (rng.nextDouble())) / (-lambda));
         nextSpawnTime += step;
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("spawningEndTime", spawningEndTime)
+                .append("lambda", lambda)
+                .build();
     }
 }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CChargingStation.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CChargingStation.java
@@ -16,8 +16,10 @@
 package org.eclipse.mosaic.fed.mapping.config.units;
 
 import org.eclipse.mosaic.lib.geo.GeoPoint;
-import org.eclipse.mosaic.lib.objects.electricity.ChargingSpot;
 import org.eclipse.mosaic.lib.objects.electricity.ChargingType;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import java.util.List;
 
@@ -46,6 +48,16 @@ public class CChargingStation {
          * The maximal current this charging spot can deliver.
          */
         public double maxCurrent;
+
+        @Override
+        public String toString() {
+            // NO_CLASS_NAME_STYLE for better formatting in ChargingStationSpawner
+            return new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE)
+                    .append("chargingType", chargingType)
+                    .append("maxVoltage", maxVoltage)
+                    .append("maxCurrent", maxCurrent)
+                    .build();
+        }
     }
 
     /**

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CServer.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CServer.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 public class CServer {
     /**
-     * The name of the tmc to be matched against this object. All
+     * The name of the server to be matched against this object. All
      * properties which are not specified will then be replaced.
      */
     public String name;

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawnerTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawnerTest.java
@@ -38,7 +38,7 @@ public class VehicleTypeSpawnerTest {
         VehicleTypeSpawner vehicleType = new VehicleTypeSpawner(a);
 
         //PRE-ASSERT
-        assertEquals("Car", vehicleType.getPrototype());
+        assertEquals("Car", vehicleType.getPrototypeName());
         assertEquals(VehicleClass.AutomatedVehicle, vehicleType.getVehicleClass());
         assertEquals(100d, vehicleType.convertType().getMaxSpeed(), 0.1d);
         assertNull(vehicleType.getGroup());
@@ -53,7 +53,7 @@ public class VehicleTypeSpawnerTest {
         vehicleType.fillInPrototype(b);
 
         //ASSERT
-        assertEquals("Car", vehicleType.getPrototype());
+        assertEquals("Car", vehicleType.getPrototypeName());
         assertEquals(VehicleClass.AutomatedVehicle, vehicleType.getVehicleClass());
         assertEquals(100d, vehicleType.convertType().getMaxSpeed(), 0.1d);
         assertEquals(0.8d, vehicleType.convertType().getTau(), 0.1d);


### PR DESCRIPTION
## Description
* This PR integrates minor improvements to the logging in the Mapping federate
* the `departureConnectionIndex` is now named `departConnectionIndex` and is properly separated with an "="
* prior to this apps were printed twice (once for the type and then again separately) -> this is now only logged once

Example of improved logging:

previous:
```
INFO  VehicleFlowGenerator - Creating Vehicle. time=5000000000, name=veh_3, route=1, laneSelectionMode=DEFAULT, lane=0, departureConnectionIndex0, pos=1417, type=Vehicle: name=Car, apps=org.eclipse.mosaic.app.tutorial.WeatherWarningAppCell,org.eclipse.mosaic.app.tutorial.SlowDownApp, departSpeed=0.0, apps=[org.eclipse.mosaic.app.tutorial.WeatherWarningAppCell, org.eclipse.mosaic.app.tutorial.SlowDownApp]
```

now:
```
INFO  VehicleFlowGenerator - Creating Vehicle. time=5000000000, name=veh_3, route=1, laneSelectionMode=DEFAULT, lane=0, departConnectionIndex=0, pos=1417, type=Car, departSpeed=0.0, apps=[org.eclipse.mosaic.app.tutorial.WeatherWarningAppCell, org.eclipse.mosaic.app.tutorial.SlowDownApp]

```

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

