### PR TITLE
fix(perception): Re-enable the perception of unequipped vehicles

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
@@ -360,7 +360,15 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
     }
 
     private void process(final VehicleRegistration vehicleRegistration) {
-        vehicleRegistrations.put(vehicleRegistration.getMapping().getName(), vehicleRegistration);
+        String vehicleName = vehicleRegistration.getMapping().getName();
+        vehicleRegistrations.put(vehicleName, vehicleRegistration);
+
+        // register vehicle type for perception
+        String vehicleTypeName = vehicleRegistration.getMapping().getVehicleType().getName();
+        SimulationKernel.SimulationKernel.getVehicleTypes().putIfAbsent(
+                vehicleTypeName, vehicleRegistration.getMapping().getVehicleType()
+        );
+        SimulationKernel.SimulationKernel.getCentralPerceptionComponent().registerVehicleType(vehicleName, vehicleTypeName);
     }
 
     private void process(final RoutelessVehicleRegistration routelessVehicleRegistration) {
@@ -678,7 +686,6 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
         final VehicleRegistration vehicleRegistration = vehicleRegistrations.remove(unitName);
         if (vehicleRegistration != null) {
             UnitSimulator.UnitSimulator.registerVehicle(time, vehicleRegistration);
-            SimulationKernel.SimulationKernel.getCentralPerceptionComponent().addVehicle(vehicleRegistration);
         }
     }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
@@ -362,13 +362,9 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
     private void process(final VehicleRegistration vehicleRegistration) {
         String vehicleName = vehicleRegistration.getMapping().getName();
         vehicleRegistrations.put(vehicleName, vehicleRegistration);
-
         // register vehicle type for perception
-        String vehicleTypeName = vehicleRegistration.getMapping().getVehicleType().getName();
-        SimulationKernel.SimulationKernel.getVehicleTypes().putIfAbsent(
-                vehicleTypeName, vehicleRegistration.getMapping().getVehicleType()
-        );
-        SimulationKernel.SimulationKernel.getCentralPerceptionComponent().registerVehicleType(vehicleName, vehicleTypeName);
+        SimulationKernel.SimulationKernel.getCentralPerceptionComponent()
+                .registerVehicleType(vehicleName, vehicleRegistration.getMapping().getVehicleType());
     }
 
     private void process(final RoutelessVehicleRegistration routelessVehicleRegistration) {

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/CentralPerceptionComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/CentralPerceptionComponent.java
@@ -22,7 +22,6 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.TrafficLightMap;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.VehicleMap;
 import org.eclipse.mosaic.fed.application.config.CApplicationAmbassador;
-import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.interactions.traffic.TrafficLightUpdates;
 import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
 import org.eclipse.mosaic.lib.geo.CartesianRectangle;
@@ -156,12 +155,14 @@ public class CentralPerceptionComponent {
     }
 
     /**
-     * Store new vehicle registration of Vehicle.
+     * Registers a vehicle and stores its corresponding vehicle type by name.
+     * This is required to extract vehicle dimensions.
      *
-     * @param vehicleRegistration the interaction holding information about the spawnend vehicle
+     * @param vehicleId       id of the vehicle to register
+     * @param vehicleTypeName name of the vehicle type
      */
-    public void addVehicle(VehicleRegistration vehicleRegistration) {
-        trafficObjectIndex.addVehicle(vehicleRegistration);
+    public void registerVehicleType(String vehicleId, String vehicleTypeName) {
+        trafficObjectIndex.registerVehicleType(vehicleId, vehicleTypeName);
     }
 
     /**
@@ -217,11 +218,6 @@ public class CentralPerceptionComponent {
                         .restart();
                 return super.getVehiclesInRange(searchRange);
             }
-        }
-
-        @Override
-        public void addVehicle(VehicleRegistration vehicleRegistration) {
-            super.addVehicle(vehicleRegistration);
         }
 
         @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/CentralPerceptionComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/CentralPerceptionComponent.java
@@ -28,6 +28,7 @@ import org.eclipse.mosaic.lib.geo.CartesianRectangle;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroupInfo;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.lib.util.PerformanceMonitor;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
@@ -158,11 +159,11 @@ public class CentralPerceptionComponent {
      * Registers a vehicle and stores its corresponding vehicle type by name.
      * This is required to extract vehicle dimensions.
      *
-     * @param vehicleId       id of the vehicle to register
-     * @param vehicleTypeName name of the vehicle type
+     * @param vehicleId   id of the vehicle to register
+     * @param vehicleType the vehicle type of the vehicle
      */
-    public void registerVehicleType(String vehicleId, String vehicleTypeName) {
-        trafficObjectIndex.registerVehicleType(vehicleId, vehicleTypeName);
+    public void registerVehicleType(String vehicleId, VehicleType vehicleType) {
+        trafficObjectIndex.registerVehicleType(vehicleId, vehicleType);
     }
 
     /**

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SumoPerceptionModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SumoPerceptionModule.java
@@ -53,7 +53,6 @@ public class SumoPerceptionModule extends AbstractPerceptionModule {
                         .setSpeed(v.getSpeed())
                         .setHeading(v.getHeading())
                         .setDimensions(v.getLength(), v.getWidth(), v.getHeight())
-                        .setInitialized()
                 ).collect(Collectors.toList());
     }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/TrafficObjectIndex.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/TrafficObjectIndex.java
@@ -20,7 +20,6 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.objects.VehicleObject;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.TrafficLightIndex;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.VehicleIndex;
-import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroupInfo;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
@@ -77,15 +76,17 @@ public class TrafficObjectIndex {
     }
 
     /**
-     * Adds a vehicle to the {@link TrafficObjectIndex}.
+     * Registers a vehicle and stores its corresponding vehicle type by name.
+     * This is required to extract vehicle dimensions.
      *
-     * @param vehicleRegistration The interaction containing information about the spawned vehicles
+     * @param vehicleId       id of the vehicle to register
+     * @param vehicleTypeName name of the vehicle type
      */
-    public void addVehicle(VehicleRegistration vehicleRegistration) {
+    public void registerVehicleType(String vehicleId, String vehicleTypeName) {
         if (vehicleIndexProviderConfigured()) {
-            vehicleIndex.addVehicle(vehicleRegistration);
+            vehicleIndex.registerVehicleType(vehicleId, vehicleTypeName);
         } else {
-            log.debug("No Vehicle Index Provider configured. No Vehicle will be added.");
+            log.debug("No Vehicle Index Provider configured. Vehicle Type won't be registered.");
         }
     }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/TrafficObjectIndex.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/TrafficObjectIndex.java
@@ -23,6 +23,7 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroupInfo;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 
 import org.slf4j.Logger;
 
@@ -80,11 +81,11 @@ public class TrafficObjectIndex {
      * This is required to extract vehicle dimensions.
      *
      * @param vehicleId       id of the vehicle to register
-     * @param vehicleTypeName name of the vehicle type
+     * @param vehicleType the vehicle type of the vehicle
      */
-    public void registerVehicleType(String vehicleId, String vehicleTypeName) {
+    public void registerVehicleType(String vehicleId, VehicleType vehicleType) {
         if (vehicleIndexProviderConfigured()) {
-            vehicleIndex.registerVehicleType(vehicleId, vehicleTypeName);
+            vehicleIndex.registerVehicleType(vehicleId, vehicleType);
         } else {
             log.debug("No Vehicle Index Provider configured. Vehicle Type won't be registered.");
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/VehicleObject.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/VehicleObject.java
@@ -52,11 +52,6 @@ public class VehicleObject extends SpatialObject<VehicleObject> {
      */
     private double height;
 
-    /**
-     * Before the first vehicle update is received vehicles have no valid positions.
-     */
-    private boolean isInitialized = false;
-
     public VehicleObject(String id) {
         super(id);
     }
@@ -118,15 +113,6 @@ public class VehicleObject extends SpatialObject<VehicleObject> {
 
     public double getHeight() {
         return height;
-    }
-
-    public VehicleObject setInitialized() {
-        this.isInitialized = true;
-        return this;
-    }
-
-    public boolean isInitialized() {
-        return isInitialized;
     }
 
     @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/SumoIndex.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/SumoIndex.java
@@ -41,6 +41,20 @@ public class SumoIndex extends VehicleIndex {
     }
 
     @Override
+    void onVehicleAdded(VehicleObject vehicleObject) {
+    }
+
+    @Override
+    void onIndexUpdate() {
+
+    }
+
+    @Override
+    void onVehicleRemoved(VehicleObject vehicleObject) {
+
+    }
+
+    @Override
     public void removeVehicles(Iterable<String> vehiclesToRemove) {
 
     }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/TrafficLightMap.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/TrafficLightMap.java
@@ -15,15 +15,10 @@
 
 package org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers;
 
-import org.eclipse.mosaic.fed.application.ambassador.SimulationKernel;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.PerceptionModel;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.objects.TrafficLightObject;
-import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
-import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroupInfo;
-import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightState;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class TrafficLightMap extends TrafficLightIndex {
@@ -41,40 +36,8 @@ public class TrafficLightMap extends TrafficLightIndex {
     }
 
     @Override
-    public void addTrafficLight(TrafficLightGroup trafficLightGroup) {
-        String trafficLightGroupId = trafficLightGroup.getGroupId();
-        trafficLightGroup.getTrafficLights().forEach(
-                (trafficLight) -> {
-                    String trafficLightId = calculateTrafficLightId(trafficLightGroupId, trafficLight.getId());
-                    if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds()
-                            .contains(trafficLight.getPosition().toCartesian())) { // check if inside bounding area
-                        indexedTrafficLights.computeIfAbsent(trafficLightId, TrafficLightObject::new)
-                                .setTrafficLightGroupId(trafficLightGroupId)
-                                .setPosition(trafficLight.getPosition().toCartesian())
-                                .setIncomingLane(trafficLight.getIncomingLane())
-                                .setOutgoingLane(trafficLight.getOutgoingLane())
-                                .setTrafficLightState(trafficLight.getCurrentState());
-                    }
-                }
-        );
+    public void onTrafficLightsUpdate() {
+        // nothing to do on update
     }
 
-    @Override
-    public void updateTrafficLights(Map<String, TrafficLightGroupInfo> trafficLightGroupsToUpdate) {
-        trafficLightGroupsToUpdate.forEach(
-                (trafficLightGroupId, trafficLightGroupInfo) -> {
-                    List<TrafficLightState> trafficLightStates = trafficLightGroupInfo.getCurrentState();
-                    for (int i = 0; i < trafficLightStates.size(); i++) {
-                        String trafficLightId = calculateTrafficLightId(trafficLightGroupId, i);
-                        final TrafficLightState trafficLightState = trafficLightStates.get(i);
-                        indexedTrafficLights.computeIfPresent(trafficLightId, (id, trafficLightObject)
-                                -> trafficLightObject.setTrafficLightState(trafficLightState));
-                    }
-                }
-        );
-    }
-
-    private String calculateTrafficLightId(String trafficLightGroupId, int trafficLightIndex) {
-        return trafficLightGroupId + "_" + trafficLightIndex;
-    }
 }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleGrid.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleGrid.java
@@ -67,6 +67,16 @@ public class VehicleGrid extends VehicleIndex {
     }
 
     @Override
+    protected VehicleObject addOrGetVehicle(VehicleData vehicleData) {
+        boolean isNew = !indexedVehicles.containsKey(vehicleData.getName());
+        VehicleObject vehicleObject = super.addOrGetVehicle(vehicleData);
+        if (isNew) {
+            vehicleGrid.addItem(vehicleObject);
+        }
+        return vehicleObject;
+    }
+
+    @Override
     public void removeVehicles(Iterable<String> vehiclesToRemove) {
         vehiclesToRemove.forEach(v -> {
             VehicleObject vehicleObject = indexedVehicles.remove(v);
@@ -81,15 +91,7 @@ public class VehicleGrid extends VehicleIndex {
         vehiclesToUpdate.forEach(v -> {
             CartesianPoint vehiclePosition = v.getProjectedPosition();
             if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds().contains(vehiclePosition)) { // check if inside bounding area
-                VehicleObject vehicleObject = indexedVehicles.get(v.getName());
-                if (vehicleObject == null) { // this should never be the case as vehicle registrations for all vehicles should be received
-                    return;
-                }
-                if (!vehicleObject.isInitialized()) { // if this is the first update for a vehicle, add vehicle to grid
-                    vehicleObject.setPosition(vehiclePosition).setInitialized();
-                    vehicleGrid.addItem(vehicleObject);
-                }
-                vehicleObject
+                VehicleObject vehicleObject = addOrGetVehicle(v)
                         .setHeading(v.getHeading())
                         .setSpeed(v.getSpeed())
                         .setPosition(vehiclePosition);

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleGrid.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleGrid.java
@@ -24,9 +24,7 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.objects.VehicleObject;
 import org.eclipse.mosaic.fed.application.app.api.perception.PerceptionModule;
 import org.eclipse.mosaic.lib.database.Database;
-import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.CartesianRectangle;
-import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.spatial.BoundingBox;
 import org.eclipse.mosaic.lib.spatial.Grid;
 import org.eclipse.mosaic.lib.util.gson.UnitFieldAdapter;
@@ -67,47 +65,18 @@ public class VehicleGrid extends VehicleIndex {
     }
 
     @Override
-    protected VehicleObject addOrGetVehicle(VehicleData vehicleData) {
-        boolean isNew = !indexedVehicles.containsKey(vehicleData.getName());
-        VehicleObject vehicleObject = super.addOrGetVehicle(vehicleData);
-        if (isNew) {
-            vehicleGrid.addItem(vehicleObject);
-        }
-        return vehicleObject;
+    void onVehicleAdded(VehicleObject vehicleObject) {
+        vehicleGrid.addItem(vehicleObject);
     }
 
     @Override
-    public void removeVehicles(Iterable<String> vehiclesToRemove) {
-        vehiclesToRemove.forEach(v -> {
-            VehicleObject vehicleObject = indexedVehicles.remove(v);
-            if (vehicleObject != null) {
-                vehicleGrid.removeItem(vehicleObject);
-            }
-            unregisterVehicleType(v);
-        });
-    }
-
-    @Override
-    public void updateVehicles(Iterable<VehicleData> vehiclesToUpdate) {
-        vehiclesToUpdate.forEach(v -> {
-            CartesianPoint vehiclePosition = v.getProjectedPosition();
-            if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds().contains(vehiclePosition)) { // check if inside bounding area
-                VehicleObject vehicleObject = addOrGetVehicle(v)
-                        .setHeading(v.getHeading())
-                        .setSpeed(v.getSpeed())
-                        .setPosition(vehiclePosition);
-                if (v.getRoadPosition() != null) {
-                    vehicleObject.setEdgeAndLane(v.getRoadPosition().getConnectionId(), v.getRoadPosition().getLaneIndex());
-                }
-            } else { // if not inside or left bounding area
-                VehicleObject vehicleObject = indexedVehicles.remove(v.getName());
-                if (vehicleObject != null) {
-                    vehicleGrid.removeItem(vehicleObject);
-                }
-            }
-
-        });
+    void onIndexUpdate() {
         vehicleGrid.updateGrid();
+    }
+
+    @Override
+    void onVehicleRemoved(VehicleObject vehicleObject) {
+        vehicleGrid.removeItem(vehicleObject);
     }
 
     @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleGrid.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleGrid.java
@@ -83,6 +83,7 @@ public class VehicleGrid extends VehicleIndex {
             if (vehicleObject != null) {
                 vehicleGrid.removeItem(vehicleObject);
             }
+            unregisterVehicleType(v);
         });
     }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleIndex.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleIndex.java
@@ -61,12 +61,15 @@ public abstract class VehicleIndex implements Serializable {
             vehicleObject = new VehicleObject(vehicleId)
                     .setHeading(vehicleData.getHeading())
                     .setSpeed(vehicleData.getSpeed())
-                    .setPosition(vehicleData.getProjectedPosition())
-                    .setDimensions(
-                            vehicleType.getLength(),
-                            vehicleType.getWidth(),
-                            vehicleType.getHeight()
-                    );
+                    .setPosition(vehicleData.getProjectedPosition());
+
+            if (vehicleType != null) {
+                vehicleObject.setDimensions(
+                        vehicleType.getLength(),
+                        vehicleType.getWidth(),
+                        vehicleType.getHeight()
+                );
+            }
             indexedVehicles.put(vehicleId, vehicleObject);
         }
         return vehicleObject;

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleMap.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleMap.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers;
 
-import org.eclipse.mosaic.fed.application.ambassador.SimulationKernel;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.PerceptionModel;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.PerceptionModuleOwner;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.SimplePerceptionConfiguration;
@@ -24,7 +23,6 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.objects.VehicleObject;
 import org.eclipse.mosaic.fed.application.app.api.perception.PerceptionModule;
 import org.eclipse.mosaic.lib.database.Database;
-import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 
 import org.slf4j.Logger;
 
@@ -49,31 +47,18 @@ public class VehicleMap extends VehicleIndex {
     }
 
     @Override
-    public void removeVehicles(Iterable<String> vehiclesToRemove) {
-        vehiclesToRemove.forEach(v -> {
-                    indexedVehicles.remove(v);
-                    unregisterVehicleType(v);
-                }
-        );
+    void onVehicleAdded(VehicleObject vehicleObject) {
+        // do nothing
     }
 
     @Override
-    public void updateVehicles(Iterable<VehicleData> vehiclesToUpdate) {
-        vehiclesToUpdate.forEach(v -> {
-                    if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds()
-                            .contains(v.getProjectedPosition())) { // check if inside bounding area
-                        VehicleObject currentVehicle = addOrGetVehicle(v)
-                                .setHeading(v.getHeading())
-                                .setSpeed(v.getSpeed())
-                                .setPosition(v.getProjectedPosition());
-                        if (v.getRoadPosition() != null) {
-                            currentVehicle.setEdgeAndLane(v.getRoadPosition().getConnectionId(), v.getRoadPosition().getLaneIndex());
-                        }
-                    } else {
-                        indexedVehicles.remove(v.getName());
-                    }
-                }
-        );
+    void onIndexUpdate() {
+        // do nothing
+    }
+
+    @Override
+    void onVehicleRemoved(VehicleObject vehicleObject) {
+        // do nothing
     }
 
     @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleMap.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleMap.java
@@ -58,13 +58,10 @@ public class VehicleMap extends VehicleIndex {
         vehiclesToUpdate.forEach(v -> {
                     if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds()
                             .contains(v.getProjectedPosition())) { // check if inside bounding area
-                        VehicleObject currentVehicle = indexedVehicles.computeIfAbsent(v.getName(), VehicleObject::new)
+                        VehicleObject currentVehicle = addOrGetVehicle(v)
                                 .setHeading(v.getHeading())
                                 .setSpeed(v.getSpeed())
                                 .setPosition(v.getProjectedPosition());
-                        if (!currentVehicle.isInitialized()) { // if this is the first update for a vehicle set initialized
-                            currentVehicle.setInitialized();
-                        }
                         if (v.getRoadPosition() != null) {
                             currentVehicle.setEdgeAndLane(v.getRoadPosition().getConnectionId(), v.getRoadPosition().getLaneIndex());
                         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleMap.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleMap.java
@@ -50,7 +50,11 @@ public class VehicleMap extends VehicleIndex {
 
     @Override
     public void removeVehicles(Iterable<String> vehiclesToRemove) {
-        vehiclesToRemove.forEach(indexedVehicles::remove);
+        vehiclesToRemove.forEach(v -> {
+                    indexedVehicles.remove(v);
+                    unregisterVehicleType(v);
+                }
+        );
     }
 
     @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleTree.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleTree.java
@@ -93,6 +93,7 @@ public class VehicleTree extends VehicleIndex {
             if (vehicleObject != null) {
                 vehicleTree.removeObject(vehicleObject);
             }
+            unregisterVehicleType(v);
         });
     }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleTree.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleTree.java
@@ -24,9 +24,7 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.objects.VehicleObject;
 import org.eclipse.mosaic.fed.application.app.api.perception.PerceptionModule;
 import org.eclipse.mosaic.lib.database.Database;
-import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.CartesianRectangle;
-import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
 import org.eclipse.mosaic.lib.spatial.BoundingBox;
 import org.eclipse.mosaic.lib.spatial.QuadTree;
 
@@ -77,46 +75,18 @@ public class VehicleTree extends VehicleIndex {
     }
 
     @Override
-    protected VehicleObject addOrGetVehicle(VehicleData vehicleData) {
-        boolean isNew = !indexedVehicles.containsKey(vehicleData.getName());
-        VehicleObject vehicleObject = super.addOrGetVehicle(vehicleData);
-        if (isNew) {
-            vehicleTree.addItem(vehicleObject);
-        }
-        return vehicleObject;
+    void onVehicleAdded(VehicleObject vehicleObject) {
+        vehicleTree.addItem(vehicleObject);
     }
 
     @Override
-    public void removeVehicles(Iterable<String> vehiclesToRemove) {
-        vehiclesToRemove.forEach(v -> {
-            VehicleObject vehicleObject = indexedVehicles.remove(v);
-            if (vehicleObject != null) {
-                vehicleTree.removeObject(vehicleObject);
-            }
-            unregisterVehicleType(v);
-        });
-    }
-
-    @Override
-    public void updateVehicles(Iterable<VehicleData> vehiclesToUpdate) {
-        vehiclesToUpdate.forEach(v -> {
-            CartesianPoint vehiclePosition = v.getProjectedPosition();
-            if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds().contains(vehiclePosition)) { // check if inside bounding area
-                VehicleObject vehicleObject = addOrGetVehicle(v)
-                        .setHeading(v.getHeading())
-                        .setSpeed(v.getSpeed())
-                        .setPosition(vehiclePosition);
-                if (v.getRoadPosition() != null) { // if not inside or left bounding area
-                    vehicleObject.setEdgeAndLane(v.getRoadPosition().getConnectionId(), v.getRoadPosition().getLaneIndex());
-                }
-            } else { // if not inside or left bounding area
-                VehicleObject vehicleObject = indexedVehicles.remove(v.getName());
-                if (vehicleObject != null) {
-                    vehicleTree.removeObject(vehicleObject);
-                }
-            }
-        });
+    void onIndexUpdate() {
         vehicleTree.updateTree();
+    }
+
+    @Override
+    void onVehicleRemoved(VehicleObject vehicleObject) {
+        vehicleTree.removeObject(vehicleObject);
     }
 
     @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleTree.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/providers/VehicleTree.java
@@ -77,6 +77,16 @@ public class VehicleTree extends VehicleIndex {
     }
 
     @Override
+    protected VehicleObject addOrGetVehicle(VehicleData vehicleData) {
+        boolean isNew = !indexedVehicles.containsKey(vehicleData.getName());
+        VehicleObject vehicleObject = super.addOrGetVehicle(vehicleData);
+        if (isNew) {
+            vehicleTree.addItem(vehicleObject);
+        }
+        return vehicleObject;
+    }
+
+    @Override
     public void removeVehicles(Iterable<String> vehiclesToRemove) {
         vehiclesToRemove.forEach(v -> {
             VehicleObject vehicleObject = indexedVehicles.remove(v);
@@ -91,15 +101,7 @@ public class VehicleTree extends VehicleIndex {
         vehiclesToUpdate.forEach(v -> {
             CartesianPoint vehiclePosition = v.getProjectedPosition();
             if (SimulationKernel.SimulationKernel.getCentralPerceptionComponent().getScenarioBounds().contains(vehiclePosition)) { // check if inside bounding area
-                VehicleObject vehicleObject = indexedVehicles.get(v.getName());
-                if (vehicleObject == null) { // this should never be the case as vehicle registrations for all vehicles should be received
-                    return;
-                }
-                if (!vehicleObject.isInitialized()) { // if this is the first update for a vehicle, add vehicle to tree
-                    vehicleObject.setPosition(vehiclePosition).setInitialized();
-                    vehicleTree.addItem(vehicleObject);
-                }
-                vehicleObject
+                VehicleObject vehicleObject = addOrGetVehicle(v)
                         .setHeading(v.getHeading())
                         .setSpeed(v.getSpeed())
                         .setPosition(vehiclePosition);

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
@@ -78,6 +78,9 @@ public class PerceptionModifierTest {
     @Mock
     public VehicleData egoVehicleData;
 
+    @Mock
+    public VehicleType vehicleType;
+
     @Rule
     public SimulationKernelRule simulationKernelRule = new SimulationKernelRule(eventManagerMock, null, cncMock, cpcMock);
 
@@ -94,14 +97,20 @@ public class PerceptionModifierTest {
                 .thenReturn(new CartesianRectangle(new MutableCartesianPoint(-VIEWING_RANGE * 2, -VIEWING_RANGE * 2, 0),
                         new MutableCartesianPoint(VIEWING_RANGE * 2, VIEWING_ANGLE * 2, 0)));
         SimulationKernel.SimulationKernel.setConfiguration(new CApplicationAmbassador());
-
+        // register vehicleType
+        when(vehicleType.getName()).thenReturn("vType");
+        when(vehicleType.getLength()).thenReturn(5d);
+        when(vehicleType.getWidth()).thenReturn(2.5d);
+        when(vehicleType.getHeight()).thenReturn(10d);
+        SimulationKernel.SimulationKernel.getVehicleTypes().put(vehicleType.getName(), vehicleType);
         trafficObjectIndex = new TrafficObjectIndex.Builder(mock(Logger.class))
                 .withVehicleIndex(new VehicleMap())
                 .build();
         // setup cpc
         when(cpcMock.getTrafficObjectIndex()).thenReturn(trafficObjectIndex);
         // setup perception module
-        VehicleUnit egoVehicleUnit = spy(new VehicleUnit("veh_0", mock(VehicleType.class), null));
+        trafficObjectIndex.registerVehicleType("veh_0", vehicleType.getName());
+        VehicleUnit egoVehicleUnit = spy(new VehicleUnit("veh_0", vehicleType, null));
         doReturn(egoVehicleData).when(egoVehicleUnit).getVehicleData();
         simplePerceptionModule = spy(new SimplePerceptionModule(egoVehicleUnit, null, mock(Logger.class)));
         doReturn(simplePerceptionModule).when(egoVehicleUnit).getPerceptionModule();
@@ -204,10 +213,12 @@ public class PerceptionModifierTest {
         List<VehicleData> vehiclesInIndex = new ArrayList<>();
         int i = 1;
         for (CartesianPoint position : positions) {
+            String vehicleId = "veh_" + i++;
             VehicleData vehicleDataMock = mock(VehicleData.class);
             when(vehicleDataMock.getProjectedPosition()).thenReturn(position);
-            when(vehicleDataMock.getName()).thenReturn("veh_" + i++);
+            when(vehicleDataMock.getName()).thenReturn(vehicleId);
             vehiclesInIndex.add(vehicleDataMock);
+            trafficObjectIndex.registerVehicleType(vehicleId, vehicleType.getName());
         }
         trafficObjectIndex.updateVehicles(vehiclesInIndex);
     }

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
@@ -102,14 +102,13 @@ public class PerceptionModifierTest {
         when(vehicleType.getLength()).thenReturn(5d);
         when(vehicleType.getWidth()).thenReturn(2.5d);
         when(vehicleType.getHeight()).thenReturn(10d);
-        SimulationKernel.SimulationKernel.getVehicleTypes().put(vehicleType.getName(), vehicleType);
         trafficObjectIndex = new TrafficObjectIndex.Builder(mock(Logger.class))
                 .withVehicleIndex(new VehicleMap())
                 .build();
         // setup cpc
         when(cpcMock.getTrafficObjectIndex()).thenReturn(trafficObjectIndex);
         // setup perception module
-        trafficObjectIndex.registerVehicleType("veh_0", vehicleType.getName());
+        trafficObjectIndex.registerVehicleType("veh_0", vehicleType);
         VehicleUnit egoVehicleUnit = spy(new VehicleUnit("veh_0", vehicleType, null));
         doReturn(egoVehicleData).when(egoVehicleUnit).getVehicleData();
         simplePerceptionModule = spy(new SimplePerceptionModule(egoVehicleUnit, null, mock(Logger.class)));
@@ -218,7 +217,7 @@ public class PerceptionModifierTest {
             when(vehicleDataMock.getProjectedPosition()).thenReturn(position);
             when(vehicleDataMock.getName()).thenReturn(vehicleId);
             vehiclesInIndex.add(vehicleDataMock);
-            trafficObjectIndex.registerVehicleType(vehicleId, vehicleType.getName());
+            trafficObjectIndex.registerVehicleType(vehicleId, vehicleType);
         }
         trafficObjectIndex.updateVehicles(vehiclesInIndex);
     }

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -351,14 +351,12 @@ public class SimplePerceptionModuleTest {
             when(vehicleDataMock.getProjectedPosition()).thenReturn(position);
             when(vehicleDataMock.getName()).thenReturn(vehicleName);
             vehiclesInIndex.add(vehicleDataMock);
+
             VehicleType vehicleType = mock(VehicleType.class);
             when(vehicleType.getLength()).thenReturn(5d);
             when(vehicleType.getWidth()).thenReturn(2.5d);
             when(vehicleType.getHeight()).thenReturn(10d);
-            when(vehicleType.getName()).thenReturn("vType");
-
-            SimulationKernel.SimulationKernel.getVehicleTypes().put(vehicleType.getName(), vehicleType);
-            trafficObjectIndex.registerVehicleType(vehicleName, vehicleType.getName());
+            trafficObjectIndex.registerVehicleType(vehicleName, vehicleType);
         }
         trafficObjectIndex.updateVehicles(vehiclesInIndex);
     }

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -33,14 +33,12 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.VehicleMap;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.index.providers.VehicleTree;
 import org.eclipse.mosaic.fed.application.config.CApplicationAmbassador;
-import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.geo.CartesianRectangle;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.geo.MutableCartesianPoint;
 import org.eclipse.mosaic.lib.junit.GeoProjectionRule;
 import org.eclipse.mosaic.lib.junit.IpResolverRule;
-import org.eclipse.mosaic.lib.objects.mapping.VehicleMapping;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLight;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightProgram;
@@ -346,7 +344,6 @@ public class SimplePerceptionModuleTest {
 
     private void setupVehicles(CartesianPoint... positions) {
         List<VehicleData> vehiclesInIndex = new ArrayList<>();
-        List<VehicleRegistration> vehicleRegistrations = new ArrayList<>();
         int i = 1;
         for (CartesianPoint position : positions) {
             String vehicleName = "veh_" + i++;
@@ -354,18 +351,15 @@ public class SimplePerceptionModuleTest {
             when(vehicleDataMock.getProjectedPosition()).thenReturn(position);
             when(vehicleDataMock.getName()).thenReturn(vehicleName);
             vehiclesInIndex.add(vehicleDataMock);
-            VehicleRegistration vehicleRegistration = mock(VehicleRegistration.class);
-            VehicleMapping vehicleMapping = mock(VehicleMapping.class);
-            when(vehicleRegistration.getMapping()).thenReturn(vehicleMapping);
-            when(vehicleMapping.getName()).thenReturn(vehicleName);
             VehicleType vehicleType = mock(VehicleType.class);
-            when(vehicleMapping.getVehicleType()).thenReturn(vehicleType);
             when(vehicleType.getLength()).thenReturn(5d);
             when(vehicleType.getWidth()).thenReturn(2.5d);
             when(vehicleType.getHeight()).thenReturn(10d);
-            vehicleRegistrations.add(vehicleRegistration);
+            when(vehicleType.getName()).thenReturn("vType");
+
+            SimulationKernel.SimulationKernel.getVehicleTypes().put(vehicleType.getName(), vehicleType);
+            trafficObjectIndex.registerVehicleType(vehicleName, vehicleType.getName());
         }
-        vehicleRegistrations.forEach(vehicleRegistration -> trafficObjectIndex.addVehicle(vehicleRegistration));
         trafficObjectIndex.updateVehicles(vehiclesInIndex);
     }
 

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -33,6 +33,8 @@ import org.eclipse.mosaic.rti.config.CLocalHost.OperatingSystem;
 
 import org.apache.commons.lang3.ObjectUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -131,7 +133,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                 );
                 return;
             }
-
+            List<String> applications = prototype.applications == null ? new ArrayList<>() : prototype.applications;
             if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
                 log.debug(
                         "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
@@ -139,20 +141,20 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                         scenarioVehicle.getId(),
                         prototype.weight
                 );
-                return;
+                applications = new ArrayList<>();
             }
 
             final VehicleRegistration vehicleRegistration = new VehicleRegistration(
                     scenarioVehicle.getTime(),
                     scenarioVehicle.getName(),
                     prototype.group,
-                    prototype.applications,
+                    applications,
                     null,
                     new VehicleTypeSpawner(prototype).convertType()
             );
             try {
                 log.info("Mapping Scenario Vehicle. time={}, name={}, type={}, apps={}",
-                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleTypeId(), prototype.applications);
+                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleTypeId(), applications);
                 rti.triggerInteraction(vehicleRegistration);
             } catch (Exception e) {
                 throw new InternalFederateException(e);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -134,6 +134,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                 return;
             }
             List<String> applications = prototype.applications == null ? new ArrayList<>() : prototype.applications;
+            String group = prototype.group == null ? null : prototype.group;
             if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
                 log.debug(
                         "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
@@ -142,12 +143,13 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                         prototype.weight
                 );
                 applications = new ArrayList<>();
+                group = null;
             }
 
             final VehicleRegistration vehicleRegistration = new VehicleRegistration(
                     scenarioVehicle.getTime(),
                     scenarioVehicle.getName(),
-                    prototype.group,
+                    group,
                     applications,
                     null,
                     new VehicleTypeSpawner(prototype).convertType()

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -348,7 +348,7 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
                     iterator.remove();
                 }
             } catch (InternalFederateException e) {
-                log.warn("Vehicle with id: " + vehicleId + " could not be added.(" + e.getClass().getCanonicalName() + ")", e);
+                log.warn("Vehicle with id: {} could not be added.({})", vehicleId, e.getClass().getCanonicalName(), e);
                 if (sumoConfig.exitOnInsertionError) {
                     throw e;
                 }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/AbstractPerceptionModuleIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/AbstractPerceptionModuleIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public abstract class AbstractPerceptionModuleIT {
 
     @ClassRule
-    public static MosaicSimulationRule simulationRule = new MosaicSimulationRule().watchdog(0);
+    public static MosaicSimulationRule simulationRule = new MosaicSimulationRule();
 
     protected static MosaicSimulation.SimulationResult simulationResult;
 
@@ -43,15 +43,15 @@ public abstract class AbstractPerceptionModuleIT {
 
     @Test
     public void rightAmountOfVehiclesPerceived() throws Exception {
-        // perceived vehicles repeat their route 10 times resulting in 11 perceptions
-        assertEquals(19, LogAssert.count(simulationRule,
+        // perceived vehicles repeat their route 10 times resulting in 10 perceptions
+        assertEquals(10, LogAssert.count(simulationRule,
                 PERCEPTION_VEHICLE_LOG,
-                ".*Perceived all vehicles: \\[veh_[1-3], veh_[1-3], veh_[1-3]\\].*"));
+                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 1 without dimensions.*"));
     }
 
     @Test
     public void rightAmountOfTrafficLightPhaseSwitches() throws Exception {
         // perceived vehicles repeat their route 10 times resulting in 11 perceptions
-        LogAssert.contains(simulationRule, PERCEPTION_VEHICLE_LOG, ".*Traffic Light switched 12 times\\..*");
+        LogAssert.contains(simulationRule, PERCEPTION_VEHICLE_LOG, ".*Traffic Light switched 11 times\\..*");
     }
 }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/AbstractPerceptionModuleIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/AbstractPerceptionModuleIT.java
@@ -33,7 +33,7 @@ public abstract class AbstractPerceptionModuleIT {
 
     protected static MosaicSimulation.SimulationResult simulationResult;
 
-    private final static String PERCEPTION_VEHICLE_LOG = "apps/veh_0/SimplePerceptionApp.log";
+    final static String PERCEPTION_VEHICLE_LOG = "apps/veh_0/SimplePerceptionApp.log";
 
     @Test
     public void executionSuccessful() throws Exception {
@@ -46,7 +46,8 @@ public abstract class AbstractPerceptionModuleIT {
         // perceived vehicles repeat their route 10 times resulting in 10 perceptions
         assertEquals(10, LogAssert.count(simulationRule,
                 PERCEPTION_VEHICLE_LOG,
-                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 1 without dimensions.*"));
+                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 1 without dimensions.*")
+        );
     }
 
     @Test

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/PerceptionModuleSumoIndexIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/PerceptionModuleSumoIndexIT.java
@@ -15,6 +15,10 @@
 
 package org.eclipse.mosaic.test;
 
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.mosaic.test.junit.LogAssert;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -24,6 +28,16 @@ public class PerceptionModuleSumoIndexIT extends AbstractPerceptionModuleIT {
     public static void runSimulation() {
         simulationRule.federateConfigurationManipulator("application", (conf) -> conf.configuration = "application_config_sumo.json");
         simulationResult = simulationRule.executeTestScenario("perception-module");
+    }
+
+    @Override
+    @Test
+    public void rightAmountOfVehiclesPerceived() throws Exception {
+        // perceived vehicles repeat their route 10 times resulting in 10 perceptions
+        assertEquals(10, LogAssert.count(simulationRule,
+                PERCEPTION_VEHICLE_LOG,
+                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 0 without dimensions.*")
+        ); // with the SUMO index the proper dimensions of vehicles are always retrievable independent of prototype configurations
     }
 
     @Override

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/perceptionmodule/SimplePerceptionApp.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/perceptionmodule/SimplePerceptionApp.java
@@ -36,8 +36,8 @@ public class SimplePerceptionApp extends AbstractApplication<VehicleOperatingSys
     private static final String EVENT_RESOURCE = "PERCEPTION";
     private static final long queryInterval = 2 * TIME.SECOND;
 
-    private static final double VIEWING_ANGLE = 60d;
-    private static final double VIEWING_RANGE = 50d;
+    private static final double VIEWING_ANGLE = 160d;
+    private static final double VIEWING_RANGE = 100d;
 
     @Override
     public void onStartup() {
@@ -80,11 +80,19 @@ public class SimplePerceptionApp extends AbstractApplication<VehicleOperatingSys
                 .schedule();
     }
 
+    private boolean perceivedNoVehicles = true;
+
     private void perceiveVehicles() {
         List<VehicleObject> perceivedVehicles = getOs().getPerceptionModule().getPerceivedVehicles();
-        if (perceivedVehicles.size() == 3) {
-            getLog().infoSimTime(this, "Perceived all vehicles: {}",
-                    perceivedVehicles.stream().map(VehicleObject::getId).collect(Collectors.toList()));
+        if (perceivedVehicles.isEmpty()) {
+            perceivedNoVehicles = true;
+        }
+        if (perceivedNoVehicles && perceivedVehicles.size() == 4) {
+            long vehiclesWithInvalidDimensions = perceivedVehicles.stream()
+                    .filter(v -> v.getLength() == 0 && v.getWidth() == 0 && v.getHeight() == 0).count();
+            getLog().infoSimTime(this, "Perceived all vehicles: {}, {} without dimensions.",
+                    perceivedVehicles.stream().map(VehicleObject::getId).collect(Collectors.toList()), vehiclesWithInvalidDimensions);
+            perceivedNoVehicles = false;
         }
     }
 

--- a/test/scenarios/perception-module/mapping/mapping_config.json
+++ b/test/scenarios/perception-module/mapping/mapping_config.json
@@ -7,7 +7,11 @@
             ]
         },
         {
-            "name": "DefaultVehicle"
+            "name": "DefaultVehicle",
+            "applications": [
+                "org.eclipse.mosaic.test.app.mosaicandsumovehicles.SumoVehicle"
+            ],
+            "weight": 0.33
         }
     ]
 }

--- a/test/scenarios/perception-module/sumo/square.net.xml
+++ b/test/scenarios/perception-module/sumo/square.net.xml
@@ -32,7 +32,7 @@
 </configuration>
 -->
 
-<net version="1.9" junctionCornerDetail="5" limitTurnSpeed="5.50" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+<net version="1.9" junctionCornerDetail="5" limitTurnSpeed="5.50" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://sumo.dlr.de/xsd/net_file.xsd">
 
     <location netOffset="0.00,0.00" convBoundary="-5.00,0.00,115.00,120.00" origBoundary="-10000000000.00,-10000000000.00,10000000000.00,10000000000.00" projParameter="!"/>
 

--- a/test/scenarios/perception-module/sumo/square.net.xml
+++ b/test/scenarios/perception-module/sumo/square.net.xml
@@ -111,9 +111,9 @@
     </edge>
 
     <tlLogic id="J1" type="static" programID="0" offset="0">
-        <phase duration="42" state="GG"/>
-        <phase duration="3"  state="yy"/>
         <phase duration="42" state="rr"/>
+        <phase duration="3"  state="yy"/>
+        <phase duration="42" state="GG"/>
         <phase duration="3"  state="yy"/>
     </tlLogic>
 

--- a/test/scenarios/perception-module/sumo/square.rou.xml
+++ b/test/scenarios/perception-module/sumo/square.rou.xml
@@ -16,6 +16,7 @@
 <routes xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://sumo.dlr.de/xsd/routes_file.xsd">
     <vType id="PerceptionVehicle"/>
     <vType id="DefaultVehicle"/>
+    <vType id="NoPrototypeVehicle"/> <!-- Vehicles of this type will have default dimensions-->
     <route id="0" repeat="10" edges="E0 E1 E2 E3"/>
     <route id="1" repeat="10" edges="-E3 -E2 -E1 -E0"/>
     <vehicle id="0" type="PerceptionVehicle" depart="0" route="0">
@@ -24,4 +25,5 @@
     <vehicle id="1" type="DefaultVehicle" depart="0" route="1"/>
     <vehicle id="2" type="DefaultVehicle" depart="5" route="1"/>
     <vehicle id="3" type="DefaultVehicle" depart="10" route="1"/>
+    <vehicle id="4" type="NoPrototypeVehicle" depart="15" route="1"/>
 </routes>

--- a/test/scenarios/perception-module/sumo/square.rou.xml
+++ b/test/scenarios/perception-module/sumo/square.rou.xml
@@ -13,7 +13,7 @@
   ~
   ~ Contact: mosaic@fokus.fraunhofer.de
   -->
-<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+<routes xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://sumo.dlr.de/xsd/routes_file.xsd">
     <vType id="PerceptionVehicle"/>
     <vType id="DefaultVehicle"/>
     <route id="0" repeat="10" edges="E0 E1 E2 E3"/>

--- a/test/scenarios/perception-module/sumo/square.sumocfg
+++ b/test/scenarios/perception-module/sumo/square.sumocfg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2022 Fraunhofer FOKUS and others. All rights reserved.
   ~
@@ -12,7 +13,7 @@
   ~
   ~ Contact: mosaic@fokus.fraunhofer.de
   -->
-<configuration>
+<configuration xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://sumo.dlr.de/xsd/sumoConfiguration.xsd">
     <input>
         <net-file value="square.net.xml"/>
         <route-files value="square.rou.xml"/>


### PR DESCRIPTION
## Description

* With the integration of vehicle dimensions (i.e., length, width, height) #278 in the `VehicleObject`s the `CentralPerceptionComponent` required `VehicleRegistration`s to extract the dimensions
* This broke the ability for all vehicles to be handled in the perception index -> vehicles failing the `weight` condition in the `MappingAmbassador`
* With this PR this functionality was revived
* Additionally, all `VehicleType`s configured in the *mapping_config.json* are now held in the `vehicleTypes`-map in the `SimulationKernel`, which enables type retrieval when adding vehicles to the perception index
* vehicles with no configured prototype will have (0, 0, 0) as their dimensions
* the perception integration test has been extended to better look at edge cases


* future work may improve on this by adding actual `VehicleTypes` to the `ScenarioVehicleRegistration`-interaction, which would remove the requirement to define all external vehicle types as an additional `prototype` in the *mapping_config.json*


## Issue(s) related to this PR

* Resolves internal issue 551
  
## Affected parts of the online documentation

* We could discuss adding a section on the perception of *Scenario Vehicles*

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

