### PR TITLE
feat(sumo): Send complete VehicleType with ScenarioVehicleRegistration

### DIFF
--- a/bundle/src/assembly/resources/etc/runtime.json
+++ b/bundle/src/assembly/resources/etc/runtime.json
@@ -18,6 +18,7 @@
                 "TrafficLightRegistration",
                 "VehicleRegistration",
                 "RoutelessVehicleRegistration",
+                "ScenarioVehicleRegistration",
                 "ApplicationInteraction",
                 "ChargingStationUpdate",
                 "VehicleChargingDenial",

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
@@ -43,6 +43,7 @@ import org.eclipse.mosaic.interactions.mapping.TmcRegistration;
 import org.eclipse.mosaic.interactions.mapping.TrafficLightRegistration;
 import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
 import org.eclipse.mosaic.interactions.mapping.advanced.RoutelessVehicleRegistration;
+import org.eclipse.mosaic.interactions.mapping.advanced.ScenarioVehicleRegistration;
 import org.eclipse.mosaic.interactions.traffic.TrafficDetectorUpdates;
 import org.eclipse.mosaic.interactions.traffic.TrafficLightUpdates;
 import org.eclipse.mosaic.interactions.traffic.VehicleRoutesInitialization;
@@ -262,6 +263,8 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                 this.process((TrafficLightRegistration) interaction);
             } else if (interaction.getTypeId().startsWith(VehicleRegistration.TYPE_ID)) {
                 this.process((VehicleRegistration) interaction);
+            } else if (interaction.getTypeId().startsWith(ScenarioVehicleRegistration.TYPE_ID)) {
+                this.process((ScenarioVehicleRegistration) interaction);
             } else if (interaction.getTypeId().startsWith(RoutelessVehicleRegistration.TYPE_ID)) {
                 this.process((RoutelessVehicleRegistration) interaction);
             } else if (interaction.getTypeId().startsWith(TmcRegistration.TYPE_ID)) {
@@ -365,6 +368,12 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
         // register vehicle type for perception
         SimulationKernel.SimulationKernel.getCentralPerceptionComponent()
                 .registerVehicleType(vehicleName, vehicleRegistration.getMapping().getVehicleType());
+    }
+
+    private void process(final ScenarioVehicleRegistration scenarioVehicleRegistration) {
+        // register vehicle type for perception, may be overridden later by VehicleRegistration
+        SimulationKernel.SimulationKernel.getCentralPerceptionComponent()
+                .registerVehicleType(scenarioVehicleRegistration.getName(), scenarioVehicleRegistration.getVehicleType());
     }
 
     private void process(final RoutelessVehicleRegistration routelessVehicleRegistration) {

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mosaic.fed.mapping.ambassador;
 
-import org.eclipse.mosaic.fed.mapping.ambassador.spawning.VehicleTypeSpawner;
 import org.eclipse.mosaic.fed.mapping.config.CMappingAmbassador;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
@@ -122,11 +121,11 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
      */
     private void handleInteraction(ScenarioVehicleRegistration scenarioVehicle) throws InternalFederateException {
         if (framework != null) {
-            final CPrototype prototype = framework.getPrototypeByName(scenarioVehicle.getVehicleTypeId());
+            final CPrototype prototype = framework.getPrototypeByName(scenarioVehicle.getVehicleType().getName());
             if (prototype == null) {
                 log.debug(
                         "There is no such prototype \"{}\" configured. No application will be mapped for vehicle \"{}\".",
-                        scenarioVehicle.getVehicleTypeId(),
+                        scenarioVehicle.getVehicleType().getName(),
                         scenarioVehicle.getId()
                 );
                 return;
@@ -135,7 +134,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
             if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
                 log.debug(
                         "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
-                        scenarioVehicle.getVehicleTypeId(),
+                        scenarioVehicle.getVehicleType().getName(),
                         scenarioVehicle.getId(),
                         prototype.weight
                 );
@@ -148,11 +147,11 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                     prototype.group,
                     prototype.applications,
                     null,
-                    new VehicleTypeSpawner(prototype).convertType()
+                   scenarioVehicle.getVehicleType()
             );
             try {
                 log.info("Mapping Scenario Vehicle. time={}, name={}, type={}, apps={}",
-                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleTypeId(), prototype.applications);
+                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleType().getName(), prototype.applications);
                 rti.triggerInteraction(vehicleRegistration);
             } catch (Exception e) {
                 throw new InternalFederateException(e);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -32,8 +32,6 @@ import org.eclipse.mosaic.rti.config.CLocalHost.OperatingSystem;
 
 import org.apache.commons.lang3.ObjectUtils;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -132,8 +130,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                 );
                 return;
             }
-            List<String> applications = prototype.applications == null ? new ArrayList<>() : prototype.applications;
-            String group = prototype.group == null ? null : prototype.group;
+
             if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
                 log.debug(
                         "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
@@ -141,21 +138,20 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                         scenarioVehicle.getId(),
                         prototype.weight
                 );
-                applications = new ArrayList<>();
-                group = null;
+                return;
             }
 
             final VehicleRegistration vehicleRegistration = new VehicleRegistration(
                     scenarioVehicle.getTime(),
                     scenarioVehicle.getName(),
-                    group,
-                    applications,
+                    prototype.group,
+                    prototype.applications,
                     null,
                     scenarioVehicle.getVehicleType()
             );
             try {
                 log.info("Mapping Scenario Vehicle. time={}, name={}, type={}, apps={}",
-                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleType().getName(), applications);
+                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleType().getName(), prototype.applications);
                 rti.triggerInteraction(vehicleRegistration);
             } catch (Exception e) {
                 throw new InternalFederateException(e);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -134,8 +134,8 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
             if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
                 log.debug(
                         "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
-                        scenarioVehicle.getVehicleType().getName(),
                         scenarioVehicle.getId(),
+                        scenarioVehicle.getVehicleType().getName(),
                         prototype.weight
                 );
                 return;

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
@@ -31,6 +31,7 @@ import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLight;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightProgram;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightState;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.Interaction;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
@@ -286,16 +287,16 @@ public class MappingAmbassadorTest {
         final MappingAmbassador ambassador = createMappingAmbassadorWithMappingFile("mapping_config.json");
         ambassador.initialize(0, 100 * TIME.SECOND);
 
-        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", "PKW"));
+        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("PKW")));
         assertVehicleRegistration();
 
-        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", "electricPKW"));
+        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("electricPKW")));
         assertVehicleRegistration(
                 "org.eclipse.mosaic.app.examples.eventprocessing.sampling.HelloWorldApp",
                 "org.eclipse.mosaic.app.examples.eventprocessing.sampling.IntervalSamplingApp"
         );
 
-        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", "UNKNOWN"));
+        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("UNKNOWN")));
         Assert.assertNull(lastReceivedInteraction);
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/LibSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/LibSumoAmbassador.java
@@ -34,7 +34,7 @@ import java.nio.file.Paths;
  */
 public class LibSumoAmbassador extends SumoAmbassador {
 
-    private static final String VALID_LIBSUMO_VERSIONS = "1\\.16\\.";
+    private static final String VALID_LIBSUMO_VERSIONS = "1\\.1[456]\\.";
 
     public LibSumoAmbassador(AmbassadorParameter ambassadorParameter) {
         super(ambassadorParameter);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -282,14 +282,16 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
     private void propagateSumoVehiclesToRti() throws InternalFederateException {
         final List<String> departedVehicles = bridge.getSimulationControl().getDepartedVehicles();
         String vehicleTypeId;
+        VehicleType vehicleType;
         for (String vehicleId : departedVehicles) {
             if (vehiclesAddedViaRti.contains(vehicleId)) { // only handle route file vehicles here
                 continue;
             }
             vehiclesAddedViaRouteFile.add(vehicleId);
             vehicleTypeId = bridge.getVehicleControl().getVehicleTypeId(vehicleId);
+            vehicleType = bridge.getVehicleControl().getVehicleType(vehicleTypeId);
             try {
-                rti.triggerInteraction(new ScenarioVehicleRegistration(this.nextTimeStep, vehicleId, vehicleTypeId));
+                rti.triggerInteraction(new ScenarioVehicleRegistration(this.nextTimeStep, vehicleId, vehicleType));
             } catch (IllegalValueException e) {
                 throw new InternalFederateException(e);
             }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetAccel.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetAccel.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the acceleration value for specific a vehicle type.
+ */
+public interface VehicleTypeGetAccel {
+
+    /**
+     * This method executes the command with the given arguments in order to get the acceleration value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetDecel.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetDecel.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the deceleration value for specific a vehicle type.
+ */
+public interface VehicleTypeGetDecel {
+
+    /**
+     * This method executes the command with the given arguments in order to get the deceleration value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetHeight.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetHeight.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the height value for specific a vehicle type.
+ */
+public interface VehicleTypeGetHeight {
+
+    /**
+     * This method executes the command with the given arguments in order to get the height value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetLength.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetLength.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the length value for specific a vehicle type.
+ */
+public interface VehicleTypeGetLength {
+
+    /**
+     * This method executes the command with the given arguments in order to get the length value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetMaxSpeed.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetMaxSpeed.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the max speed value for specific a vehicle type.
+ */
+public interface VehicleTypeGetMaxSpeed {
+
+    /**
+     * This method executes the command with the given arguments in order to get the max speed value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetMinGap.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetMinGap.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the min gap value for specific a vehicle type.
+ */
+public interface VehicleTypeGetMinGap {
+
+    /**
+     * This method executes the command with the given arguments in order to get the min gap value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetSigma.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetSigma.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the sigma value for specific a vehicle type.
+ */
+public interface VehicleTypeGetSigma {
+
+    /**
+     * This method executes the command with the given arguments in order to get the sigma value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetSpeedFactor.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetSpeedFactor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the speed factor value for specific a vehicle type.
+ */
+public interface VehicleTypeGetSpeedFactor {
+
+    /**
+     * This method executes the command with the given arguments in order to get the speed factor value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetTau.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetTau.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the tau value for specific a vehicle type.
+ */
+public interface VehicleTypeGetTau {
+
+    /**
+     * This method executes the command with the given arguments in order to get the tau value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetVClass.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetVClass.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the vclass value for specific a vehicle type.
+ */
+public interface VehicleTypeGetVClass {
+
+    /**
+     * This method executes the command with the given arguments in order to get the vclass value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    String execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetWidth.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleTypeGetWidth.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+/**
+ * This class reads the width value for specific a vehicle type.
+ */
+public interface VehicleTypeGetWidth {
+
+    /**
+     * This method executes the command with the given arguments in order to get the width value of a specific vehicle type.
+     *
+     * @param bridge        Connection to SUMO.
+     * @param vehicleTypeId Id of the vehicle type.
+     * @return the value of the parameter, or {@code null} if not present
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/VehicleFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/VehicleFacade.java
@@ -111,6 +111,7 @@ public class VehicleFacade {
     private final VehicleTypeGetSigma getVehicleTypeSigma;
     private final VehicleTypeGetTau getVehicleTypeTau;
     private final VehicleTypeGetSpeedFactor getVehicleTypeSpeedFactor;
+
     private final Map<String, VehicleType> cachedVehicleTypes = new HashMap<>();
 
 
@@ -213,13 +214,13 @@ public class VehicleFacade {
                         SumoVehicleClassMapping.fromSumo(getVehicleTypeVClass.execute(bridge, vehicleTypeId)),
                         getVehicleTypeAccel.execute(bridge, vehicleTypeId),
                         getVehicleTypeDecel.execute(bridge, vehicleTypeId),
-                        null,
+                        null, // not available via TraCI, will use the decel value instead
                         getVehicleTypeSigma.execute(bridge, vehicleTypeId),
                         getVehicleTypeTau.execute(bridge, vehicleTypeId),
                         getVehicleTypeSpeedFactor.execute(bridge, vehicleTypeId),
-                        null,
-                        null,
-                        null
+                        null, // would require to translate from rgb to a string name
+                        null, // not available via TraCI
+                        null // not available via TraCI
                 );
                 cachedVehicleTypes.put(vehicleTypeId, vehicleType);
             }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/VehicleFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/VehicleFacade.java
@@ -40,16 +40,31 @@ import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSetSpeedFactor;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSetSpeedMode;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSetStop;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSetVehicleLength;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetAccel;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetDecel;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetHeight;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetLength;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetMaxSpeed;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetMinGap;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetSigma;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetSpeedFactor;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetTau;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetVClass;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetWidth;
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.SumoLaneChangeMode;
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.SumoSpeedMode;
+import org.eclipse.mosaic.fed.sumo.util.SumoVehicleClassMapping;
 import org.eclipse.mosaic.lib.enums.VehicleStopMode;
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
+import java.util.HashMap;
+import java.util.Map;
 
 public class VehicleFacade {
 
@@ -85,6 +100,19 @@ public class VehicleFacade {
     private final VehicleSetSpeedMode setSpeedMode;
     private final VehicleSetParameter setParameter;
 
+    private final VehicleTypeGetLength getVehicleTypeLength;
+    private final VehicleTypeGetWidth getVehicleTypeWidth;
+    private final VehicleTypeGetHeight getVehicleTypeHeight;
+    private final VehicleTypeGetMinGap getVehicleTypeMinGap;
+    private final VehicleTypeGetMaxSpeed getVehicleTypeMaxSpeed;
+    private final VehicleTypeGetVClass getVehicleTypeVClass;
+    private final VehicleTypeGetAccel getVehicleTypeAccel;
+    private final VehicleTypeGetDecel getVehicleTypeDecel;
+    private final VehicleTypeGetSigma getVehicleTypeSigma;
+    private final VehicleTypeGetTau getVehicleTypeTau;
+    private final VehicleTypeGetSpeedFactor getVehicleTypeSpeedFactor;
+    private final Map<String, VehicleType> cachedVehicleTypes = new HashMap<>();
+
 
     /**
      * Creates a new {@link VehicleFacade} object.
@@ -119,6 +147,18 @@ public class VehicleFacade {
         setSpeedMode = bridge.getCommandRegister().getOrCreate(VehicleSetSpeedMode.class);
         setParameter = bridge.getCommandRegister().getOrCreate(VehicleSetParameter.class);
 
+        getVehicleTypeLength = bridge.getCommandRegister().getOrCreate(VehicleTypeGetLength.class);
+        getVehicleTypeWidth = bridge.getCommandRegister().getOrCreate(VehicleTypeGetWidth.class);
+        getVehicleTypeHeight = bridge.getCommandRegister().getOrCreate(VehicleTypeGetHeight.class);
+        getVehicleTypeMinGap = bridge.getCommandRegister().getOrCreate(VehicleTypeGetMinGap.class);
+        getVehicleTypeMaxSpeed = bridge.getCommandRegister().getOrCreate(VehicleTypeGetMaxSpeed.class);
+        getVehicleTypeVClass = bridge.getCommandRegister().getOrCreate(VehicleTypeGetVClass.class);
+        getVehicleTypeAccel = bridge.getCommandRegister().getOrCreate(VehicleTypeGetAccel.class);
+        getVehicleTypeDecel = bridge.getCommandRegister().getOrCreate(VehicleTypeGetDecel.class);
+        getVehicleTypeSigma = bridge.getCommandRegister().getOrCreate(VehicleTypeGetSigma.class);
+        getVehicleTypeTau = bridge.getCommandRegister().getOrCreate(VehicleTypeGetTau.class);
+        getVehicleTypeSpeedFactor = bridge.getCommandRegister().getOrCreate(VehicleTypeGetSpeedFactor.class);
+
         highlight = bridge.getCommandRegister().getOrCreate(VehicleSetHighlight.class);
     }
 
@@ -149,6 +189,43 @@ public class VehicleFacade {
             return getVehicleTypeId.execute(bridge, vehicleId);
         } catch (IllegalArgumentException | CommandException e) {
             throw new InternalFederateException("Could not request route for vehicle " + vehicleId, e);
+        }
+    }
+
+    /**
+     * Getter for the complete Vehicle type.
+     *
+     * @param vehicleTypeId The id of the vehicle type.
+     * @return The complete vehicle type.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The TraCI connection is shut down.
+     */
+    public VehicleType getVehicleType(String vehicleTypeId) throws InternalFederateException {
+        try {
+            VehicleType vehicleType = cachedVehicleTypes.get(vehicleTypeId);
+            if (vehicleType == null) {
+                vehicleType = new VehicleType(
+                        vehicleTypeId,
+                        getVehicleTypeLength.execute(bridge, vehicleTypeId),
+                        getVehicleTypeWidth.execute(bridge, vehicleTypeId),
+                        getVehicleTypeHeight.execute(bridge, vehicleTypeId),
+                        getVehicleTypeMinGap.execute(bridge, vehicleTypeId),
+                        getVehicleTypeMaxSpeed.execute(bridge, vehicleTypeId),
+                        SumoVehicleClassMapping.fromSumo(getVehicleTypeVClass.execute(bridge, vehicleTypeId)),
+                        getVehicleTypeAccel.execute(bridge, vehicleTypeId),
+                        getVehicleTypeDecel.execute(bridge, vehicleTypeId),
+                        null,
+                        getVehicleTypeSigma.execute(bridge, vehicleTypeId),
+                        getVehicleTypeTau.execute(bridge, vehicleTypeId),
+                        getVehicleTypeSpeedFactor.execute(bridge, vehicleTypeId),
+                        null,
+                        null,
+                        null
+                );
+                cachedVehicleTypes.put(vehicleTypeId, vehicleType);
+            }
+            return vehicleType;
+        } catch (IllegalArgumentException | CommandException e) {
+            throw new InternalFederateException("Could not request vehicle type for type id " + vehicleTypeId, e);
         }
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetAccel.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetAccel.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetAccel implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetAccel {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getAccel(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetDecel.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetDecel.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetDecel implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetDecel {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getDecel(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetHeight.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetHeight.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetHeight implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetHeight {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getHeight(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetLength.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetLength.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetLength implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetLength {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getLength(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetMaxSpeed.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetMaxSpeed.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetMaxSpeed implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetMaxSpeed {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getMaxSpeed(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetMinGap.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetMinGap.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetMinGap implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetMinGap {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getMinGap(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetSigma.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetSigma.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetSigma implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetSigma {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getImperfection(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetSpeedFactor.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetSpeedFactor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetSpeedFactor implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetSpeedFactor {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getSpeedFactor(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetTau.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetTau.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetTau implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetTau {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getTau(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetVClass.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetVClass.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetVClass implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetVClass {
+
+    public String execute(Bridge bridge, String typeId) {
+        return VehicleType.getVehicleClass(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetWidth.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleTypeGetWidth.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+
+import org.eclipse.sumo.libsumo.VehicleType;
+
+public class VehicleTypeGetWidth implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetWidth {
+
+    public double execute(Bridge bridge, String typeId) {
+        return VehicleType.getWidth(typeId);
+    }
+
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetAccel.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetAccel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetAccel
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetAccel {
+
+    /**
+     * Creates a new {@link VehicleTypeGetAccel} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetAccel() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_ACCEL)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetDecel.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetDecel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetDecel
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetDecel {
+
+    /**
+     * Creates a new {@link VehicleTypeGetDecel} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetDecel() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_DECEL)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetHeight.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetHeight.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetHeight
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetHeight {
+
+    /**
+     * Creates a new {@link VehicleTypeGetHeight} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetHeight() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_HEIGHT)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetLength.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetLength.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetLength
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetLength {
+
+    /**
+     * Creates a new {@link VehicleTypeGetLength} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetLength() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_LENGTH)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetMaxSpeed.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetMaxSpeed.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetMaxSpeed
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetMaxSpeed {
+
+    /**
+     * Creates a new {@link VehicleTypeGetMaxSpeed} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetMaxSpeed() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_MAX_SPEED)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetMinGap.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetMinGap.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetMinGap
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetMinGap {
+
+    /**
+     * Creates a new {@link VehicleTypeGetMinGap} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetMinGap() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_MIN_GAP)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetSigma.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetSigma.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetSigma
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetSigma {
+
+    /**
+     * Creates a new {@link VehicleTypeGetSigma} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetSigma() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_SIGMA)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetSpeedFactor.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetSpeedFactor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetSpeedFactor
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetSpeedFactor {
+
+    /**
+     * Creates a new {@link VehicleTypeGetSpeedFactor} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetSpeedFactor() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_SPEED_FACTOR)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetTau.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetTau.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetTau
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetTau {
+
+    /**
+     * Creates a new {@link VehicleTypeGetTau} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetTau() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_TAU)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetVClass.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetVClass.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetVClass
+        extends AbstractTraciCommand<String>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetVClass {
+
+    /**
+     * Creates a new {@link VehicleTypeGetVClass} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetVClass() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_VCLASS)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readStringWithType();
+    }
+
+    public String execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse("passenger");
+    }
+
+    @Override
+    protected String constructResult(Status status, Object... objects) {
+        return (String) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetWidth.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleTypeGetWidth.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleTypeState;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+public class VehicleTypeGetWidth
+        extends AbstractTraciCommand<Double>
+        implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleTypeGetWidth {
+
+    /**
+     * Creates a new {@link VehicleTypeGetWidth} traci command.
+     * Access needs to be public, because command is called using Reflection.
+     *
+     * @see <a href="https://sumo.dlr.de/docs/TraCI/VehicleType_Value_Retrieval.html">VehicleType Value Retrieval</a>
+     */
+    @SuppressWarnings("WeakerAccess")
+    public VehicleTypeGetWidth() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleTypeState.COMMAND)
+                .variable(CommandRetrieveVehicleTypeState.VAR_WIDTH)
+                .writeStringParam(); // vehicle type name
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .readDoubleWithType();
+    }
+
+    public double execute(Bridge bridge, String vehicleTypeId) throws CommandException, InternalFederateException {
+        return super.executeAndReturn(bridge, vehicleTypeId).orElse(0d);
+    }
+
+    @Override
+    protected Double constructResult(Status status, Object... objects) {
+        return (Double) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleTypeState.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleTypeState.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci.constants;
+
+public class CommandRetrieveVehicleTypeState {
+
+    public final static int COMMAND = 0xa5;
+
+    public final static SumoVar VAR_MIN_GAP = SumoVar.var(0x4c);
+
+    public final static SumoVar VAR_MAX_SPEED = SumoVar.var(0x41);
+
+    public final static SumoVar VAR_ACCEL = SumoVar.var(0x46);
+
+    public final static SumoVar VAR_DECEL = SumoVar.var(0x47);
+
+    public final static SumoVar VAR_TAU = SumoVar.var(0x48);
+
+    public final static SumoVar VAR_SIGMA = SumoVar.var(0x5d);
+
+    public final static SumoVar VAR_SPEED_FACTOR = SumoVar.var(0x5e);
+
+    public final static SumoVar VAR_VCLASS = SumoVar.var(0x49);
+
+    public final static SumoVar VAR_LENGTH = SumoVar.var(0x44);
+
+    public final static SumoVar VAR_WIDTH = SumoVar.var(0x4d);
+
+    public final static SumoVar VAR_HEIGHT = SumoVar.var(0xbc);
+}
+

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/TraciTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.mosaic.fed.sumo.bridge.api.complex.SumoLaneChangeMode;
@@ -38,6 +39,7 @@ import org.eclipse.mosaic.fed.sumo.junit.SumoTraciRule;
 import org.eclipse.mosaic.interactions.traffic.VehicleUpdates;
 import org.eclipse.mosaic.lib.enums.LaneChangeMode;
 import org.eclipse.mosaic.lib.enums.SpeedMode;
+import org.eclipse.mosaic.lib.enums.VehicleClass;
 import org.eclipse.mosaic.lib.enums.VehicleStopMode;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.geo.UtmPoint;
@@ -47,6 +49,7 @@ import org.eclipse.mosaic.lib.objects.traffic.InductionLoopInfo;
 import org.eclipse.mosaic.lib.objects.trafficlight.TrafficLightGroup;
 import org.eclipse.mosaic.lib.objects.vehicle.PublicTransportData;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.lib.objects.vehicle.sensor.SensorValue.SensorStatus;
 import org.eclipse.mosaic.rti.TIME;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
@@ -133,6 +136,35 @@ public class TraciTest {
         traci.getVehicleControl().setSpeedFactor(vehicle, SPEED_FACTOR);
         traci.getVehicleControl().setLaneChangeMode(vehicle, LANE_CHANGE_MODE);
         traci.getVehicleControl().setSpeedMode(vehicle, SPEED_MODE);
+
+    }
+
+    @Test
+    public void getVehicleType() throws Exception {
+        final TraciClientBridge traci = traciRule.getTraciClient();
+        final String vehicle = "1";
+
+        // RUN
+        String vehicleTypeId = traci.getVehicleControl().getVehicleTypeId(vehicle);
+        VehicleType type = traci.getVehicleControl().getVehicleType(vehicleTypeId);
+
+        // ASSERT
+        assertEquals(vehicleTypeId, type.getName());
+        assertEquals(5.0, type.getLength(), 0.00001d);
+        assertEquals(1.8, type.getWidth(), 0.00001d);
+        assertEquals(1.5, type.getHeight(), 0.00001d);
+        assertEquals(2.5, type.getMinGap(), 0.00001d);
+        assertEquals(50.0, type.getMaxSpeed(), 0.00001d);
+        assertEquals(1.0, type.getSpeedFactor(), 0.00001d);
+        assertEquals(1.5, type.getAccel(), 0.00001d);
+        assertEquals(4.5, type.getDecel(), 0.00001d);
+        assertEquals(1.0, type.getTau(), 0.00001d);
+        assertEquals(0.5, type.getSigma(), 0.00001d);
+        assertEquals(VehicleClass.Car, type.getVehicleClass());
+
+        assertNull(type.getColor());
+        assertEquals(LaneChangeMode.DEFAULT, type.getLaneChangeMode());
+        assertEquals(SpeedMode.DEFAULT, type.getSpeedMode());
 
     }
 

--- a/lib/mosaic-interactions/src/main/java/org/eclipse/mosaic/interactions/mapping/advanced/ScenarioVehicleRegistration.java
+++ b/lib/mosaic-interactions/src/main/java/org/eclipse/mosaic/interactions/mapping/advanced/ScenarioVehicleRegistration.java
@@ -17,6 +17,7 @@ package org.eclipse.mosaic.interactions.mapping.advanced;
 
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 import org.eclipse.mosaic.rti.api.Interaction;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -24,8 +25,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * This extension of {@link Interaction} is sent by SUMO ambassador if it launches vehicles by
- * itself (e.g. by using predefined scenarios).
+ * This extension of {@link Interaction} is sent by any simulator, which launches vehicles by
+ * itself (e.g., SUMO by using predefined scenarios).
  */
 public final class ScenarioVehicleRegistration extends Interaction {
 
@@ -37,34 +38,34 @@ public final class ScenarioVehicleRegistration extends Interaction {
     public final static String TYPE_ID = createTypeIdentifier(ScenarioVehicleRegistration.class);
 
     private final String name;
-    private final String vehicleTypeId;
+    private final VehicleType vehicleType;
 
     /**
      * Creates a new interaction that informs that a vehicle was added to the simulation by SUMO.
      *
-     * @param time          Timestamp of this interaction, unit: [ns]
-     * @param name          name of the vehicle
-     * @param vehicleTypeId name of the vehicle type
+     * @param time        Timestamp of this interaction, unit: [ns]
+     * @param name        name of the vehicle
+     * @param vehicleType the complete vehicle type
      */
-    public ScenarioVehicleRegistration(final long time, final String name, final String vehicleTypeId) {
+    public ScenarioVehicleRegistration(final long time, final String name, final VehicleType vehicleType) {
         super(time);
         this.name = name;
-        this.vehicleTypeId = vehicleTypeId;
+        this.vehicleType = vehicleType;
     }
 
     public String getName() {
         return name;
     }
 
-    public String getVehicleTypeId() {
-        return vehicleTypeId;
+    public VehicleType getVehicleType() {
+        return vehicleType;
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder(7, 19)
                 .append(name)
-                .append(vehicleTypeId)
+                .append(vehicleType)
                 .toHashCode();
     }
 
@@ -83,7 +84,7 @@ public final class ScenarioVehicleRegistration extends Interaction {
         ScenarioVehicleRegistration other = (ScenarioVehicleRegistration) obj;
         return new EqualsBuilder()
                 .append(this.name, other.name)
-                .append(this.vehicleTypeId, other.vehicleTypeId)
+                .append(this.vehicleType, other.vehicleType)
                 .isEquals();
     }
 
@@ -92,7 +93,7 @@ public final class ScenarioVehicleRegistration extends Interaction {
         return new ToStringBuilder(this, SHORT_PREFIX_STYLE)
                 .appendSuper(super.toString())
                 .append("name", name)
-                .append("vehicleTypeId", vehicleTypeId)
+                .append("vehicleType", vehicleType)
                 .toString();
     }
 

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/AbstractPerceptionModuleIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/AbstractPerceptionModuleIT.java
@@ -46,7 +46,7 @@ public abstract class AbstractPerceptionModuleIT {
         // perceived vehicles repeat their route 10 times resulting in 10 perceptions
         assertEquals(10, LogAssert.count(simulationRule,
                 PERCEPTION_VEHICLE_LOG,
-                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 1 without dimensions.*")
+                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 0 without dimensions.*")
         );
     }
 

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/PerceptionModuleSumoIndexIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/PerceptionModuleSumoIndexIT.java
@@ -15,10 +15,6 @@
 
 package org.eclipse.mosaic.test;
 
-import static org.junit.Assert.assertEquals;
-
-import org.eclipse.mosaic.test.junit.LogAssert;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -28,16 +24,6 @@ public class PerceptionModuleSumoIndexIT extends AbstractPerceptionModuleIT {
     public static void runSimulation() {
         simulationRule.federateConfigurationManipulator("application", (conf) -> conf.configuration = "application_config_sumo.json");
         simulationResult = simulationRule.executeTestScenario("perception-module");
-    }
-
-    @Override
-    @Test
-    public void rightAmountOfVehiclesPerceived() throws Exception {
-        // perceived vehicles repeat their route 10 times resulting in 10 perceptions
-        assertEquals(10, LogAssert.count(simulationRule,
-                PERCEPTION_VEHICLE_LOG,
-                ".*Perceived all vehicles: \\[veh_[1-4], veh_[1-4], veh_[1-4], veh_[1-4]\\], 0 without dimensions.*")
-        ); // with the SUMO index the proper dimensions of vehicles are always retrievable independent of prototype configurations
     }
 
     @Override


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* With this PR, the `ScenarioVehicleRegistration` not provides a complete `VehicleType`. This allows easier handling of vehicle types in mapping and application simulator, especially if no prototype is configured in the mapping_config.json for vehicles created by the simulator (e.g. via SUMOs rou-file).
* Accordingly, SumoAmbassador now creates a complete VehicleType for each vehicle defined in the rou-file based on vehicle parameters read via TraCI or Libsumo. 
* #289 could profit from this change.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 556
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

