### PR TITLE
fix(sumo): workaround for loading libsumojni dll on Windows

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
@@ -254,11 +254,11 @@ public abstract class AbstractSumoAmbassador extends AbstractFederateAmbassador 
     @Override
     public FederateExecutor createFederateExecutor(String host, int port, CLocalHost.OperatingSystem os) {
         // SUMO needs to start the federate by itself, therefore we need to store the federate starter locally and use it later
-        federateExecutor = new ExecutableFederateExecutor(descriptor, getSumoExecutable("sumo"), getProgramArguments(port));
+        federateExecutor = new ExecutableFederateExecutor(descriptor, getFromSumoHome("sumo"), getProgramArguments(port));
         return new NopFederateExecutor();
     }
 
-    static String getSumoExecutable(String executable) {
+    static String getFromSumoHome(String executable) {
         String sumoHome = System.getenv("SUMO_HOME");
         if (StringUtils.isNotBlank(sumoHome)) {
             return sumoHome + File.separator + "bin" + File.separator + executable;

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoGuiAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoGuiAmbassador.java
@@ -55,7 +55,7 @@ public class SumoGuiAmbassador extends SumoAmbassador {
         // SUMO needs to start the federate by itself, therefore we need to store the federate starter locally and use it later
         this.federateExecutor = new ExecutableFederateExecutor(
                 this.descriptor,
-                AbstractSumoAmbassador.getSumoExecutable("sumo-gui"),
+                AbstractSumoAmbassador.getFromSumoHome("sumo-gui"),
                 super.getProgramArguments(port)
         );
         this.startCmdPort = port;

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/junit/LibsumoCheckRule.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/junit/LibsumoCheckRule.java
@@ -37,7 +37,7 @@ public class LibsumoCheckRule implements TestRule {
                 if (!libsumoAvailable) {
                     throw new AssumptionViolatedException("Library 'Libsumo' is not available. Skipping tests.");
                 }
-                if (!LibSumoAmbassador.correctLibSumoVersion()) {
+                if (LibSumoAmbassador.incorrectLibSumoVersion()) {
                     throw new AssumptionViolatedException("Current SUMO version at " + getSumoExecutable("sumo") + " is not supported with LibSumo.");
                 }
                 statement.evaluate();


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

Since 1.16.0, the `libsumojni.dll` cannot be loaded anymore, resulting in a `UnsatisfiedLinkError` due to a missing dependent library. According to https://github.com/eclipse/sumo/issues/12605, neither the reason nor a solution for the error could be found, however, a workaround is proposed by loading dependent libraries before loading `libsumojni.dll`.

This MR implements the workaround by loading `iconv-2.dll`, `intl-8.dll` and `proj_9_0.dll` in advance. This is only executed on Windows machines, as it ~~seems to~~ works on Linux based systems as usual.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Internal issue 559
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

