### PR TITLE
fix(perception): perception modifiers should not alter objects from the index

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/AbstractPerceptionModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/AbstractPerceptionModule.java
@@ -94,9 +94,7 @@ public abstract class AbstractPerceptionModule
 
     @Override
     public List<VehicleObject> getPerceivedVehicles() {
-        List<VehicleObject> vehiclesInRange = new ArrayList<>(getVehiclesInRange());
-        vehiclesInRange = applyPerceptionModifiers(vehiclesInRange);
-        return vehiclesInRange;
+        return applyPerceptionModifiers(getVehiclesInRange());
     }
 
     /**
@@ -109,10 +107,8 @@ public abstract class AbstractPerceptionModule
 
     @Override
     public List<TrafficLightObject> getPerceivedTrafficLights() {
-        List<TrafficLightObject> trafficLightsInRange = new ArrayList<>(getTrafficLightsInRange());
         // TODO: we could add an additional filter here to check the traffic lights' orientation
-        trafficLightsInRange = applyPerceptionModifiers(trafficLightsInRange);
-        return trafficLightsInRange;
+        return applyPerceptionModifiers(getTrafficLightsInRange());
     }
 
     /**
@@ -138,8 +134,13 @@ public abstract class AbstractPerceptionModule
      */
     abstract List<SpatialObject> getObjectsInRange();
 
-    private <T extends SpatialObject> List<T> applyPerceptionModifiers(List<T> objectsInRange) {
-        List<T> filteredList = objectsInRange;
+    private <T extends SpatialObject<T>> List<T> applyPerceptionModifiers(List<T> objectsInRange) {
+        if (configuration.getPerceptionModifiers().isEmpty()) {
+            return objectsInRange;
+        }
+        List<T> filteredList = new ArrayList<>(objectsInRange);
+        // create copy of all perceived objects to avoid interference with modifiers of other perception modules.
+        filteredList.replaceAll(T::copy);
         for (PerceptionModifier perceptionModifier : configuration.getPerceptionModifiers()) {
             filteredList = perceptionModifier.apply(owner, filteredList); // apply filters in sequence
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/SpatialObject.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/SpatialObject.java
@@ -90,4 +90,12 @@ public abstract class SpatialObject<T extends SpatialObject<T>> extends Vector3d
         // use id as hashcode to store only one VehicleObject per vehicle id in perception index (e.q. quadtree)
         return this.id.hashCode();
     }
+
+    /**
+     * Returns a hard copy of the {@link SpatialObject}, this should be used
+     * when the data of a perceived object is to be altered or stored in memory.
+     *
+     * @return a copy of the {@link SpatialObject}
+     */
+    public abstract T copy();
 }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/TrafficLightObject.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/TrafficLightObject.java
@@ -105,4 +105,21 @@ public class TrafficLightObject extends SpatialObject<TrafficLightObject> {
                 .append(outgoingLane, that.outgoingLane)
                 .isEquals();
     }
+
+    /**
+     * Returns a hard copy of the {@link TrafficLightObject}, this should be used
+     * when the data of a perceived traffic light is to be altered or stored in memory.
+     *
+     * @return a copy of the {@link TrafficLightObject}
+     */
+    @Override
+    public TrafficLightObject copy() {
+        return (TrafficLightObject) new TrafficLightObject(getId())
+                .setIncomingLane(getIncomingLane())
+                .setOutgoingLane(getOutgoingLane())
+                .setTrafficLightState(getTrafficLightState())
+                .setTrafficLightGroupId(getTrafficLightGroupId())
+                .setPosition(getProjectedPosition());
+
+    }
 }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/VehicleObject.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/VehicleObject.java
@@ -141,17 +141,18 @@ public class VehicleObject extends SpatialObject<VehicleObject> {
 
     /**
      * Returns a hard copy of the {@link VehicleObject}, this should be used
-     * when the data of a perceived vehicle is to be stored in memory.
+     * when the data of a perceived vehicle is to be altered or stored in memory.
      *
      * @return a copy of the {@link VehicleObject}
      */
+    @Override
     public VehicleObject copy() {
-        VehicleObject copy = new VehicleObject(getId());
-        copy.setPosition(getProjectedPosition());
-        copy.setHeading(getHeading());
-        copy.setSpeed(getSpeed());
-        copy.setEdgeAndLane(getEdgeId(), getLaneIndex());
-        copy.setDimensions(getLength(), getWidth(), getHeight());
-        return copy;
+        return (VehicleObject) new VehicleObject(getId())
+                .setHeading(getHeading())
+                .setSpeed(getSpeed())
+                .setEdgeAndLane(getEdgeId(), getLaneIndex())
+                .setDimensions(getLength(), getWidth(), getHeight())
+                .setPosition(getProjectedPosition());
+
     }
 }


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* When perception modifiers were configured, they changed not only the perceived traffic objects, but also the indexed objects.
* This would lead to problems as soon as two vehicles with perception modifiers would perceive the same object.
* Therefore, with this PR copies of all `SpatialObject`s are created, before passing them to the configured perception modifiers. This is only done if perception modifiers are configured, in order to avoid unnecessary copy operations if they would not be required.
* An additional unit test proofs that the objects in the index are still at their original positions after applying any modifiers.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves issue internal issue 564
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

