### PR TITLE
bugfix(sumo): Proper handling of teleporting vehicles

### DIFF
--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/vehicle/PerceptionApp.java
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/vehicle/PerceptionApp.java
@@ -74,9 +74,7 @@ public class PerceptionApp extends AbstractApplication<VehicleOperatingSystem> i
 
         SimplePerceptionConfiguration perceptionModuleConfiguration =
                 new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE)
-                        .addModifier(simpleOcclusionModifier)
-                        .addModifier(distanceModifier)
-                        .addModifier(positionErrorModifier)
+                        .addModifiers(simpleOcclusionModifier, distanceModifier, positionErrorModifier)
                         .build();
         getOs().getPerceptionModule().enable(perceptionModuleConfiguration);
     }

--- a/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/vehicle/PerceptionApp.java
+++ b/app/tutorials/example-applications/src/main/java/org/eclipse/mosaic/app/tutorial/vehicle/PerceptionApp.java
@@ -72,10 +72,12 @@ public class PerceptionApp extends AbstractApplication<VehicleOperatingSystem> i
         // filter adding noise to longitudinal and lateral
         PositionErrorModifier positionErrorModifier = new PositionErrorModifier(getRandom());
 
-        SimplePerceptionConfiguration perceptionModuleConfiguration = new SimplePerceptionConfiguration(
-                VIEWING_ANGLE, VIEWING_RANGE,
-                simpleOcclusionModifier, distanceModifier, positionErrorModifier
-        );
+        SimplePerceptionConfiguration perceptionModuleConfiguration =
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE)
+                        .addModifier(simpleOcclusionModifier)
+                        .addModifier(distanceModifier)
+                        .addModifier(positionErrorModifier)
+                        .build();
         getOs().getPerceptionModule().enable(perceptionModuleConfiguration);
     }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/AbstractPerceptionModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/AbstractPerceptionModule.java
@@ -57,7 +57,7 @@ public abstract class AbstractPerceptionModule
         if (configuration == null) {
             log.warn("Provided perception configuration is null. Using default configuration with viewingAngle={}°, viewingRange={}m.",
                     DEFAULT_VIEWING_ANGLE, DEFAULT_VIEWING_RANGE);
-            this.configuration = new SimplePerceptionConfiguration(DEFAULT_VIEWING_ANGLE, DEFAULT_VIEWING_ANGLE);
+            this.configuration = new SimplePerceptionConfiguration.Builder(DEFAULT_VIEWING_ANGLE, DEFAULT_VIEWING_ANGLE).build();
         } else {
             this.configuration = configuration;
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionConfiguration.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionConfiguration.java
@@ -18,7 +18,10 @@ package org.eclipse.mosaic.fed.application.ambassador.simulation.perception;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.errormodels.PerceptionModifier;
 import org.eclipse.mosaic.fed.application.app.api.perception.PerceptionModuleConfiguration;
 
+import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SimplePerceptionConfiguration implements PerceptionModuleConfiguration {
@@ -70,8 +73,13 @@ public class SimplePerceptionConfiguration implements PerceptionModuleConfigurat
             return this;
         }
 
+        public Builder addModifiers(PerceptionModifier... perceptionModifiers) {
+            this.perceptionModifiers.addAll(Arrays.asList(perceptionModifiers));
+            return this;
+        }
+
         public SimplePerceptionConfiguration build() {
-            return new SimplePerceptionConfiguration(viewingAngle, viewingRange, perceptionModifiers);
+            return new SimplePerceptionConfiguration(viewingAngle, viewingRange, Lists.newArrayList(perceptionModifiers));
         }
     }
 }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionConfiguration.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionConfiguration.java
@@ -18,8 +18,7 @@ package org.eclipse.mosaic.fed.application.ambassador.simulation.perception;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.perception.errormodels.PerceptionModifier;
 import org.eclipse.mosaic.fed.application.app.api.perception.PerceptionModuleConfiguration;
 
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.List;
 
 public class SimplePerceptionConfiguration implements PerceptionModuleConfiguration {
@@ -36,10 +35,10 @@ public class SimplePerceptionConfiguration implements PerceptionModuleConfigurat
 
     private final List<PerceptionModifier> perceptionModifiers;
 
-    public SimplePerceptionConfiguration(double viewingAngle, double viewingRange, PerceptionModifier... perceptionModifiers) {
+    private SimplePerceptionConfiguration(double viewingAngle, double viewingRange, List<PerceptionModifier> perceptionModifiers) {
         this.viewingAngle = viewingAngle;
         this.viewingRange = viewingRange;
-        this.perceptionModifiers = Lists.newArrayList(perceptionModifiers);
+        this.perceptionModifiers = perceptionModifiers;
     }
 
     public double getViewingAngle() {
@@ -53,5 +52,26 @@ public class SimplePerceptionConfiguration implements PerceptionModuleConfigurat
 
     public List<PerceptionModifier> getPerceptionModifiers() {
         return perceptionModifiers;
+    }
+
+    public static class Builder {
+        private final double viewingAngle;
+        private final double viewingRange;
+
+        private final List<PerceptionModifier> perceptionModifiers = new ArrayList<>();
+
+        public Builder(double viewingAngle, double viewingRange) {
+            this.viewingAngle = viewingAngle;
+            this.viewingRange = viewingRange;
+        }
+
+        public Builder addModifier(PerceptionModifier perceptionModifier) {
+            perceptionModifiers.add(perceptionModifier);
+            return this;
+        }
+
+        public SimplePerceptionConfiguration build() {
+            return new SimplePerceptionConfiguration(viewingAngle, viewingRange, perceptionModifiers);
+        }
     }
 }

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/PerceptionModifierTest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mosaic.fed.application.ambassador.simulation.perception;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
@@ -135,7 +136,9 @@ public class PerceptionModifierTest {
     @Test
     public void testOcclusionModifier() {
         SimpleOcclusionModifier occlusionModifier = new SimpleOcclusionModifier(3, 10);
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(VIEWING_ANGLE, VIEWING_RANGE, occlusionModifier));
+        simplePerceptionModule.enable(
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE).addModifier(occlusionModifier).build()
+        );
         List<VehicleObject> perceivedVehicles = simplePerceptionModule.getPerceivedVehicles();
         if (PRINT_POSITIONS) {
             printPerceivedPositions(perceivedVehicles);
@@ -146,7 +149,9 @@ public class PerceptionModifierTest {
     @Test
     public void testDistanceErrorModifier() {
         DistanceModifier distanceModifier = new DistanceModifier(rng, 0);
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(VIEWING_ANGLE, VIEWING_RANGE, distanceModifier));
+        simplePerceptionModule.enable(
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE).addModifier(distanceModifier).build()
+        );
 
         List<VehicleObject> perceivedVehicles = simplePerceptionModule.getPerceivedVehicles();
         if (PRINT_POSITIONS) {
@@ -158,13 +163,15 @@ public class PerceptionModifierTest {
     @Test
     public void testPositionErrorModifier() {
         PositionErrorModifier positionErrorModifier = new PositionErrorModifier(rng, 1, 1);
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(VIEWING_ANGLE, VIEWING_RANGE, positionErrorModifier));
+        simplePerceptionModule.enable(
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE).addModifier(positionErrorModifier).build()
+        );
 
         List<VehicleObject> perceivedVehicles = simplePerceptionModule.getPerceivedVehicles();
         if (PRINT_POSITIONS) {
             printPerceivedPositions(perceivedVehicles);
         }
-        assertTrue("The position error filter shouldn't remove vehicles", VEHICLE_AMOUNT == perceivedVehicles.size());
+        assertEquals("The position error filter shouldn't remove vehicles", VEHICLE_AMOUNT, perceivedVehicles.size());
     }
 
     @Test
@@ -175,7 +182,9 @@ public class PerceptionModifierTest {
         doReturn(surroundingWalls).when(simplePerceptionModule).getSurroundingWalls();
 
         WallOcclusionModifier occlusionModifier = new WallOcclusionModifier();
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(VIEWING_ANGLE, VIEWING_RANGE, occlusionModifier));
+        simplePerceptionModule.enable(
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE).addModifier(occlusionModifier).build()
+        );
         List<VehicleObject> perceivedVehicles = simplePerceptionModule.getPerceivedVehicles();
         if (PRINT_POSITIONS) {
             printPerceivedPositions(perceivedVehicles);
@@ -192,7 +201,9 @@ public class PerceptionModifierTest {
     @Test
     public void testIndexedObjectsNotChanged() {
         PositionErrorModifier positionErrorModifier = new PositionErrorModifier(rng, 1, 1);
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(VIEWING_ANGLE, VIEWING_RANGE, positionErrorModifier));
+        simplePerceptionModule.enable(
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE).addModifier(positionErrorModifier).build()
+        );
 
         // collect positions of perceived objects BEFORE applying modifier
         PerceptionModel godView = mock(PerceptionModel.class);

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/SimplePerceptionModuleTest.java
@@ -103,7 +103,7 @@ public class SimplePerceptionModuleTest {
         VehicleUnit egoVehicleUnit = spy(new VehicleUnit("veh_0", mock(VehicleType.class), null));
         doReturn(egoVehicleData).when(egoVehicleUnit).getVehicleData();
         simplePerceptionModule = spy(new SimplePerceptionModule(egoVehicleUnit, null, mock(Logger.class)));
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(90d, 200d));
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(90d, 200d).build());
 
         // setup ego vehicle
         when(egoVehicleData.getHeading()).thenReturn(90d);
@@ -165,21 +165,21 @@ public class SimplePerceptionModuleTest {
 
     @Test
     public void vehicleCanBePerceived_270viewingAngle_VehicleOnDirectionVector_TrivialIndex() {
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(110, 100, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
     public void vehicleCanBePerceived_FarLeft_270viewingAngle_TrivialIndex() {
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(105, 115, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
 
     @Test
     public void vehicleCanBePerceived_FarRight_270viewingAngle_TrivialIndex() {
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(105, 90, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
@@ -241,7 +241,7 @@ public class SimplePerceptionModuleTest {
     @Test
     public void vehicleCanBePerceived_FarLeft_270viewingAngle_QuadTree() {
         useQuadTree();
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(105, 115, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
@@ -249,7 +249,7 @@ public class SimplePerceptionModuleTest {
     @Test
     public void vehicleCanBePerceived_FarRight_270viewingAngle_QuadTree() {
         useQuadTree();
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(105, 90, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
@@ -311,7 +311,7 @@ public class SimplePerceptionModuleTest {
     @Test
     public void vehicleCanBePerceived_FarLeft_270viewingAngle_Grid() {
         useGrid();
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(105, 115, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }
@@ -319,7 +319,7 @@ public class SimplePerceptionModuleTest {
     @Test
     public void vehicleCanBePerceived_FarRight_270viewingAngle_Grid() {
         useGrid();
-        simplePerceptionModule.enable(new SimplePerceptionConfiguration(270d, 200d)); // overwrite config
+        simplePerceptionModule.enable(new SimplePerceptionConfiguration.Builder(270d, 200d).build()); // overwrite config
         setupVehicles(new MutableCartesianPoint(105, 90, 0));
         assertEquals(1, simplePerceptionModule.getPerceivedVehicles().size());
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleGetTeleportingList.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/VehicleGetTeleportingList.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.api;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+import java.util.List;
+
+public interface VehicleGetTeleportingList {
+
+    /**
+     * This method executes the SUMO command to the list of vehicles that are currently teleporting (not simulated in the network).
+     *
+     * @param bridge Connection to SUMO.
+     * @return a list of vehicles that are currently teleporting
+     * @throws CommandException          if the status code of the response is ERROR. The connection to SUMO is still available.
+     * @throws InternalFederateException if some serious error occurs during writing or reading. The connection to SUMO is shut down.
+     */
+    List<String> execute(Bridge bridge) throws CommandException, InternalFederateException;
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/facades/SimulationFacade.java
@@ -30,6 +30,7 @@ import org.eclipse.mosaic.fed.sumo.bridge.api.SimulationGetTrafficLightIds;
 import org.eclipse.mosaic.fed.sumo.bridge.api.SimulationSimulateStep;
 import org.eclipse.mosaic.fed.sumo.bridge.api.TrafficLightSubscribe;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleAdd;
+import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleGetTeleportingList;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSetRemove;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSetUpdateBestLanes;
 import org.eclipse.mosaic.fed.sumo.bridge.api.VehicleSubscribe;
@@ -100,6 +101,7 @@ public class SimulationFacade {
     private final SimulationGetTrafficLightIds getTrafficLightIds;
     private final VehicleAdd vehicleAdd;
     private final VehicleSetRemove remove;
+    private final VehicleGetTeleportingList getTeleportingList;
 
 
     private final VehicleSubscribe vehicleSubscribe;
@@ -139,7 +141,7 @@ public class SimulationFacade {
             return lastVehicleData != currentVehicleData && currentVehicleData != null;
         }
 
-        private boolean isRemoved() {
+        private boolean isNotUpdated() {
             return lastVehicleData != null && currentVehicleData == lastVehicleData;
         }
     }
@@ -169,6 +171,7 @@ public class SimulationFacade {
         this.getTrafficLightIds = bridge.getCommandRegister().getOrCreate(SimulationGetTrafficLightIds.class);
         this.vehicleAdd = bridge.getCommandRegister().getOrCreate(VehicleAdd.class);
         this.remove = bridge.getCommandRegister().getOrCreate(VehicleSetRemove.class);
+        this.getTeleportingList = bridge.getCommandRegister().getOrCreate(VehicleGetTeleportingList.class);
 
         this.inductionloopSubscribe = bridge.getCommandRegister().getOrCreate(InductionLoopSubscribe.class);
         this.laneAreaSubscribe = bridge.getCommandRegister().getOrCreate(LaneAreaSubscribe.class);
@@ -401,7 +404,7 @@ public class SimulationFacade {
      * Enables the calculation of distance sensor values for the given vehicle.
      */
     public void configureDistanceSensors(String vehicleId, double maximumLookahead, boolean front, boolean rear) {
-        SumoVehicleState vehicleState = getVehicleState(vehicleId);
+        SumoVehicleState vehicleState = getOrCreateVehicleState(vehicleId);
         if (front) {
             vehicleState.frontSensorDistance = maximumLookahead > 0 ? maximumLookahead : null;
         }
@@ -491,9 +494,9 @@ public class SimulationFacade {
     private SumoVehicleState processVehicleSubscriptionResult(final long time,
                                                               final VehicleSubscriptionResult veh,
                                                               final Map<String, String> vehicleSegmentInfo
-    ) {
+    ) throws CommandException, InternalFederateException {
 
-        final SumoVehicleState sumoVehicle = getVehicleState(veh.id);
+        final SumoVehicleState sumoVehicle = getOrCreateVehicleState(veh.id);
         final VehicleStopMode vehicleStopMode = VehicleStopMode.fromSumoInt(veh.stoppedStateEncoded);
         final boolean isParking = vehicleStopMode.isParking();
         final boolean hasInvalidPosition = veh.position == null || !veh.position.isValid();
@@ -503,17 +506,23 @@ public class SimulationFacade {
         final boolean isWaitingToLeaveParking = !isNewVehicle && hasInvalidPosition // check for "waiting" state
                 && sumoVehicle.lastVehicleData.getVehicleStopMode().isParking(); // check if was parked
 
-        if (hasInvalidPosition && isNewVehicle) {
-            /* if a vehicle has not yet been simulated but loaded by SUMO, the vehicle's position will be invalid.
-             * We ignore this vehicle until it's added to the simulation. */
-            log.debug("Skip vehicle {} which is loaded but not yet simulated.", veh.id);
-            return null;
-        }
-
         if (hasInvalidPosition && !isWaitingToLeaveParking) {
-            /* If the vehicle, however,  has already been in the simulation (lastVehicleData was valid),
-             * then there seems to be an error and the vehicle state will not be updated, resulting in a removal of the vehicle. */
-            log.warn("vehicle {} has no valid position and will be removed.", veh.id);
+            if (isNewVehicle) {
+                /* If a vehicle has not yet been simulated but loaded by SUMO, the vehicle's position will be invalid.
+                 * We ignore this vehicle until it's added to the simulation. */
+                log.debug("Skip vehicle {} which is loaded but not yet simulated.", veh.id);
+                return null;
+            }
+            boolean isTeleporting = getTeleportingList.execute(bridge).contains(veh.id); // we check this here to limit SUMO API calls
+            if (isTeleporting) {
+                /* If the vehicle is teleporting we don't stop the subscription. However, the state of the vehicle won't
+                be updated until the teleport is finished, as we cannot be sure of the behaviour during teleporting. */
+                sumoVehicle.currentVehicleData = new VehicleData.Builder(time, veh.id).copyFrom(sumoVehicle.lastVehicleData)
+                        .stopped(VehicleStopMode.NOT_STOPPED) // teleporting vehicles are not stopped to differentiate from stopped vehicles
+                        .create();
+                return sumoVehicle;
+            }
+            log.warn("Vehicle {} has no valid position and will be removed.", veh.id);
             return sumoVehicle;
         }
 
@@ -552,9 +561,8 @@ public class SimulationFacade {
                         // for parking vehicles, there are no consumptions and emissions to measure
                         .consumptions(new VehicleConsumptions(
                                 new Consumptions(0d), sumoVehicle.lastVehicleData.getVehicleConsumptions().getAllConsumptions())
-                        ).emissions(
-                                new VehicleEmissions(new Emissions(0d, 0d, 0d, 0d, 0d),
-                                        sumoVehicle.lastVehicleData.getVehicleEmissions().getAllEmissions()));
+                        ).emissions(new VehicleEmissions(
+                                new Emissions(0d, 0d, 0d, 0d, 0d), sumoVehicle.lastVehicleData.getVehicleEmissions().getAllEmissions()));
             } else {
                 vehicleDataBuilder
                         .road(getRoadPosition(veh, sumoVehicle.lastVehicleData))
@@ -571,11 +579,11 @@ public class SimulationFacade {
         return new PublicTransportData.Builder().withLineId(veh.line).nextStops(veh.nextStops).build();
     }
 
-    private List<String> findRemovedVehicles(long time) {
+    private List<String> findRemovedVehicles(long time) throws CommandException, InternalFederateException {
         final List<String> removedVehicles = new LinkedList<>();
         for (Iterator<SumoVehicleState> vehicleIt = sumoVehicles.values().iterator(); vehicleIt.hasNext(); ) {
             SumoVehicleState vehicle = vehicleIt.next();
-            if (vehicle.isRemoved()) {
+            if (vehicle.isNotUpdated()) {
                 removedVehicles.add(vehicle.id);
                 vehicleIt.remove();
                 log.info("Removed vehicle \"{}\" at simulation time {}ns", vehicle.id, time);
@@ -586,7 +594,7 @@ public class SimulationFacade {
 
 
     private void processVehicleContextSubscriptionResult(VehicleContextSubscriptionResult contextSubscriptionResult) {
-        SumoVehicleState sumoVehicleState = getVehicleState(contextSubscriptionResult.id);
+        SumoVehicleState sumoVehicleState = getOrCreateVehicleState(contextSubscriptionResult.id);
         for (VehicleSubscriptionResult vehInSight : contextSubscriptionResult.contextSubscriptions) {
             if (contextSubscriptionResult.id.equals(vehInSight.id)) {
                 continue;
@@ -726,7 +734,7 @@ public class SimulationFacade {
         return vehicleToSegmentMap;
     }
 
-    private SumoVehicleState getVehicleState(String id) {
+    private SumoVehicleState getOrCreateVehicleState(String id) {
         return sumoVehicles.computeIfAbsent(id, SumoVehicleState::new);
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleGetTeleportingList.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/VehicleGetTeleportingList.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.libsumo;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+import com.google.common.collect.Lists;
+import org.eclipse.sumo.libsumo.StringVector;
+import org.eclipse.sumo.libsumo.Vehicle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class VehicleGetTeleportingList implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleGetTeleportingList {
+    @Override
+    public List<String> execute(Bridge bridge) throws CommandException, InternalFederateException {
+        return Vehicle.getTeleportingIDList().stream()
+                .map(Bridge.VEHICLE_ID_TRANSFORMER::fromExternalId).collect(Collectors.toList());
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleGetTeleportingList.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleGetTeleportingList.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.fed.sumo.bridge.traci;
+
+import org.eclipse.mosaic.fed.sumo.bridge.Bridge;
+import org.eclipse.mosaic.fed.sumo.bridge.CommandException;
+import org.eclipse.mosaic.fed.sumo.bridge.TraciVersion;
+import org.eclipse.mosaic.fed.sumo.bridge.api.complex.Status;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.constants.TraciDatatypes;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.reader.ListTraciReader;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.reader.StringTraciReader;
+import org.eclipse.mosaic.fed.sumo.bridge.traci.reader.VehicleIdTraciReader;
+import org.eclipse.mosaic.rti.api.InternalFederateException;
+
+import java.util.List;
+
+public class VehicleGetTeleportingList extends AbstractTraciCommand<List<String>> implements org.eclipse.mosaic.fed.sumo.bridge.api.VehicleGetTeleportingList {
+
+    public VehicleGetTeleportingList() {
+        super(TraciVersion.LOWEST);
+
+        write()
+                .command(CommandRetrieveVehicleState.COMMAND)
+                .variable(CommandRetrieveVehicleState.VAR_TELEPORTING_LIST)
+                .writeString("");
+
+        read()
+                .skipBytes(2)
+                .skipString()
+                .expectByte(TraciDatatypes.STRING_LIST)
+                .readComplex(new ListTraciReader<>(new VehicleIdTraciReader()));
+    }
+
+    @Override
+    public List<String> execute(Bridge bridge) throws CommandException, InternalFederateException {
+        return executeAndReturn(bridge).orElseThrow(
+                () -> new CommandException("Could not extract teleporting vehicles.")
+        );
+    }
+
+    @Override
+    protected List<String> constructResult(Status status, Object... objects) {
+        return (List<String>) objects[0];
+    }
+}

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleSubscribe.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/VehicleSubscribe.java
@@ -26,8 +26,8 @@ import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieve
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_EMISSIONS_NOX;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_EMISSIONS_PMX;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_FOLLOWER;
-import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_GET_LINE;
-import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_GET_NEXT_STOPS;
+import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LINE;
+import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_NEXT_STOPS;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LANE_INDEX;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LANE_POSITION;
 import static org.eclipse.mosaic.fed.sumo.bridge.traci.constants.CommandRetrieveVehicleState.VAR_LATERAL_LANE_POSITION;
@@ -123,8 +123,8 @@ public class VehicleSubscribe
         }
 
         if (subscriptionCategories.contains(CSumo.SUBSCRIPTION_TRAINS)) {
-            Collections.addAll(subscriptionCodes, VAR_GET_NEXT_STOPS);
-            Collections.addAll(subscriptionCodes, VAR_GET_LINE);
+            Collections.addAll(subscriptionCodes, VAR_NEXT_STOPS);
+            Collections.addAll(subscriptionCodes, VAR_LINE);
         }
         return subscriptionCodes;
     }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleState.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/constants/CommandRetrieveVehicleState.java
@@ -67,8 +67,8 @@ public class CommandRetrieveVehicleState {
 
     public final static SumoVar VAR_EMISSIONS_ELECTRICITY = SumoVar.var(0x71);
 
-    public final static SumoVar VAR_GET_NEXT_STOPS = SumoVar.var(0x73);
-    public final static SumoVar VAR_GET_LINE = SumoVar.var(0xbd);
+    public final static SumoVar VAR_NEXT_STOPS = SumoVar.var(0x73);
+    public final static SumoVar VAR_LINE = SumoVar.var(0xbd);
 
     public final static SumoVar VAR_STOP_STATE = SumoVar.var(0xb5);
 
@@ -76,5 +76,7 @@ public class CommandRetrieveVehicleState {
     public final static SumoVar VAR_LENGTH = SumoVar.var(0x44);
     public final static SumoVar VAR_WIDTH = SumoVar.var(0x4d);
     public final static SumoVar VAR_HEIGHT = SumoVar.var(0xbc);
+
+    public final static SumoVar VAR_TELEPORTING_LIST = SumoVar.var(0x25);
 }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/VehicleSubscriptionTraciReader.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/VehicleSubscriptionTraciReader.java
@@ -38,7 +38,7 @@ public class VehicleSubscriptionTraciReader extends AbstractSubscriptionTraciRea
         LeadingVehicleReader leadingVehicleReader = new LeadingVehicleReader();
         getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_LEADER.var, leadingVehicleReader);
         getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_FOLLOWER.var, leadingVehicleReader);
-        getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_GET_NEXT_STOPS.var, new StoppingPlaceReader());
+        getTypeBasedTraciReader().registerCompoundReader(CommandRetrieveVehicleState.VAR_NEXT_STOPS.var, new StoppingPlaceReader());
     }
 
     @Override
@@ -104,9 +104,9 @@ public class VehicleSubscriptionTraciReader extends AbstractSubscriptionTraciRea
             result.followerVehicle = (LeadFollowVehicle) varValue;
         } else if (varId == CommandRetrieveVehicleState.VAR_MIN_GAP.var) {
             result.minGap = (double) varValue;
-        } else if (varId == CommandRetrieveVehicleState.VAR_GET_NEXT_STOPS.var) {
+        } else if (varId == CommandRetrieveVehicleState.VAR_NEXT_STOPS.var) {
             result.nextStops = (List<PublicTransportData.StoppingPlace>) varValue;
-        } else if (varId == CommandRetrieveVehicleState.VAR_GET_LINE.var) {
+        } else if (varId == CommandRetrieveVehicleState.VAR_LINE.var) {
             result.line = (String) varValue;
         } else if (varId == CommandRetrieveVehicleState.VAR_LENGTH.var) {
             result.length = (double) varValue;

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/SumoTeleportIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/SumoTeleportIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.test;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.mosaic.starter.MosaicSimulation;
+import org.eclipse.mosaic.test.junit.LogAssert;
+import org.eclipse.mosaic.test.junit.MosaicSimulationRule;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class SumoTeleportIT {
+
+    @ClassRule
+    public static MosaicSimulationRule simulationRule = new MosaicSimulationRule().logLevelOverride("TRACE");
+
+    private static MosaicSimulation.SimulationResult simulationResult;
+
+
+    private final static String VEH_LOG = "apps/veh_0/TeleportingVehicleApp.log";
+
+    @BeforeClass
+    public static void runSimulation() {
+        simulationRule.watchdog(0);
+        // use Tiergarten scenario with different route and mapping file
+        simulationRule.federateConfigurationManipulator("mapping", (conf) -> conf.configuration = "teleport_mapping_config.json")
+                .federateConfigurationManipulator("sumo", (conf) -> {
+                    conf.configuration = "teleport_sumo_config.json";
+                });
+        simulationResult = simulationRule.executeTestScenario("sumo-predefined-scenario-integration");
+    }
+
+    @Test
+    public void executionSuccessful() {
+        assertNull(simulationResult.exception);
+        assertTrue(simulationResult.success);
+    }
+
+    @Test
+    public void allLogsCreated() {
+        LogAssert.exists(simulationRule, VEH_LOG);
+    }
+
+    @Test
+    public void vehicleTeleportsAndIsStillSubscribed() throws Exception {
+        LogAssert.contains(simulationRule, VEH_LOG, ".*I moved from .* to .* before teleport.*");
+        LogAssert.contains(simulationRule, VEH_LOG, ".*I started teleporting.*");
+        LogAssert.contains(simulationRule, VEH_LOG, ".*I'm currently teleporting.*");
+        LogAssert.contains(simulationRule, VEH_LOG, ".*I moved from .* to .* after teleport.*");
+    }
+}

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/perceptionmodule/SimplePerceptionApp.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/perceptionmodule/SimplePerceptionApp.java
@@ -49,7 +49,7 @@ public class SimplePerceptionApp extends AbstractApplication<VehicleOperatingSys
 
     private void enablePerceptionModule() {
         SimplePerceptionConfiguration perceptionModuleConfiguration =
-                new SimplePerceptionConfiguration(VIEWING_ANGLE, VIEWING_RANGE);
+                new SimplePerceptionConfiguration.Builder(VIEWING_ANGLE, VIEWING_RANGE).build();
         getOs().getPerceptionModule().enable(perceptionModuleConfiguration);
     }
 

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendonshutdown/SendOnShutdownApp.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendonshutdown/SendOnShutdownApp.java
@@ -27,18 +27,18 @@ public class SendOnShutdownApp extends AbstractApplication<VehicleOperatingSyste
         getOs().getAdHocModule().enable();
 
         getOs().getAdHocModule().sendV2xMessage(new ShutdownMessage(
-                getOs().getAdHocModule().createMessageRouting().topoCast("rsu_0", 1 )
+                getOs().getAdHocModule().createMessageRouting().topoCast("rsu_0", 1)
         ));
     }
 
     @Override
     public void onShutdown() {
         getOs().getCellModule().sendV2xMessage(new ShutdownMessage(
-                getOs().getCellModule().createMessageRouting().topoCast("server_0" )
+                getOs().getCellModule().createMessageRouting().topoCast("server_0")
         ));
 
         getOs().getAdHocModule().sendV2xMessage(new ShutdownMessage(
-                getOs().getAdHocModule().createMessageRouting().topoCast("rsu_0", 1 )
+                getOs().getAdHocModule().createMessageRouting().topoCast("rsu_0", 1)
         ));
     }
 

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendonshutdown/ServerReceiverApp.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendonshutdown/ServerReceiverApp.java
@@ -41,7 +41,7 @@ public class ServerReceiverApp extends AbstractApplication<ServerOperatingSystem
 
     @Override
     public void onShutdown() {
-        getLog().infoSimTime(this, "Shutdown server." );
+        getLog().infoSimTime(this, "Shutdown server.");
     }
 
     @Override

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sumoteleport/TeleportingVehicleApp.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sumoteleport/TeleportingVehicleApp.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.test.app.sumoteleport;
+
+import org.eclipse.mosaic.fed.application.app.AbstractApplication;
+import org.eclipse.mosaic.fed.application.app.api.VehicleApplication;
+import org.eclipse.mosaic.fed.application.app.api.os.VehicleOperatingSystem;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
+import org.eclipse.mosaic.lib.util.scheduling.Event;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class TeleportingVehicleApp extends AbstractApplication<VehicleOperatingSystem> implements VehicleApplication {
+
+    private boolean startedTeleporting = false;
+    private boolean stoppedTeleporting = false;
+
+    @Override
+    public void onStartup() {
+
+    }
+
+    @Override
+    public void onShutdown() {
+
+    }
+
+    @Override
+    public void processEvent(Event event) throws Exception {
+
+    }
+
+    @Override
+    public void onVehicleUpdated(@Nullable VehicleData previousVehicleData, @Nonnull VehicleData updatedVehicleData) {
+        if (previousVehicleData == null) {
+            return;
+        }
+        if (updatedVehicleData.isStopped()) {
+            getLog().infoSimTime(this, "I'm stopped at", updatedVehicleData.getPosition());
+        } else if (previousVehicleData.getPosition().equals(updatedVehicleData.getPosition())) {
+            if (!startedTeleporting) {
+                getLog().infoSimTime(this, "I started teleporting");
+                startedTeleporting = true;
+            } else {
+                getLog().infoSimTime(this, "I'm currently teleporting");
+            }
+        } else {
+            if (!startedTeleporting && !stoppedTeleporting) {
+                getLog().infoSimTime(this, "I moved from {} to {} before teleport",
+                        previousVehicleData.getPosition(), updatedVehicleData.getPosition());
+            } else if (startedTeleporting && !stoppedTeleporting) {
+                getLog().infoSimTime(this, "I finished teleporting at {}", updatedVehicleData.getPosition());
+                stoppedTeleporting = true;
+            } else {
+                getLog().infoSimTime(this, "I moved from {} to {} after teleport",
+                        previousVehicleData.getPosition(), updatedVehicleData.getPosition());
+            }
+        }
+    }
+}

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/junit/MosaicSimulationRule.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/junit/MosaicSimulationRule.java
@@ -311,6 +311,7 @@ public class MosaicSimulationRule extends TemporaryFolder {
      * DO NOT commit test with having this activated.
      */
     public void activateSumoGui() {
+        watchdog(0); // when using GUI watchdog pretty much has to be disabled
         getRuntimeConfiguration().federates.stream().filter(s -> s.id.equals("sumo")).forEach(
                 s -> s.classname = SumoGuiAmbassador.class.getCanonicalName()
         );

--- a/test/scenarios/sumo-predefined-scenario-integration/mapping/teleport_mapping_config.json
+++ b/test/scenarios/sumo-predefined-scenario-integration/mapping/teleport_mapping_config.json
@@ -1,0 +1,10 @@
+{
+    "prototypes": [
+        {
+            "name": "TeleportVehicle",
+            "applications": [
+                "org.eclipse.mosaic.test.app.sumoteleport.TeleportingVehicleApp"
+            ]
+        }
+    ]
+}

--- a/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_sumo_config.json
+++ b/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_sumo_config.json
@@ -1,0 +1,3 @@
+{
+    "sumoConfigurationFile": "teleport_tiergarten.sumocfg"
+}

--- a/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_tiergarten.rou.xml
+++ b/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_tiergarten.rou.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020 Fraunhofer FOKUS and others. All rights reserved.
+  ~ Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.

--- a/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_tiergarten.rou.xml
+++ b/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_tiergarten.rou.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2020 Fraunhofer FOKUS and others. All rights reserved.
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Eclipse Public License 2.0 which is available at
+  ~ http://www.eclipse.org/legal/epl-2.0
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  ~
+  ~ Contact: mosaic@fokus.fraunhofer.de
+  -->
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vType id="TeleportVehicle"/>
+    <route id="teleport_route" edges="4068038_251150126_428788319 4068038_428788319_408194194 4068038_408194194_423839224"/>
+    <vehicle id="0" type="TeleportVehicle" depart="10" route="teleport_route">
+        <stop edge="4068038_251150126_428788319" jump="15" endPos="10" duration="10"/>
+        <stop edge="4068038_408194194_423839224" endPos="10" duration="10"/>
+    </vehicle>
+</routes>

--- a/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_tiergarten.sumocfg
+++ b/test/scenarios/sumo-predefined-scenario-integration/sumo/teleport_tiergarten.sumocfg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <input>
+        <net-file value="tiergarten.net.xml"/>
+        <route-files value="teleport_tiergarten.rou.xml"/>
+    </input>
+    <time>
+        <begin value="0"/>
+        <end value="10000"/>
+    </time>
+</configuration>


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* This PR adds proper handling of SUMO vehicles that teleport for more than one second
* Instead of removing them from the subscription list they will now have the `VehicleData` from the last time step before the teleport starts.
    * To differentiate between parking/stopped vehicles the `VehicleStopMode` will be set to `NOT_STOPPED`.
* The current implementation requires the additional traci command `getTeleportingList` of the vehicle domain. However, the calls are limited as they are only required if the subscription result from SUMO was erroneous.
* The new functionality is tested by an integration test, which builds on the existing Tiergarten test-scenario.

* As an additional feature of this PR the instantiation of the `SimplePerceptionConfiguration` has been transferred to be using a builder pattern as this allows easier configuration of perception modifiers

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* relates to internal issue 568
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

None.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

