### PR TITLE
fix(application): schedule application shutdown events last

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
@@ -218,7 +218,10 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
         SimulationKernel.SimulationKernel.setRandomNumberGenerator(rti.createRandomNumberGenerator());
 
         // shutdown remaining simulation units within the simulation time frame
-        SimulationKernel.SimulationKernel.getEventManager().addEvent(endTime, this::shutdownSimulationUnits);
+        SimulationKernel.SimulationKernel.getEventManager()
+                .newEvent(endTime, this::shutdownSimulationUnits)
+                .withNice(EventNicenessPriorityRegister.UNIT_REMOVED)
+                .schedule();
     }
 
     private void shutdownSimulationUnits(Event event) {
@@ -322,7 +325,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
             final Event event = new Event(
                     vehicleBatteryUpdates.getTime(), simulationUnit,
                     batteryData,
-                    EventNicenessPriorityRegister.batteryUpdated
+                    EventNicenessPriorityRegister.BATTERY_UPDATED
             );
             addEvent(event);
         }
@@ -413,13 +416,13 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                     addEvent(new Event(
                             vehicleSeenTrafficSignsUpdate.getTime(),
                             e -> vehicleSeenTrafficSignsUpdate.getNewSigns(vehicleId).forEach(application::onTrafficSignNoticed),
-                            EventNicenessPriorityRegister.updateSeenTrafficSign
+                            EventNicenessPriorityRegister.UPDATE_SEEN_TRAFFIC_SIGN
 
                     ));
                     addEvent(new Event(
                             vehicleSeenTrafficSignsUpdate.getTime(),
                             e -> vehicleSeenTrafficSignsUpdate.getPassedSigns(vehicleId).forEach(application::onTrafficSignInvalidated),
-                            EventNicenessPriorityRegister.updateSeenTrafficSign
+                            EventNicenessPriorityRegister.UPDATE_SEEN_TRAFFIC_SIGN
                     ));
                 }
             }
@@ -438,7 +441,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                 chargingStationData.getTime(),
                 simulationUnit,
                 chargingStationData,
-                EventNicenessPriorityRegister.updateChargingStation
+                EventNicenessPriorityRegister.UPDATE_CHARGING_STATION
         );
         addEvent(event);
     }
@@ -453,7 +456,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                 vehicleChargingDenial.getTime(),
                 simulationUnit,
                 vehicleChargingDenial,
-                EventNicenessPriorityRegister.chargingRejected
+                EventNicenessPriorityRegister.CHARGING_REJECTED
         );
         addEvent(event);
     }
@@ -478,7 +481,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                 v2xMessageReception.getTime(),
                 simulationUnit,
                 receivedV2xMessage,
-                EventNicenessPriorityRegister.v2xMessageReception
+                EventNicenessPriorityRegister.V2X_MESSAGE_RECEPTION
         );
 
         addEvent(event);
@@ -499,7 +502,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                 v2xFullMessageReception.getTime(),
                 simulationUnit,
                 receivedV2xMessage,
-                EventNicenessPriorityRegister.v2xFullMessageReception
+                EventNicenessPriorityRegister.V2X_FULL_MESSAGE_RECEPTION
         );
         addEvent(event);
     }
@@ -551,7 +554,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                         relevantUpdates.getTime(),
                         tmc,
                         relevantUpdates,
-                        EventNicenessPriorityRegister.updateTrafficDetectors
+                        EventNicenessPriorityRegister.UPDATE_TRAFFIC_DETECTORS
                 );
                 addEvent(event);
             }
@@ -603,7 +606,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
         final Event event = new Event(
                 v2xMessageAcknowledgement.getTime(),
                 simulationUnit, v2xMessageAcknowledgement,
-                EventNicenessPriorityRegister.v2xMessageAcknowledgement
+                EventNicenessPriorityRegister.V2X_MESSAGE_ACKNOWLEDGEMENT
         );
         addEvent(event);
     }
@@ -618,7 +621,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                         trafficLightUpdates.getTime(),
                         simulationUnit,
                         trafficLightGroupInfo,
-                        EventNicenessPriorityRegister.updateTrafficLight
+                        EventNicenessPriorityRegister.UPDATE_TRAFFIC_LIGHT
                 );
                 addEvent(event);
             }
@@ -640,7 +643,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                     vehicleData.getTime(),
                     simulationUnit,
                     vehicleData,
-                    EventNicenessPriorityRegister.vehicleAdded
+                    EventNicenessPriorityRegister.VEHICLE_ADDED
             );
             addEvent(event);
         }
@@ -657,7 +660,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                     vehicleData.getTime(),
                     simulationUnit,
                     vehicleData,
-                    EventNicenessPriorityRegister.vehicleUpdated
+                    EventNicenessPriorityRegister.VEHICLE_UPDATED
             );
             addEvent(event);
         }
@@ -672,7 +675,7 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
                 vehicleUpdates.getTime(),
                 UnitSimulator.UnitSimulator,
                 removeVehicles,
-                EventNicenessPriorityRegister.vehicleRemoved
+                EventNicenessPriorityRegister.VEHICLE_REMOVED
         );
         addEvent(event);
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/AbstractSimulationUnit.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/AbstractSimulationUnit.java
@@ -292,10 +292,10 @@ public abstract class AbstractSimulationUnit implements EventProcessor, Operatin
                             throw new RuntimeException(ErrorRegister.SIMULATION_UNIT_IsNotAssignableFrom.toString());
                         }
                     } else {
-                        osLog.warn("Could not check operating system of Application. Skipping check.");
+                        osLog.debug("Could not check operating system of Application. Skipping check.");
                     }
                 } catch (ClassNotFoundException e) {
-                    osLog.warn("Check for operating system of Application failed. Skipping check.", e);
+                    osLog.debug("Check for operating system of Application failed. Skipping check.", e);
                 }
             }
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/util/EventNicenessPriorityRegister.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/util/EventNicenessPriorityRegister.java
@@ -19,29 +19,30 @@ package org.eclipse.mosaic.fed.application.ambassador.util;
  * top = highest priority. bottom lowest priority.
  */
 public class EventNicenessPriorityRegister {
+    public final static long UNIT_REMOVED = 1;
     // vehicle
-    public final static long vehicleAdded = -99_999_900;
-    public final static long vehicleUpdated = -99_999_800;
-    public final static long vehicleRemoved = -99_999_700;
+    public final static long VEHICLE_ADDED = -99_999_900;
+    public final static long VEHICLE_UPDATED = -99_999_800;
+    public final static long VEHICLE_REMOVED = -99_999_700;
 
     // update traffic detectors
-    public final static long updateTrafficDetectors = -99_999_600;
+    public final static long UPDATE_TRAFFIC_DETECTORS = -99_999_600;
 
     // update charging station
-    public final static long updateChargingStation = -99_999_500;
+    public final static long UPDATE_CHARGING_STATION = -99_999_500;
     // update seen traffic signs
-    public final static long updateSeenTrafficSign = -99_999_450;
+    public final static long UPDATE_SEEN_TRAFFIC_SIGN = -99_999_450;
     // update traffic light
-    public final static long updateTrafficLight = -99_999_400;
+    public final static long UPDATE_TRAFFIC_LIGHT = -99_999_400;
 
 
     // v2x messages
-    public final static long v2xMessageAcknowledgement = -99_999_200;
-    public final static long v2xMessageReception = -99_999_100;
-    public final static long v2xFullMessageReception = -99_999_99;
+    public final static long V2X_MESSAGE_ACKNOWLEDGEMENT = -99_999_200;
+    public final static long V2X_MESSAGE_RECEPTION = -99_999_100;
+    public final static long V2X_FULL_MESSAGE_RECEPTION = -99_999_99;
     // charging status
-    public final static long chargingRejected = -99_999_000;
+    public final static long CHARGING_REJECTED = -99_999_000;
 
     // batteryUpdated
-    public final static long batteryUpdated = -99_998_900;
+    public final static long BATTERY_UPDATED = -99_998_900;
 }


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->
* it was found that if an application schedules an event at the time of shutdown, the event could triggered after the application was already teared down
* to prevent this the niceness value `UNIT_REMOVED` was introduced, which schedules shutdown events with a low priority
* additionally the names of the constants in `EventNicenessPriorityRegister` were adjusted according to style conventions

* the log-levels of the OS-check in `AbstractSimulationUnit` were moved from `WARN` to `DEBUG` as this check fails when we introduce more complex application-class hierarchies 


  
## Affected parts of the online documentation

* None
Changes in the documentation required?

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

