### PR TITLE
bugfix(sumo): Fix call of adjustToSumoTimeStep

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
@@ -863,14 +863,14 @@ public abstract class AbstractSumoAmbassador extends AbstractFederateAmbassador 
             case WITH_DURATION:
                 if (vehicleSpeedChange.getDuration() > 0) {
                     // set speed smoothly with given interval
-                    final long changeSpeedTimestep = vehicleSpeedChange.getTime() + vehicleSpeedChange.getDuration();
-                    log.debug("slow down vehicle {} and schedule change speed event for timestep {} ns ",
-                            vehicleSpeedChange.getVehicleId(), changeSpeedTimestep);
+                    final long changeSpeedTimeStep = vehicleSpeedChange.getTime() + vehicleSpeedChange.getDuration();
+                    log.debug("slow down vehicle {} and schedule change speed event for time step {} ns ",
+                            vehicleSpeedChange.getVehicleId(), changeSpeedTimeStep);
                     bridge.getVehicleControl()
                             .slowDown(vehicleSpeedChange.getVehicleId(), vehicleSpeedChange.getSpeed(), vehicleSpeedChange.getDuration());
 
                     // set speed permanently after given interval (in the future) via the event scheduler
-                    long adjustedTime = adjustToSumoTimeStep(changeSpeedTimestep, sumoConfig.updateInterval);
+                    long adjustedTime = adjustToSumoTimeStep(changeSpeedTimeStep, sumoConfig.updateInterval * TIME.MILLI_SECOND);
                     eventScheduler.addEvent(new Event(adjustedTime, this, vehicleSpeedChange)
                     );
                 } else {

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassadorTimeStepAdjustmentTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassadorTimeStepAdjustmentTest.java
@@ -16,29 +16,33 @@
 package org.eclipse.mosaic.fed.sumo.ambassador;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+import org.eclipse.mosaic.rti.TIME;
 
 import org.junit.Test;
 
 public class SumoAmbassadorTimeStepAdjustmentTest {
 
-    private final static long sumoTimeStep = 10000;
+    private final static long sumoTimeStep = TIME.SECOND;
 
     @Test
     public void testEqualTimeStep() {
         // Requested time is the same as the sumo timestep. Shouldn't be changed
-        assertEquals(sumoTimeStep, AbstractSumoAmbassador.adjustToSumoTimeStep(10000, sumoTimeStep));
+        assertEquals(sumoTimeStep, AbstractSumoAmbassador.adjustToSumoTimeStep(TIME.SECOND, sumoTimeStep));
     }
 
     @Test
     public void testRoundDown() {
         // Just 2 over, should round down
-        assertEquals(sumoTimeStep, AbstractSumoAmbassador.adjustToSumoTimeStep(10002, sumoTimeStep));
+        assertEquals(sumoTimeStep, AbstractSumoAmbassador.adjustToSumoTimeStep(TIME.SECOND + 2 * TIME.MILLI_SECOND, sumoTimeStep));
     }
 
     @Test
     public void testRoundUp() {
         // Closer to the next higher value, should round up
-        assertEquals(sumoTimeStep * 2, AbstractSumoAmbassador.adjustToSumoTimeStep(19999, sumoTimeStep));
+        assertEquals(sumoTimeStep * 2, AbstractSumoAmbassador.adjustToSumoTimeStep(TIME.SECOND + 999 * TIME.MILLI_SECOND, sumoTimeStep));
     }
 
     @Test


### PR DESCRIPTION
## Description
* this PR reverts a regression that happened during a refactor and would lead to the issue described in #326
* it was fixed by calling `adjustToSumoTimeStep` with the configured update interval as nanoseconds instead of milliseconds (i.e., `sumoConfig.updateInterval * TIME.MILLI_SECOND`)

What is this PR about?

## Issue(s) related to this PR

* solves internal issue 629

* Resolves issue #<eclipse-mosaic-issue> / internal issue <internal-issue>
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->
* no changes required

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

