### PR TITLE
cleanup(general): Renamed variable in DatabaseRouting

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/SimulationSimulateStep.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/libsumo/SimulationSimulateStep.java
@@ -181,9 +181,11 @@ public class SimulationSimulateStep implements org.eclipse.mosaic.fed.sumo.bridg
         List<PublicTransportData.StoppingPlace> nextStops = new ArrayList<>();
         for (TraCINextStopData stopData : stops) {
             PublicTransportData.StoppingPlace stoppingPlace = new PublicTransportData.StoppingPlace.Builder()
-                    .laneId(stopData.getLane()).endPos(stopData.getEndPos()).stoppingPlaceId(stopData.getStoppingPlaceID())
-                    .stopFlags(VehicleStopMode.fromSumoInt(stopData.getStopFlags())).stopDuration(stopData.getDuration())
-                    .stoppedUntil(stopData.getUntil()).startPos(stopData.getStartPos())
+                    .stoppingPlaceId(stopData.getStoppingPlaceID())
+                    .laneId(stopData.getLane())
+                    .startPos(stopData.getStartPos()).endPos(stopData.getEndPos())
+                    .stopFlags(VehicleStopMode.fromSumoInt(stopData.getStopFlags()))
+                    .stopDuration(stopData.getDuration()).stoppedUntil(stopData.getUntil())
                     .build();
             nextStops.add(stoppingPlace);
         }

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/StoppingPlaceReader.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/StoppingPlaceReader.java
@@ -46,7 +46,8 @@ public class StoppingPlaceReader extends AbstractTraciResultReader<List<PublicTr
             stoppingPlaceBuilder.stopFlags(VehicleStopMode.fromSumoInt(readIntWithType(in)));
             stoppingPlaceBuilder.stopDuration(readDoubleWithType(in));
             stoppingPlaceBuilder.stoppedUntil(readDoubleWithType(in));
-            // NOTE: this doesn't contain the start position of the stopping place
+            // startPos of the stop is currently not available in the TraCI subscription result
+            // (see https://sumo.dlr.de/docs/TraCI/Vehicle_Value_Retrieval.html, variable 0x73)
             stoppingPlaces.add(stoppingPlaceBuilder.build());
         }
         return stoppingPlaces;

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/StoppingPlaceReader.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/reader/StoppingPlaceReader.java
@@ -46,7 +46,7 @@ public class StoppingPlaceReader extends AbstractTraciResultReader<List<PublicTr
             stoppingPlaceBuilder.stopFlags(VehicleStopMode.fromSumoInt(readIntWithType(in)));
             stoppingPlaceBuilder.stopDuration(readDoubleWithType(in));
             stoppingPlaceBuilder.stoppedUntil(readDoubleWithType(in));
-
+            // NOTE: this doesn't contain the start position of the stopping place
             stoppingPlaces.add(stoppingPlaceBuilder.build());
         }
         return stoppingPlaces;

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/database/DatabaseRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/database/DatabaseRouting.java
@@ -240,15 +240,15 @@ public class DatabaseRouting implements Routing {
 
         LazyLoadingConnection connection = new LazyLoadingConnection(closestEdge.getConnection());
         LazyLoadingNode previousNode = new LazyLoadingNode(closestEdge.getPreviousNode());
-        LazyLoadingNode upcommingNode = new LazyLoadingNode(closestEdge.getNextNode());
+        LazyLoadingNode upcomingNode = new LazyLoadingNode(closestEdge.getNextNode());
 
         GeoPoint startOfEdge = closestEdge.getPreviousNode().getPosition();
         GeoPoint endOfEdge = closestEdge.getNextNode().getPosition();
         GeoPoint closestPointOnEdge = GeoUtils.closestPointOnLine(location, startOfEdge, endOfEdge);
         double distanceFromStart = closestEdge.getPreviousNode().getPosition().distanceTo(closestPointOnEdge);
-        distanceFromStart = min(distanceFromStart, previousNode.getPosition().distanceTo(upcommingNode.getPosition()));
+        distanceFromStart = min(distanceFromStart, previousNode.getPosition().distanceTo(upcomingNode.getPosition()));
 
-        return new LazyLoadingRoadPosition(connection, previousNode, upcommingNode, distanceFromStart);
+        return new LazyLoadingRoadPosition(connection, previousNode, upcomingNode, distanceFromStart);
     }
 
     @Override


### PR DESCRIPTION
## Description

* rearranged some code and added some comments in SUMO bridge parts to show that the start position is missing in traci coupling

## Issue(s) related to this PR

* relates to issue 625
  
## Affected parts of the online documentation

* no changes required

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

