### PR TITLE
f:ix allow to set a classloader for PackageSpecificTypeAdapter

### DIFF
--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/gson/PackageSpecificTypeAdapter.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/gson/PackageSpecificTypeAdapter.java
@@ -20,27 +20,64 @@ import org.eclipse.mosaic.lib.gson.AbstractTypeAdapterFactory;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapterFactory;
+import org.apache.commons.lang3.Validate;
 
 import java.util.LinkedList;
 import java.util.List;
 
-public class PackageSpecificTypeAdapter<T> extends AbstractTypeAdapterFactory<T> {
+/**
+ * This {@link TypeAdapterFactory} allows to create an object from JSON definition
+ * based on a "type" attribute. According to the value of the value in the "type" attribute,
+ * a class is loaded and an object of this class is instantiated. Since this explicitly works
+ * with simple class names only, a search space of possible packages need to be defined, which
+ * are used to resolve the actual class.
+ */
+public final class PackageSpecificTypeAdapter<T> extends AbstractTypeAdapterFactory<T> {
+
+    /**
+     * Holds all package names which are used to search for suitable classes to instantiate based on the given type name.
+     */
     private final List<String> packageNames = new LinkedList<>();
+
+    /**
+     * The class loader to load the given class from.
+     */
+    private ClassLoader classLoader = PackageSpecificTypeAdapter.class.getClassLoader();
 
     public PackageSpecificTypeAdapter(TypeAdapterFactory parentFactory, Gson gson) {
         super(parentFactory, gson);
     }
 
+    /**
+     * Adds the package of the given class to the search space. All classes within this package
+     * are candidates to be loaded by a given type name.
+     */
     public PackageSpecificTypeAdapter<T> searchInPackageOfClass(Class<?> clazz) {
         return searchInPackage(clazz.getPackage());
     }
 
+    /**
+     * Adds the given package to the search space. All classes within this package
+     * are candidates to be loaded by a given type name.
+     */
     public PackageSpecificTypeAdapter<T> searchInPackage(Package searchPackage) {
         return searchInPackage(searchPackage.getName());
     }
 
+    /**
+     * Adds the given fully qualified package name to the search space. All classes
+     * within the given package are candidates to be loaded by a given type name.
+     */
     public PackageSpecificTypeAdapter<T> searchInPackage(String packageName) {
         packageNames.add(packageName);
+        return this;
+    }
+
+    /**
+     * Defines a specific class loader from which the searched classes are loaded.
+     */
+    public PackageSpecificTypeAdapter<T> withClassLoader(ClassLoader classLoader) {
+        this.classLoader = Validate.notNull(classLoader, "Given class loader must not be null");
         return this;
     }
 
@@ -49,7 +86,7 @@ public class PackageSpecificTypeAdapter<T> extends AbstractTypeAdapterFactory<T>
         Class<?> returnClass = null;
         for (String searchPackage : packageNames) {
             try {
-                returnClass = Class.forName(searchPackage + "." + type);
+                returnClass = classLoader.loadClass(searchPackage + "." + type);
             } catch (ClassNotFoundException ignored) {
                 // nop
             }


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

In order to allow the `PackageSpecificTypeAdapter` also work within context of applications, the correct class loader must be specified. This is now possible with this given change. The application code which uses this type adapter must now pass the `SimulationKernel.SimulationKernel.getClassLoader()` to this type adapter.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves issue internal issue 620
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

