### PR TITLE
feat(mapping): configure type distributions for ScenarioVehicle

### DIFF
--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mosaic.fed.mapping.ambassador;
 
+import org.eclipse.mosaic.fed.mapping.ambassador.weighting.StochasticSelector;
 import org.eclipse.mosaic.fed.mapping.config.CMappingAmbassador;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
@@ -32,6 +33,7 @@ import org.eclipse.mosaic.rti.config.CLocalHost.OperatingSystem;
 
 import org.apache.commons.lang3.ObjectUtils;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 
 /**
@@ -121,43 +123,56 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
      */
     private void handleInteraction(ScenarioVehicleRegistration scenarioVehicle) throws InternalFederateException {
         if (framework != null) {
-            final CPrototype prototype = framework.getPrototypeByName(scenarioVehicle.getVehicleType().getName());
-            if (prototype == null) {
-                log.debug(
-                        "There is no such prototype \"{}\" configured. No application will be mapped for vehicle \"{}\".",
-                        scenarioVehicle.getVehicleType().getName(),
-                        scenarioVehicle.getId()
-                );
-                return;
+
+            final List<CPrototype> typeDistribution = framework.getTypeDistributionByName(scenarioVehicle.getVehicleType().getName());
+            if (!typeDistribution.isEmpty()) {
+                final CPrototype selected  = new StochasticSelector<>(typeDistribution, randomNumberGenerator).nextItem();
+                sendVehicleRegistrationForScenarioVehicle(scenarioVehicle, selected.group, selected.applications);
+            } else {
+                final CPrototype prototype = framework.getPrototypeByName(scenarioVehicle.getVehicleType().getName());
+                if (prototype == null) {
+                    log.debug(
+                            "There is no such prototype \"{}\" configured. No application will be mapped for vehicle \"{}\".",
+                            scenarioVehicle.getVehicleType().getName(),
+                            scenarioVehicle.getId()
+                    );
+                    return;
+                }
+
+                if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
+                    log.debug(
+                            "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
+                            scenarioVehicle.getId(),
+                            scenarioVehicle.getVehicleType().getName(),
+                            prototype.weight
+                    );
+                    return;
+                }
+                sendVehicleRegistrationForScenarioVehicle(scenarioVehicle, prototype.group, prototype.applications);
             }
 
-            if (randomNumberGenerator.nextDouble() >= ObjectUtils.defaultIfNull(prototype.weight, 1.0)) {
-                log.debug(
-                        "This scenario vehicle \"{}\" of prototype \"{}\" will not be equipped due to a weight condition of {}.",
-                        scenarioVehicle.getId(),
-                        scenarioVehicle.getVehicleType().getName(),
-                        prototype.weight
-                );
-                return;
-            }
-
-            final VehicleRegistration vehicleRegistration = new VehicleRegistration(
-                    scenarioVehicle.getTime(),
-                    scenarioVehicle.getName(),
-                    prototype.group,
-                    prototype.applications,
-                    null,
-                    scenarioVehicle.getVehicleType()
-            );
-            try {
-                log.info("Mapping Scenario Vehicle. time={}, name={}, type={}, apps={}",
-                        framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleType().getName(), prototype.applications);
-                rti.triggerInteraction(vehicleRegistration);
-            } catch (Exception e) {
-                throw new InternalFederateException(e);
-            }
         } else {
             log.warn("No mapping configuration available. Skipping {}", scenarioVehicle.getClass().getSimpleName());
+        }
+    }
+
+    private void sendVehicleRegistrationForScenarioVehicle(
+            ScenarioVehicleRegistration scenarioVehicle, String group, List<String> applications
+    ) throws InternalFederateException {
+        final VehicleRegistration vehicleRegistration = new VehicleRegistration(
+                scenarioVehicle.getTime(),
+                scenarioVehicle.getName(),
+                group,
+                applications,
+                null,
+                scenarioVehicle.getVehicleType()
+        );
+        try {
+            log.info("Mapping Scenario Vehicle. time={}, name={}, type={}, apps={}",
+                    framework.getTime(), scenarioVehicle.getName(), scenarioVehicle.getVehicleType().getName(), applications);
+            rti.triggerInteraction(vehicleRegistration);
+        } catch (Exception e) {
+            throw new InternalFederateException(e);
         }
     }
 

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -46,6 +46,7 @@ import org.eclipse.mosaic.rti.api.IllegalValueException;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +66,7 @@ public class SpawningFramework {
     private static final Logger LOG = LoggerFactory.getLogger(SpawningFramework.class);
 
     private final List<CPrototype> prototypeConfigurations = new ArrayList<>();
+    private final Map<String, List<CPrototype>> typeDistributions = new HashMap<>();
     private final Map<String, TrafficLightSpawner> tls = new HashMap<>();
     private final List<VehicleFlowGenerator> vehicleFlowGenerators = new ArrayList<>();
     private final List<RoadSideUnitSpawner> rsus = new ArrayList<>();
@@ -172,12 +174,16 @@ public class SpawningFramework {
                 }
             }
         }
+
+        if (mappingConfiguration.typeDistributions != null) {
+            SpawningFramework.this.typeDistributions.putAll(mappingConfiguration.typeDistributions);
+        }
+
         // randomize weights in type-distributions
-        if (mappingConfiguration.typeDistributions != null
-                && mappingConfiguration.config != null
+        if (mappingConfiguration.config != null
                 && mappingConfiguration.config.randomizeWeights
         ) {
-            for (List<CPrototype> prototypes : mappingConfiguration.typeDistributions.values()) {
+            for (List<CPrototype> prototypes : typeDistributions.values()) {
                 randomizeWeights(rng, prototypes);
             }
         }
@@ -424,6 +430,19 @@ public class SpawningFramework {
         }
 
         return null;
+    }
+
+    public List<CPrototype> getTypeDistributionByName(String name) {
+        if (name == null) {
+            return Lists.newArrayList();
+        }
+
+        final List<CPrototype> types = typeDistributions.get(name);
+        if (types != null) {
+            return types;
+        }
+
+        return Lists.newArrayList();
     }
 
     /**

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CPrototype.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CPrototype.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mosaic.fed.mapping.config;
 
+import org.eclipse.mosaic.fed.mapping.ambassador.weighting.Weighted;
 import org.eclipse.mosaic.lib.enums.LaneChangeMode;
 import org.eclipse.mosaic.lib.enums.SpeedMode;
 import org.eclipse.mosaic.lib.enums.VehicleClass;
@@ -31,7 +32,7 @@ import java.util.List;
  * <p/>
  * If these values are not defined some default values might be applied depending on prototype type.
  */
-public class CPrototype {
+public class CPrototype implements Weighted {
 
     /**
      * The name of this prototype. This identifier is used to match it against
@@ -147,6 +148,10 @@ public class CPrototype {
      */
     public CParameterDeviations deviations;
 
+    @Override
+    public double getWeight() {
+        return weight;
+    }
 
     /**
      * Creates a copy of this prototype.
@@ -202,5 +207,4 @@ public class CPrototype {
                 + ", applications: " + (applications != null ? applications : "null")
                 + "]";
     }
-
 }

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
@@ -300,6 +300,27 @@ public class MappingAmbassadorTest {
         Assert.assertNull(lastReceivedInteraction);
     }
 
+    @Test
+    public void initializeWithMappingFile_scenarioVehicleRegistrationWithTypeDistribution() throws Exception {
+        final MappingAmbassador ambassador = createMappingAmbassadorWithMappingFile("mapping_config.json");
+        ambassador.initialize(0, 100 * TIME.SECOND);
+
+        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
+        assertVehicleRegistration(
+                "package.appA"
+        );
+
+        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
+        assertVehicleRegistration(
+                "package.appA"
+        );
+
+        ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
+        assertVehicleRegistration(
+                "package.appB"
+        );
+    }
+
     @Before
     public void setup() throws Throwable {
         when(rtiMock.createRandomNumberGenerator()).thenReturn(new DefaultRandomNumberGenerator(989123));

--- a/fed/mosaic-mapping/src/test/resources/mapping_config.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config.json
@@ -1,49 +1,67 @@
 {
-	"prototypes":[
-		{
-			"name":"PKW",
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":70.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1
-		},
-		{
-			"name":"electricPKW",			
-			"vehicleClass": "ElectricVehicle",
-			"applications":["org.eclipse.mosaic.app.examples.eventprocessing.sampling.HelloWorldApp", "org.eclipse.mosaic.app.examples.eventprocessing.sampling.IntervalSamplingApp"],
-			"accel":2.6,
-			"decel":4.5,
-			"length":5.00,
-			"maxSpeed":40.0,
-			"minGap":2.5,
-			"sigma":0.5,
-			"tau":1
-		}
-	],
-	"vehicles":[
-		{
-			"startingTime": 5.0,
-			"targetFlow":1200,
-			"maxNumberVehicles": 120,
-			"route":"1",
-			"types":[
-				{
-					"applications":["org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp"],
-					"name":"PKW",
-					"weight":0.2
-				},
-				{
-					"name":"PKW",
-					"weight":0.7
-				},
-				{
-					"name":"electricPKW",
-					"weight":0.1
-				}
-			]
-		}
-	]
+    "prototypes": [
+        {
+            "name": "PKW",
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 70.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1
+        },
+        {
+            "name": "electricPKW",
+            "vehicleClass": "ElectricVehicle",
+            "applications": [
+                "org.eclipse.mosaic.app.examples.eventprocessing.sampling.HelloWorldApp",
+                "org.eclipse.mosaic.app.examples.eventprocessing.sampling.IntervalSamplingApp"
+            ],
+            "accel": 2.6,
+            "decel": 4.5,
+            "length": 5.00,
+            "maxSpeed": 40.0,
+            "minGap": 2.5,
+            "sigma": 0.5,
+            "tau": 1
+        }
+    ],
+    "vehicles": [
+        {
+            "startingTime": 5.0,
+            "targetFlow": 1200,
+            "maxNumberVehicles": 120,
+            "route": "1",
+            "types": [
+                {
+                    "applications": [ "org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp" ],
+                    "name": "PKW",
+                    "weight": 0.2
+                },
+                {
+                    "name": "PKW",
+                    "weight": 0.7
+                },
+                {
+                    "name": "electricPKW",
+                    "weight": 0.1
+                }
+            ]
+        }
+    ],
+    "typeDistributions": {
+        "myCarDistribution": [
+            {
+                "name": "Car",
+                "group": "CarWithAppA",
+                "applications": [ "package.appA" ],
+                "weight": 60
+            }, {
+                "name": "Car",
+                "group": "CarWithAppB",
+                "applications": [ "package.appB" ],
+                "weight": 40
+            }
+        ]
+    }
 }


### PR DESCRIPTION
## Description

When using predefined SUMO scenarios with, the mapping of applications could be configured using the `prototype` section by defining a prototype with a name matching the vType identifier of the vehicles, with the `weight` attribute to control the equipment rate of applications. 

However, this allowed only to configure if a vehicle type could be configured with applications or not. No distinction between multiple application deployments could be done. This is now possible with this PR.

In the `mapping_config,json`, we now allow the `typeDistribution` section to define a whole distribution of application mappings for one vType identifier from the given SUMO scenario. Let's suppose we only have one vehicle type defined in the SUMO scenario, called "DefaultVehicle", then we can configure  a complex application mapping as the following:

```json
"typeDistribution": {
  "DefaultVehicle": [
    { 
      "group": "equippedWithAppA",
      "applications": ["appA"],
      "weight": 0.1 
    },
    { 
      "group": "equippedWithAppB",
      "applications": ["appB"],
      "weight": 0.3 
    },
    { 
      "group": "unequipped",
      "applications": [],
      "weight": 0.6 
    }
  ]
}
```

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves issue internal issue 624
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

Yes, LuST tutorial should be adjusted to use `typeDistributions` instead.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

