### PR TITLE
fix(mapping): decel was missed when creating a vehicle type

### DIFF
--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawner.java
@@ -142,6 +142,7 @@ public class VehicleTypeSpawner extends UnitSpawner implements Weighted {
         this.maxSpeed = prototypeConfiguration.maxSpeed;
         this.vehicleClass = prototypeConfiguration.vehicleClass;
         this.accel = prototypeConfiguration.accel;
+        this.decel = prototypeConfiguration.decel;
         this.emergencyDecel = prototypeConfiguration.emergencyDecel;
         this.sigma = prototypeConfiguration.sigma;
         this.tau = prototypeConfiguration.tau;

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawnerTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/spawning/VehicleTypeSpawnerTest.java
@@ -19,13 +19,61 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
+import org.eclipse.mosaic.lib.enums.LaneChangeMode;
+import org.eclipse.mosaic.lib.enums.SpeedMode;
 import org.eclipse.mosaic.lib.enums.VehicleClass;
 import org.eclipse.mosaic.lib.math.DefaultRandomNumberGenerator;
+import org.eclipse.mosaic.lib.math.MathUtils;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
+import org.eclipse.mosaic.lib.objects.vehicle.VehicleType;
 
 import org.junit.Test;
 
 public class VehicleTypeSpawnerTest {
+
+    @Test
+    public void creationFromCPrototype() {
+        // SETUP
+        CPrototype prototype = new CPrototype();
+        prototype.weight = 0.1;
+
+        prototype.length = 5.0;
+        prototype.width = 2.0;
+        prototype.height = 1.5;
+
+        prototype.minGap = 2.3;
+        prototype.tau = 1.0;
+        prototype.sigma = 0.2;
+
+        prototype.accel = 2.3;
+        prototype.decel = 2.5;
+        prototype.maxSpeed = 30.0;
+        prototype.emergencyDecel = 7.4;
+        prototype.speedFactor = 1.2;
+
+        prototype.vehicleClass = VehicleClass.AutomatedVehicle;
+        prototype.speedMode = SpeedMode.SPEEDER;
+        prototype.laneChangeMode = LaneChangeMode.COOPERATIVE;
+
+        // RUN
+        VehicleType type = new VehicleTypeSpawner(prototype).convertType();
+
+        // ASSERT
+        assertEquals(prototype.length, type.getLength(), MathUtils.EPSILON_D);
+        assertEquals(prototype.width, type.getWidth(), MathUtils.EPSILON_D);
+        assertEquals(prototype.height, type.getHeight(), MathUtils.EPSILON_D);
+        assertEquals(prototype.minGap, type.getMinGap(), MathUtils.EPSILON_D);
+        assertEquals(prototype.tau, type.getTau(), MathUtils.EPSILON_D);
+        assertEquals(prototype.sigma, type.getSigma(), MathUtils.EPSILON_D);
+        assertEquals(prototype.accel, type.getAccel(), MathUtils.EPSILON_D);
+        assertEquals(prototype.decel, type.getDecel(), MathUtils.EPSILON_D);
+        assertEquals(prototype.maxSpeed, type.getMaxSpeed(), MathUtils.EPSILON_D);
+        assertEquals(prototype.emergencyDecel, type.getEmergencyDecel(), MathUtils.EPSILON_D);
+        assertEquals(prototype.speedFactor, type.getSpeedFactor(), MathUtils.EPSILON_D);
+        assertEquals(prototype.vehicleClass, type.getVehicleClass());
+        assertEquals(prototype.speedMode, type.getSpeedMode());
+        assertEquals(prototype.laneChangeMode, type.getLaneChangeMode());
+    }
 
     @Test
     public void fillInPrototype() {


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

When `decel` was configured in the `types` section of either a `vehicle` or `matrixMapper`, it was missed when the corresponding ` VehicleType` was created. See discussion #336 .

This is now fixed and a test has been added to check all currently existing fields

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves issue #336 
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

