### PR TITLE
feat: configure fixedOrder globally instead for every spawner

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Barnim/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/Barnim/mapping/mapping_config.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "fixedOrder": true
+    },
     "prototypes": [
         {
             "name": "Car",

--- a/bundle/src/assembly/resources/scenarios/HelloWorld/mapping/mapping_config.json
+++ b/bundle/src/assembly/resources/scenarios/HelloWorld/mapping/mapping_config.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "fixedOrder": true
+    },
     "prototypes": [
         {
             "name": "Car",

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -15,7 +15,9 @@
 
 package org.eclipse.mosaic.fed.mapping.ambassador;
 
+import org.eclipse.mosaic.fed.mapping.ambassador.weighting.FixedOrderSelector;
 import org.eclipse.mosaic.fed.mapping.ambassador.weighting.StochasticSelector;
+import org.eclipse.mosaic.fed.mapping.ambassador.weighting.WeightedSelector;
 import org.eclipse.mosaic.fed.mapping.config.CMappingAmbassador;
 import org.eclipse.mosaic.fed.mapping.config.CPrototype;
 import org.eclipse.mosaic.interactions.mapping.VehicleRegistration;
@@ -71,7 +73,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
     /**
      * Cache stochastic selectors to avoid unnecessary instantiations.
      */
-    private final Map<String, StochasticSelector<CPrototype>> typeDistributionSelectors = new HashMap<>();
+    private final Map<String, WeightedSelector<CPrototype>> typeDistributionSelectors = new HashMap<>();
 
     /**
      * Constructor for the {@link MappingAmbassador}.
@@ -134,9 +136,13 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
 
             final List<CPrototype> typeDistribution = framework.getTypeDistributionByName(scenarioVehicle.getVehicleType().getName());
             if (!typeDistribution.isEmpty()) {
-                StochasticSelector<CPrototype> selector = typeDistributionSelectors.get(scenarioVehicle.getVehicleType().getName());
+                WeightedSelector<CPrototype> selector = typeDistributionSelectors.get(scenarioVehicle.getVehicleType().getName());
                 if (selector == null) {
-                    selector = new StochasticSelector<>(typeDistribution, randomNumberGenerator);
+                    if (mappingAmbassadorConfiguration.config != null && mappingAmbassadorConfiguration.config.fixedOrder) {
+                        selector = new FixedOrderSelector<>(typeDistribution, randomNumberGenerator);
+                    } else {
+                        selector = new StochasticSelector<>(typeDistribution, randomNumberGenerator);
+                    }
                     typeDistributionSelectors.put(scenarioVehicle.getVehicleType().getName(), selector);
                 }
                 final CPrototype selected  = selector.nextItem();

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -138,7 +138,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
             if (!typeDistribution.isEmpty()) {
                 WeightedSelector<CPrototype> selector = typeDistributionSelectors.get(scenarioVehicle.getVehicleType().getName());
                 if (selector == null) {
-                    if (mappingAmbassadorConfiguration.config != null && mappingAmbassadorConfiguration.config.fixedOrder) {
+                    if (mappingAmbassadorConfiguration.config == null || mappingAmbassadorConfiguration.config.fixedOrder) {
                         selector = new FixedOrderSelector<>(typeDistribution, randomNumberGenerator);
                     } else {
                         selector = new StochasticSelector<>(typeDistribution, randomNumberGenerator);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -138,7 +138,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
             if (!typeDistribution.isEmpty()) {
                 WeightedSelector<CPrototype> selector = typeDistributionSelectors.get(scenarioVehicle.getVehicleType().getName());
                 if (selector == null) {
-                    if (mappingAmbassadorConfiguration.config == null || mappingAmbassadorConfiguration.config.fixedOrder) {
+                    if (mappingAmbassadorConfiguration.config != null && mappingAmbassadorConfiguration.config.fixedOrder) {
                         selector = new FixedOrderSelector<>(typeDistribution);
                     } else {
                         selector = new StochasticSelector<>(typeDistribution, randomNumberGenerator);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassador.java
@@ -139,7 +139,7 @@ public class MappingAmbassador extends AbstractFederateAmbassador {
                 WeightedSelector<CPrototype> selector = typeDistributionSelectors.get(scenarioVehicle.getVehicleType().getName());
                 if (selector == null) {
                     if (mappingAmbassadorConfiguration.config == null || mappingAmbassadorConfiguration.config.fixedOrder) {
-                        selector = new FixedOrderSelector<>(typeDistribution, randomNumberGenerator);
+                        selector = new FixedOrderSelector<>(typeDistribution);
                     } else {
                         selector = new StochasticSelector<>(typeDistribution, randomNumberGenerator);
                     }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/OriginDestinationVehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/OriginDestinationVehicleFlowGenerator.java
@@ -30,8 +30,6 @@ import java.util.List;
 public class OriginDestinationVehicleFlowGenerator {
     private final List<COriginDestinationMatrixMapper.COriginDestinationPoint> originDestinationPointConfigurations;
     private final List<CPrototype> prototypeConfigurations;
-    private final Boolean fixedOrder;
-
     /**
      * Values for the OD-matrix. Unit should be vehicles/hour.
      */
@@ -49,7 +47,6 @@ public class OriginDestinationVehicleFlowGenerator {
     OriginDestinationVehicleFlowGenerator(COriginDestinationMatrixMapper matrixMapperConfiguration) {
         this.originDestinationPointConfigurations = matrixMapperConfiguration.points;
         this.prototypeConfigurations = matrixMapperConfiguration.types;
-        this.fixedOrder = matrixMapperConfiguration.fixedOrder;
         this.odValues = matrixMapperConfiguration.odValues;
         this.startingTime = matrixMapperConfiguration.startingTime;
         this.maxTime = matrixMapperConfiguration.maxTime;
@@ -64,7 +61,7 @@ public class OriginDestinationVehicleFlowGenerator {
      * @param randomNumberGenerator {@link RandomNumberGenerator} used for flow noise
      * @param flowNoise             flag if the stream should be affected by noise
      */
-    void generateVehicleStreams(SpawningFramework framework, RandomNumberGenerator randomNumberGenerator, boolean flowNoise) {
+    void generateVehicleStreams(SpawningFramework framework, RandomNumberGenerator randomNumberGenerator, boolean flowNoise, boolean fixedOrder) {
         for (int fromId = 0; fromId < originDestinationPointConfigurations.size(); fromId++) {
             for (int toId = 0; toId < originDestinationPointConfigurations.size(); toId++) {
 
@@ -78,7 +75,6 @@ public class OriginDestinationVehicleFlowGenerator {
                 vehicleConfiguration.destination = originDestinationPointConfigurations.get(toId).position;
                 vehicleConfiguration.targetFlow = flow;
                 vehicleConfiguration.types = prototypeConfigurations;
-                vehicleConfiguration.fixedOrder = fixedOrder;
 
                 vehicleConfiguration.startingTime = startingTime;
                 vehicleConfiguration.maxTime = maxTime;
@@ -86,7 +82,7 @@ public class OriginDestinationVehicleFlowGenerator {
                 vehicleConfiguration.departSpeedMode = departureSpeedMode;
                 // Assuming, if we only have set a flow, that we want to have an unlimited number of vehicles
 
-                framework.addVehicleStream(new VehicleFlowGenerator(vehicleConfiguration, randomNumberGenerator, flowNoise));
+                framework.addVehicleStream(new VehicleFlowGenerator(vehicleConfiguration, randomNumberGenerator, flowNoise, fixedOrder));
             }
         }
     }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -320,7 +320,7 @@ public class SpawningFramework {
                 boolean fixedOrder = config == null || config.fixedOrder;
 
                 vehicleFlowGenerators.add(
-                        new VehicleFlowGenerator(vehicleConfiguration, rng, config != null && flowNoise, fixedOrder)
+                        new VehicleFlowGenerator(vehicleConfiguration, rng, flowNoise, fixedOrder)
                 );
             }
         }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -208,8 +208,9 @@ public class SpawningFramework {
         }
 
         boolean flowNoise = mappingConfiguration.config != null && mappingConfiguration.config.randomizeFlows;
+        boolean fixedOrder = mappingConfiguration.config == null || mappingConfiguration.config.fixedOrder;
         for (OriginDestinationVehicleFlowGenerator mapper : matrices) {
-            mapper.generateVehicleStreams(this, rng, flowNoise);
+            mapper.generateVehicleStreams(this, rng, flowNoise, fixedOrder);
         }
 
         // Use the prototype configurations to complete the spawner-definitions:
@@ -315,7 +316,12 @@ public class SpawningFramework {
             }
 
             if (vehicleConfiguration.startingTime >= 0) {
-                vehicleFlowGenerators.add(new VehicleFlowGenerator(vehicleConfiguration, rng, config != null && config.randomizeFlows));
+                boolean flowNoise = config != null && config.randomizeFlows;
+                boolean fixedOrder = config == null || config.fixedOrder;
+
+                vehicleFlowGenerators.add(
+                        new VehicleFlowGenerator(vehicleConfiguration, rng, config != null && flowNoise, fixedOrder)
+                );
             }
         }
         return spawnersExist;

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/SpawningFramework.java
@@ -208,7 +208,7 @@ public class SpawningFramework {
         }
 
         boolean flowNoise = mappingConfiguration.config != null && mappingConfiguration.config.randomizeFlows;
-        boolean fixedOrder = mappingConfiguration.config == null || mappingConfiguration.config.fixedOrder;
+        boolean fixedOrder = mappingConfiguration.config != null && mappingConfiguration.config.fixedOrder;
         for (OriginDestinationVehicleFlowGenerator mapper : matrices) {
             mapper.generateVehicleStreams(this, rng, flowNoise, fixedOrder);
         }
@@ -317,7 +317,7 @@ public class SpawningFramework {
 
             if (vehicleConfiguration.startingTime >= 0) {
                 boolean flowNoise = config != null && config.randomizeFlows;
-                boolean fixedOrder = config == null || config.fixedOrder;
+                boolean fixedOrder = config != null && config.fixedOrder;
 
                 vehicleFlowGenerators.add(
                         new VehicleFlowGenerator(vehicleConfiguration, rng, flowNoise, fixedOrder)

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -116,7 +116,7 @@ public class VehicleFlowGenerator {
      *
      * @param vehicleConfiguration vehicle spawner configuration
      */
-    public VehicleFlowGenerator(CVehicle vehicleConfiguration, @Nonnull RandomNumberGenerator randomNumberGenerator, boolean flowNoise) {
+    public VehicleFlowGenerator(CVehicle vehicleConfiguration, @Nonnull RandomNumberGenerator randomNumberGenerator, boolean flowNoise, boolean fixedOrder) {
 
         // Enforce that types are defined
         if (vehicleConfiguration.types == null || vehicleConfiguration.types.isEmpty()) {
@@ -141,7 +141,7 @@ public class VehicleFlowGenerator {
         // create SpawningMode using given definitions
         this.spawningMode = createSpawningMode(vehicleConfiguration, randomNumberGenerator, flowNoise);
         // create the selector deciding which vehicle is spawned next
-        this.selector = createSelector(vehicleConfiguration, randomNumberGenerator);
+        this.selector = createSelector(randomNumberGenerator, fixedOrder);
         // create lane index list
         this.lanes = createLanes(vehicleConfiguration);
         // create lane selector deciding which lane the next vehicle is spawned on
@@ -268,11 +268,10 @@ public class VehicleFlowGenerator {
         return newSpawningMode;
     }
 
-    private WeightedSelector<VehicleTypeSpawner> createSelector(
-            CVehicle vehicleConfiguration, RandomNumberGenerator randomNumberGenerator) {
+    private WeightedSelector<VehicleTypeSpawner> createSelector(RandomNumberGenerator randomNumberGenerator, boolean fixedOrder) {
         if (types.size() == 1) {
             selector = () -> Iterables.getOnlyElement(types);
-        } else if (vehicleConfiguration.fixedOrder) {
+        } else if (fixedOrder) {
             selector = new FixedOrderSelector<>(types, randomNumberGenerator);
         } else {
             selector = new StochasticSelector<>(types, randomNumberGenerator);

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -272,7 +272,7 @@ public class VehicleFlowGenerator {
         if (types.size() == 1) {
             selector = () -> Iterables.getOnlyElement(types);
         } else if (fixedOrder) {
-            selector = new FixedOrderSelector<>(types, randomNumberGenerator);
+            selector = new FixedOrderSelector<>(types);
         } else {
             selector = new StochasticSelector<>(types, randomNumberGenerator);
         }

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
@@ -36,7 +36,7 @@ public class CMappingConfiguration {
      * When set to true the spawning-process will choose exactly the same types with every execution.
      * When set to false the order of types may be different and selected weights will be reached more slowly.
      */
-    public boolean fixedOrder = true;
+    public boolean fixedOrder = false;
 
     /**
      * Defines the point in time to start spawning vehicles. If not set (default),

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/CMappingConfiguration.java
@@ -32,6 +32,13 @@ public class CMappingConfiguration {
     public double scaleTraffic = 1.0;
 
     /**
+     * Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model.
+     * When set to true the spawning-process will choose exactly the same types with every execution.
+     * When set to false the order of types may be different and selected weights will be reached more slowly.
+     */
+    public boolean fixedOrder = true;
+
+    /**
      * Defines the point in time to start spawning vehicles. If not set (default),
      * all vehicles will be spawned according to the vehicles configuration. [s]
      */

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/config/units/CVehicle.java
@@ -161,13 +161,6 @@ public class CVehicle implements Comparable<CVehicle> {
     public String typeDistribution;
 
     /**
-     * Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model.
-     * When set to true the spawning-process will choose exactly the same types with every execution.
-     * When set to false the order of types may be different and selected weights will be reached more slowly.
-     */
-    public boolean fixedOrder = true;
-
-    /**
      * The index of the connection of the route where the vehicle will start on.
      */
     public int departConnectionIndex = 0;
@@ -228,7 +221,6 @@ public class CVehicle implements Comparable<CVehicle> {
                 .append(startingTime, that.startingTime)
                 .append(targetFlow, that.targetFlow)
                 .append(departSpeed, that.departSpeed)
-                .append(fixedOrder, that.fixedOrder)
                 .append(departConnectionIndex, that.departConnectionIndex)
                 .append(pos, that.pos)
                 .append(maxTime, that.maxTime)
@@ -260,7 +252,6 @@ public class CVehicle implements Comparable<CVehicle> {
                 .append(departSpeedMode)
                 .append(types)
                 .append(typeDistribution)
-                .append(fixedOrder)
                 .append(departConnectionIndex)
                 .append(pos)
                 .append(route)

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -403,11 +403,6 @@
                     "type": "array",
                     "items": { "$ref": "#/definitions/prototype" }
                 },
-                "fixedOrder": {
-                    "description": "If fixedOrder is true the spawning-process will be exactly the same with every execution. If left false the order is different and the selected weights will be reached slower than in the fixedOrder mode.",
-                    "type": "boolean",
-                    "default": true
-                },
                 "odValues": {
                     "description": "Values for the OD-matrix. Unit should be vehicles/hour.",
                     "type": "array",

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -80,9 +80,9 @@
                     "default": 1.0
                 },
                 "fixedOrder": {
-                    "description": "Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model. When set to true the spawning-process will choose exactly the same types with every execution. When set to false the order of types may be different and selected weights will be reached more slowly.",
+                    "description": "Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model. When set to true the spawning-process will choose exactly the same types with every execution. When set to false (default) the order of types follow a stochastic manner and will be different each time, however, selected weights may be reached more slowly.",
                     "type": "boolean",
-                    "default": true
+                    "default": false
                 },
                 "adjustStartingTimes": {
                     "description": "If set to true and if the parameter start is set, the starting times of each spawner is adjusted accordingly, so that we shouldn't wait in case that the simulation starting time and spawner starting time are widely spread out. All spawners before start will be completely ignored then.",

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -79,6 +79,11 @@
                     "minimum": 0,
                     "default": 1.0
                 },
+                "fixedOrder": {
+                    "description": "Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model. When set to true the spawning-process will choose exactly the same types with every execution. When set to false the order of types may be different and selected weights will be reached more slowly.",
+                    "type": "boolean",
+                    "default": true
+                },
                 "adjustStartingTimes": {
                     "description": "If set to true and if the parameter start is set, the starting times of each spawner is adjusted accordingly, so that we shouldn't wait in case that the simulation starting time and spawner starting time are widely spread out. All spawners before start will be completely ignored then.",
                     "type": "boolean",
@@ -332,11 +337,6 @@
                         "GROW_AND_SHRINK_EXPONENTIAL"
                     ],
                     "default": "CONSTANT"
-                },
-                "fixedOrder": {
-                    "description": "Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model. When set to true the spawning-process will choose exactly the same types with every execution. When set to false the order of types may be different and selected weights will be reached more slowly.",
-                    "type": "boolean",
-                    "default": true
                 },
                 "departConnectionIndex": {
                     "description": "The index of the connection of the route where the vehicle will start on.",

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
@@ -79,12 +79,12 @@ public class MappingAmbassadorTest {
         assertEquals(5 * TIME.SECOND, lastTimeAdvanceGrant);
 
         ambassador.advanceTime(lastTimeAdvanceGrant);
-        assertVehicleRegistration("org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp");
+        assertVehicleRegistration();
 
         assertEquals(8 * TIME.SECOND, lastTimeAdvanceGrant);
 
         ambassador.advanceTime(lastTimeAdvanceGrant);
-        assertVehicleRegistration();
+        assertVehicleRegistration("org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp");
 
         assertEquals(11 * TIME.SECOND, lastTimeAdvanceGrant);
 
@@ -197,13 +197,13 @@ public class MappingAmbassadorTest {
         assertVehicleRegistration("Car2App");
 
         ambassador.advanceTime(17 * TIME.SECOND);
-        assertVehicleRegistration("Car2App");
-
-        ambassador.advanceTime(20 * TIME.SECOND);
         assertVehicleRegistration("Car1App");
 
-        ambassador.advanceTime(23 * TIME.SECOND);
+        ambassador.advanceTime(20 * TIME.SECOND);
         assertVehicleRegistration("Car2App");
+
+        ambassador.advanceTime(23 * TIME.SECOND);
+        assertVehicleRegistration("Car1App");
 
         ambassador.advanceTime(26 * TIME.SECOND);
         assertNull(lastReceivedInteraction);

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
@@ -79,7 +79,7 @@ public class MappingAmbassadorTest {
         assertEquals(5 * TIME.SECOND, lastTimeAdvanceGrant);
 
         ambassador.advanceTime(lastTimeAdvanceGrant);
-        assertVehicleRegistration();
+        assertVehicleRegistration("org.eclipse.mosaic.app.tutorials.barnim.WeatherWarningApp");
 
         assertEquals(8 * TIME.SECOND, lastTimeAdvanceGrant);
 
@@ -312,12 +312,12 @@ public class MappingAmbassadorTest {
 
         ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
         assertVehicleRegistration(
-                "package.appB"
+                "package.appA"
         );
 
         ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
         assertVehicleRegistration(
-                "package.appA"
+                "package.appB"
         );
     }
 

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/ambassador/MappingAmbassadorTest.java
@@ -312,12 +312,12 @@ public class MappingAmbassadorTest {
 
         ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
         assertVehicleRegistration(
-                "package.appA"
+                "package.appB"
         );
 
         ambassador.processInteraction(new ScenarioVehicleRegistration(0, "veh_0", new VehicleType("myCarDistribution")));
         assertVehicleRegistration(
-                "package.appB"
+                "package.appA"
         );
     }
 

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/BarnimMappingTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/BarnimMappingTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.mosaic.fed.mapping.config.units.CRoadSideUnit;
 import org.eclipse.mosaic.fed.mapping.config.units.CVehicle;
@@ -78,13 +77,13 @@ public class BarnimMappingTest {
         assertNull(pkw.group);
         assertNull(pkw.vehicleClass);
         assertNull(pkw.applications);
-        assertEquals(pkw.accel, new Double(2.6));
-        assertEquals(pkw.decel, new Double(4.5));
-        assertEquals(pkw.length, new Double(5.0));
-        assertEquals(pkw.maxSpeed, new Double(70.0));
-        assertEquals(pkw.minGap, new Double(2.5));
-        assertEquals(pkw.sigma, new Double(0.5));
-        assertEquals(pkw.tau, new Double(1));
+        assertEquals(pkw.accel, Double.valueOf(2.6));
+        assertEquals(pkw.decel, Double.valueOf(4.5));
+        assertEquals(pkw.length, Double.valueOf(5.0));
+        assertEquals(pkw.maxSpeed, Double.valueOf(70.0));
+        assertEquals(pkw.minGap, Double.valueOf(2.5));
+        assertEquals(pkw.sigma, Double.valueOf(0.5));
+        assertEquals(pkw.tau, Double.valueOf(1));
         assertNull(pkw.weight);
 
         // CPrototype "electricPKW"
@@ -94,13 +93,13 @@ public class BarnimMappingTest {
         assertNull(electricPKW.applications);
         assertNull(electricPKW.group);
         assertEquals(electricPKW.vehicleClass, VehicleClass.ElectricVehicle);
-        assertEquals(electricPKW.accel, new Double(2.6));
-        assertEquals(electricPKW.decel, new Double(4.5));
-        assertEquals(electricPKW.length, new Double(5.0));
-        assertEquals(electricPKW.maxSpeed, new Double(40.0));
-        assertEquals(electricPKW.minGap, new Double(2.5));
-        assertEquals(electricPKW.sigma, new Double(0.5));
-        assertEquals(electricPKW.tau, new Double(1));
+        assertEquals(electricPKW.accel, Double.valueOf(2.6));
+        assertEquals(electricPKW.decel, Double.valueOf(4.5));
+        assertEquals(electricPKW.length, Double.valueOf(5.0));
+        assertEquals(electricPKW.maxSpeed, Double.valueOf(40.0));
+        assertEquals(electricPKW.minGap, Double.valueOf(2.5));
+        assertEquals(electricPKW.sigma, Double.valueOf(0.5));
+        assertEquals(electricPKW.tau, Double.valueOf(1));
         assertNull(electricPKW.weight);
 
         // CPrototype UNNAMED ("WeatherServer")
@@ -154,10 +153,9 @@ public class BarnimMappingTest {
         assertNotEquals(vehicle, null);
         assertNull(vehicle.destination);
         assertNull(vehicle.origin);
-        assertTrue(vehicle.fixedOrder);
         assertNull(vehicle.group);
         assertNull(vehicle.lanes);
-        assertEquals(vehicle.maxNumberVehicles, new Integer(120));
+        assertEquals(vehicle.maxNumberVehicles, Integer.valueOf(120));
         assertNull(vehicle.maxTime);
         assertEquals(vehicle.pos, 0);
         assertEquals(vehicle.route, "1");
@@ -182,7 +180,7 @@ public class BarnimMappingTest {
         assertNull(CPrototype1.minGap);
         assertNull(CPrototype1.sigma);
         assertNull(CPrototype1.tau);
-        assertEquals(CPrototype1.weight, new Double(0.1));
+        assertEquals(CPrototype1.weight, Double.valueOf(0.1));
         assertNotEquals(CPrototype1.applications, null);
         assertEquals(CPrototype1.applications.size(), 2);
         assertNotEquals(CPrototype1.applications.get(0), null);
@@ -200,7 +198,7 @@ public class BarnimMappingTest {
         assertNull(CPrototype2.minGap);
         assertNull(CPrototype2.sigma);
         assertNull(CPrototype2.tau);
-        assertEquals(CPrototype2.weight, new Double(0.2));
+        assertEquals(CPrototype2.weight, Double.valueOf(0.2));
         assertNotEquals(CPrototype2.applications, null);
         assertEquals(CPrototype2.applications.size(), 2);
         assertNotEquals(CPrototype2.applications.get(0), null);
@@ -218,7 +216,7 @@ public class BarnimMappingTest {
         assertNull(CPrototype3.minGap);
         assertNull(CPrototype3.sigma);
         assertNull(CPrototype3.tau);
-        assertEquals(CPrototype3.weight, new Double(0.6));
+        assertEquals(CPrototype3.weight, Double.valueOf(0.6));
         assertNotEquals(CPrototype3.applications, null);
         assertEquals(CPrototype3.applications.size(), 1);
         assertNotEquals(CPrototype3.applications.get(0), null);
@@ -234,7 +232,7 @@ public class BarnimMappingTest {
         assertNull(CPrototype4.minGap);
         assertNull(CPrototype4.sigma);
         assertNull(CPrototype4.tau);
-        assertEquals(CPrototype4.weight, new Double(0.1));
+        assertEquals(CPrototype4.weight, Double.valueOf(0.1));
         assertNotEquals(CPrototype4.applications, null);
         assertEquals(CPrototype4.applications.size(), 1);
         assertNotEquals(CPrototype4.applications.get(0), null);

--- a/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/TiergartenMappingTest.java
+++ b/fed/mosaic-mapping/src/test/java/org/eclipse/mosaic/fed/mapping/config/TiergartenMappingTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.mosaic.fed.mapping.config.units.CRoadSideUnit;
 import org.eclipse.mosaic.fed.mapping.config.units.CTrafficLight;
@@ -191,7 +190,6 @@ public class TiergartenMappingTest {
         assertNotNull(vehicle1);
         assertNull(vehicle1.destination);
         assertNull(vehicle1.origin);
-        assertTrue(vehicle1.fixedOrder);
         assertNull(vehicle1.group);
         assertNull(vehicle1.lanes);
         assertEquals(vehicle1.maxNumberVehicles, (Integer) 1);
@@ -220,7 +218,6 @@ public class TiergartenMappingTest {
         assertNotNull(vehicle2);
         assertNull(vehicle2.destination);
         assertNull(vehicle2.origin);
-        assertTrue(vehicle2.fixedOrder);
         assertNull(vehicle2.group);
         assertNull(vehicle2.lanes);
         assertEquals((Integer) 1, vehicle2.maxNumberVehicles);
@@ -249,7 +246,6 @@ public class TiergartenMappingTest {
         assertNotNull(vehicle3);
         assertNull(vehicle3.destination);
         assertNull(vehicle3.origin);
-        assertTrue(vehicle3.fixedOrder);
         assertNull(vehicle3.group);
         assertNull(vehicle3.lanes);
         assertEquals(vehicle3.maxNumberVehicles, (Integer) 1);
@@ -278,7 +274,6 @@ public class TiergartenMappingTest {
         assertNotNull(vehicle4);
         assertNull(vehicle4.destination);
         assertNull(vehicle4.origin);
-        assertTrue(vehicle4.fixedOrder);
         assertNull(vehicle4.group);
         assertNull(vehicle4.lanes);
         assertEquals((Integer) 1, vehicle4.maxNumberVehicles);

--- a/fed/mosaic-mapping/src/test/resources/mapping/invalid/matrixMapper/point/MissingProperties.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/invalid/matrixMapper/point/MissingProperties.json
@@ -3,7 +3,6 @@
         {
             "points": [ { } ],
             "types": [ ],
-            "fixedOrder": true,
             "odValues": [ [ 0, 1 ], [ 2, 3 ] ]
         }
     ]

--- a/fed/mosaic-mapping/src/test/resources/mapping/invalid/matrixMapper/point/position/MissingProperties.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/invalid/matrixMapper/point/position/MissingProperties.json
@@ -8,7 +8,6 @@
                 }
             ],
             "types": [ ],
-            "fixedOrder": true,
             "odValues": [ [ 0, 1 ], [ 2, 3 ] ]
         }
     ]

--- a/fed/mosaic-mapping/src/test/resources/mapping/invalid/matrixMapper/point/position/center/MissingProperties.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping/invalid/matrixMapper/point/position/center/MissingProperties.json
@@ -11,7 +11,6 @@
                 }
             ],
             "types": [ ],
-            "fixedOrder": true,
             "odValues": [ [ 0, 1 ], [ 2, 3 ] ]
         }
     ]

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_reference.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_reference.json
@@ -1,4 +1,7 @@
 {
+	"config": {
+		"fixedOrder": true
+	},
 	"prototypes":[
 		{
 			"name":"Car",

--- a/fed/mosaic-mapping/src/test/resources/mapping_config_weights_in_prototype.json
+++ b/fed/mosaic-mapping/src/test/resources/mapping_config_weights_in_prototype.json
@@ -1,4 +1,7 @@
 {
+    "config": {
+        "fixedOrder": true
+    },
     "prototypes": [
         {
             "name": "Car1",


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* Instead of configuring `fixedOrder` for every vehicles spawner, it can now be configured once in the common configuration section of the `mapping_config.json`
* This also allows to consider this config when transforming `ScenarioVehicleRegistration` to `VehicleRegistration`

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 678
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

Yes, separate MR is created.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

