### PR TITLE
Release 23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Changelog Eclipse MOSAIC 23.1 (October 2023)
+
+* [M+] MOSAIC now requires at least Java 11 Runtime Environment to be executed.
+* [M+] Improved MOSAIC Tutorials on eclipse.dev/mosaic and related applications.
+* [A+] Perception Module leaves experimental phase and is now available per default.
+* [A+] New perception modifiers model occlusion based on bounding boxes, and errors on heading and dimension of perceived objects.
+* [A+] The application API was extended to get access to the unit's logging directory (e.g. for data export).
+* [M+] Mapping of vehicle applications now follows a stochastic distribution per default instead of a repeating pattern (configurable).
+* [M-] Fixed that vehicle deceleration values were omitted in specific configuration setups.
+* [S+] Import of SUMO net files in Scenario-Convert supports almost any projection now (only UTM was supported).
+* [S-] Fixed database type affinities to make scenario-database more robust.
+* [T+] Vehicles defined in integrated SUMO scenarios can now be mapped with complex application distributions.
+* [T+] Now supports SUMO 1.18.0
+* [X+] Path handling in Simulation-Runner is more robust now.
+
 # Changelog Eclipse MOSAIC 23.0 (April 2023)
 
 * [A+] Perceived objects provide dimension information (length, width, height).

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -11,7 +11,7 @@ Eclipse, and the Eclipse Logo are registered trademarks of the Eclipse Foundatio
 
 ## Copyright
 
-* Copyright 2020-2022 Fraunhofer FOKUS
+* Copyright 2020-2023 Fraunhofer FOKUS
 
 All rights reserved. All content is the property of the respective authors or their employers.
 For more information regarding authorship of content, please consult the listed source code repository logs.

--- a/app/tutorials/example-applications/pom.xml
+++ b/app/tutorials/example-applications/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/app/tutorials/highway-management/pom.xml
+++ b/app/tutorials/highway-management/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/app/tutorials/traffic-light-communication/pom.xml
+++ b/app/tutorials/traffic-light-communication/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/app/tutorials/weather-warning/pom.xml
+++ b/app/tutorials/weather-warning/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
+++ b/bundle/src/assembly/resources/fed/ns3/ns3_installer.sh
@@ -69,7 +69,7 @@ ns3_scratch="${ns3_simulator_folder}/scratch"
 ns3_source="${ns3_simulator_folder}/src"
 
 ####### semi automatic parameters ########
-ns3_federate_url="https://github.com/mosaic-addons/ns3-federate/archive/refs/tags/23.0.zip"
+ns3_federate_url="https://github.com/mosaic-addons/ns3-federate/archive/refs/tags/23.1.zip"
 ns3_url="https://www.nsnam.org/releases/$ns3_version_affix.tar.bz2"
 
 ###### more automatic parameters #########

--- a/bundle/src/assembly/resources/fed/omnetpp/omnet_installer.sh
+++ b/bundle/src/assembly/resources/fed/omnetpp/omnet_installer.sh
@@ -46,7 +46,7 @@ check_shell
 required_programs=( unzip tar bison flex protoc gcc python )
 required_libraries=( "libprotobuf-dev >= 3.7.0" "libxml2-dev" )
 
-omnet_federate_url="https://github.com/mosaic-addons/omnetpp-federate/archive/refs/tags/23.0.zip"
+omnet_federate_url="https://github.com/mosaic-addons/omnetpp-federate/archive/refs/tags/23.1.zip"
 omnet_src_url="https://github.com/omnetpp/omnetpp/releases/download/omnetpp-5.5.1/omnetpp-5.5.1-src-linux.tgz"
 inet_src_url="https://github.com/inet-framework/inet/releases/download/v4.1.1/inet-4.1.1-src.tgz"
 

--- a/bundle/src/assembly/resources/scenarios/Sievekingplatz/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/Sievekingplatz/output/output_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <output id="websocket" enabled="true" loader="org.eclipse.mosaic.fed.output.generator.websocket.WebsocketVisualizerLoader">
+        <synchronized>true</synchronized>
+        <port>46587</port>
+        <subscriptions>
+            <subscription id="VehicleUpdates" enabled="true"/>
+            <subscription id="V2xMessageReception" enabled="true"/>
+            <subscription id="V2xMessageTransmission" enabled="true"/>
+            <subscription id="VehicleRegistration" enabled="true"/>
+            <subscription id="RsuRegistration" enabled="true"/>
+        </subscriptions>
+    </output>
+</configuration>

--- a/bundle/src/assembly/resources/scenarios/Sievekingplatz/scenario_config.json
+++ b/bundle/src/assembly/resources/scenarios/Sievekingplatz/scenario_config.json
@@ -5,8 +5,8 @@
         "randomSeed": 212323853,
         "projection": {
             "centerCoordinates": {
-                "latitude": 52.63,
-                "longitude": 13.56
+                "latitude": 53.56,
+                "longitude": 9.98
             },
             "cartesianOffset": {
                 "x": -563984.16,
@@ -30,6 +30,7 @@
         "sns": false,
         "ns3": false,
         "omnetpp": false,
+        "output": true,
         "sumo": true
     }
 }

--- a/fed/mosaic-application/pom.xml
+++ b/fed/mosaic-application/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/errormodels/BoundingBoxOcclusion.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/errormodels/BoundingBoxOcclusion.java
@@ -59,6 +59,8 @@ public class BoundingBoxOcclusion implements PerceptionModifier {
      *
      * @param pointsPerSide      the number of points that will be evaluated per object side (corners count towards 2 edges)
      * @param detectionThreshold how many points have to be visible in order for an object to be treated as detected
+     *
+     * @throws IllegalArgumentException if pointsPerSide or detectionThreshold is configured wrongly
      */
     public BoundingBoxOcclusion(int pointsPerSide, int detectionThreshold) {
         if (pointsPerSide < 2) {

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/errormodels/HeadingModifier.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/errormodels/HeadingModifier.java
@@ -35,12 +35,12 @@ import java.util.List;
 public class HeadingModifier implements PerceptionModifier {
 
     /**
-     * Default standard deviation for heading error
+     * Default standard deviation for heading error.
      */
     private static final double SIGMA_HEADING_OFFSET = 4; // given in degree
 
     /**
-     * Default chance of the car being perceived heading in the complete other direction (180° error)
+     * Default chance of the car being perceived heading in the complete other direction (180° error).
      */
     private static final double DEFAULT_CHANCE_WRONG_DIR = 0.01;
 

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/app/AbstractApplication.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/app/AbstractApplication.java
@@ -129,8 +129,7 @@ public abstract class AbstractApplication<OS extends OperatingSystem> implements
     /**
      * This method logs and returns the state of the application.
      *
-     * @return {@code true} if the application was set up and is not torn
-     * down. Otherwise, it returns {@code false}.
+     * @return {@code true} if the application was set up and is not torn down. Otherwise, it returns {@code false}.
      */
     public final boolean isValidStateAndLog() {
         if (!isSetUp) {

--- a/fed/mosaic-cell/pom.xml
+++ b/fed/mosaic-cell/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-environment/pom.xml
+++ b/fed/mosaic-environment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-mapping/pom.xml
+++ b/fed/mosaic-mapping/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -115,6 +115,7 @@ public class VehicleFlowGenerator {
      * Constructor for {@link VehicleFlowGenerator} using one vehicle type configuration.
      *
      * @param vehicleConfiguration vehicle spawner configuration
+     * @throws IllegalArgumentException if vehicleConfiguration does not provide any types to select from
      */
     public VehicleFlowGenerator(CVehicle vehicleConfiguration, @Nonnull RandomNumberGenerator randomNumberGenerator, boolean flowNoise, boolean fixedOrder) {
 
@@ -395,7 +396,6 @@ public class VehicleFlowGenerator {
         // (either fixedOrder or stochastic, determined in constructor)
         VehicleTypeSpawner type = selector.nextItem();
         String name = UnitNameGenerator.nextVehicleName();
-
 
         createVehicle(framework, name, group, laneSelector.nextLane(type), type);
 

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/VehicleFlowGenerator.java
@@ -81,10 +81,12 @@ public class VehicleFlowGenerator {
     private final GeoCircle destination;
     private final OriginDestinationPair odInfo;
     private final String group;
+
     /**
      * The speed at which the vehicle will depart. Only used by SUMO so far.
      */
     private double departSpeed;
+
     /**
      * The depart speed mode, where depending on the value, the depart speed behaves as follows.
      *
@@ -101,10 +103,12 @@ public class VehicleFlowGenerator {
      * Reference to the selector which will select the next vehicle type to be used.
      */
     private WeightedSelector<VehicleTypeSpawner> selector;
+
     /**
      * Running variable to determine when the next vehicle has to be spawned.
      */
     private long nextSpawnTime = -1;
+
     /**
      * Max number of vehicles that should be spawned in this flow.
      * Value of 1 means an individual vehicle, Integer.MAX_VALUE means an endless flow.
@@ -115,6 +119,7 @@ public class VehicleFlowGenerator {
      * Constructor for {@link VehicleFlowGenerator} using one vehicle type configuration.
      *
      * @param vehicleConfiguration vehicle spawner configuration
+     *
      * @throws IllegalArgumentException if vehicleConfiguration does not provide any types to select from
      */
     public VehicleFlowGenerator(CVehicle vehicleConfiguration, @Nonnull RandomNumberGenerator randomNumberGenerator, boolean flowNoise, boolean fixedOrder) {
@@ -181,6 +186,7 @@ public class VehicleFlowGenerator {
      * @param vehicleConfiguration  the vehicle configuration containing necessary information to determine the {@link SpawningMode}
      * @param randomNumberGenerator the {@link RandomNumberGenerator} to be used, for example to introduce flowNoise
      * @param flowNoise             whether flow noise should be introduced
+     *
      * @return the created {@link SpawningMode}
      */
     private SpawningMode createSpawningMode(
@@ -349,6 +355,7 @@ public class VehicleFlowGenerator {
      *
      * @param framework the {@link SpawningFramework} handling the time advance
      * @return true if there is no more vehicles to spawn or max time reached, thus the vehicle spawner can be removed
+     *
      * @throws InternalFederateException thrown if time advance couldn't be completed successfully
      */
     boolean timeAdvance(SpawningFramework framework) throws InternalFederateException {

--- a/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/weighting/FixedOrderSelector.java
+++ b/fed/mosaic-mapping/src/main/java/org/eclipse/mosaic/fed/mapping/ambassador/weighting/FixedOrderSelector.java
@@ -61,7 +61,7 @@ public class FixedOrderSelector<T extends Weighted> implements WeightedSelector<
     /**
      * Constructor for {@link FixedOrderSelector}.
      *
-     * @param objects       list of all types that might be selected from
+     * @param objects list of all types that might be selected from
      */
     public FixedOrderSelector(List<T> objects) {
         Validate.notNull(objects, "Illegal constructor call for WeightedSelector: objects is null.");
@@ -126,7 +126,7 @@ public class FixedOrderSelector<T extends Weighted> implements WeightedSelector<
     }
 
     private Item<T> selectFirstItem() {
-        Comparator<Item<T>> compareByWeight =Comparator.comparingDouble(Item::getWeight);
+        Comparator<Item<T>> compareByWeight = Comparator.comparingDouble(Item::getWeight);
         Comparator<Item<T>> compareByPriority = Comparator.comparingInt((item) -> item.priority);
         // choose first item according to weight. if two or items have the same weight, the first item in the list will be chosen
         return items.stream().max(compareByWeight.thenComparing(compareByPriority)).orElse(null);

--- a/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
+++ b/fed/mosaic-mapping/src/main/resources/CMappingAmbassadorScheme.json
@@ -80,7 +80,7 @@
                     "default": 1.0
                 },
                 "fixedOrder": {
-                    "description": "Determines if selection of a vehicles type when spawning follows a fixedOrder or stochastic model. When set to true the spawning-process will choose exactly the same types with every execution. When set to false (default) the order of types follow a stochastic manner and will be different each time, however, selected weights may be reached more slowly.",
+                    "description": "Determines if the type selection of a spawning vehicle follows a fixed order or stochastic model. When set to true the spawning-process will choose exactly the same type order with every execution. When set to false (default) the order of types follows a stochastic manner and will be different each time depending on the set random seed, however, selected weights may be reached more slowly.",
                     "type": "boolean",
                     "default": false
                 },

--- a/fed/mosaic-ns3/pom.xml
+++ b/fed/mosaic-ns3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-omnetpp/pom.xml
+++ b/fed/mosaic-omnetpp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-output/pom.xml
+++ b/fed/mosaic-output/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-sns/pom.xml
+++ b/fed/mosaic-sns/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fed/mosaic-sumo/pom.xml
+++ b/fed/mosaic-sumo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-communication/pom.xml
+++ b/lib/mosaic-communication/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-database/pom.xml
+++ b/lib/mosaic-database/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-docker/pom.xml
+++ b/lib/mosaic-docker/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-geomath/pom.xml
+++ b/lib/mosaic-geomath/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-interactions/pom.xml
+++ b/lib/mosaic-interactions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-network/pom.xml
+++ b/lib/mosaic-network/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-objects/pom.xml
+++ b/lib/mosaic-objects/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-routing/pom.xml
+++ b/lib/mosaic-routing/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/mosaic-utils/pom.xml
+++ b/lib/mosaic-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.eclipse.mosaic</groupId>
     <artifactId>mosaic-parent</artifactId>
-    <version>23.1-SNAPSHOT</version>
+    <version>23.1</version>
     <packaging>pom</packaging>
 
     <name>Eclipse MOSAIC Parent</name>
@@ -79,7 +79,7 @@
     </modules>
 
     <properties>
-        <mosaic.version>23.1-SNAPSHOT</mosaic.version>
+        <mosaic.version>23.1</mosaic.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceTarget>11</project.build.sourceTarget>
         <skip.coverage>true</skip.coverage>
@@ -112,7 +112,7 @@
         <version.stax2-api>4.2.1</version.stax2-api><!-- 4.1 is approved in #2670 -->
         <version.woodstox-core>5.1.0</version.woodstox-core><!-- 5.1.0 is approved in CQ17827 -->
         <!-- note, when upgrading, the field LibSumoAmbassador#VALID_LIBSUMO_VERSIONS needs to be changed too -->
-        <version.libsumo>1.17.0</version.libsumo>
+        <version.libsumo>1.18.0</version.libsumo>
     </properties>
 
     <dependencies>

--- a/rti/mosaic-rti-api/pom.xml
+++ b/rti/mosaic-rti-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/rti/mosaic-rti-core/pom.xml
+++ b/rti/mosaic-rti-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/rti/mosaic-starter/pom.xml
+++ b/rti/mosaic-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test/mosaic-integration-tests/pom.xml
+++ b/test/mosaic-integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.mosaic</groupId>
         <artifactId>mosaic-parent</artifactId>
-        <version>23.1-SNAPSHOT</version>
+        <version>23.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Changelog Eclipse MOSAIC 23.1 (October 2023)

* [M+] MOSAIC now requires at least Java 11 Runtime Environment to be executed.
* [M+] Improved MOSAIC Tutorials on eclipse.dev/mosaic and related applications.
* [A+] Perception Module leaves experimental phase and is now available per default.
* [A+] New perception modifiers model occlusion based on bounding boxes, and errors on heading and dimension of perceived objects.
* [A+] The application API was extended to get access to the unit's logging directory (e.g. for data export).
* [M+] Mapping of vehicle applications now follows a stochastic distribution per default instead of a repeating pattern (configurable).
* [M-] Fixed that vehicle deceleration values were omitted in specific configuration setups.
* [S+] Import of SUMO net files in Scenario-Convert supports almost any projection now (only UTM was supported).
* [S-] Fixed database type affinities to make scenario-database more robust.
* [T+] Vehicles defined in integrated SUMO scenarios can now be mapped with complex application distributions.
* [T+] Now supports SUMO 1.18.0
* [X+] Path handling in Simulation-Runner is more robust now.

**Prerequisites**

- [ ] You have read CONTRIBUTING.md carefully.
- [ ] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [ ] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [ ] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [ ] `origin/main` has been merged into your Fork.
- [ ] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

