### PR TITLE
fix: remove items from index implementations grid and tree (regression)

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/SpatialObject.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/SpatialObject.java
@@ -20,6 +20,7 @@ import org.eclipse.mosaic.lib.geo.MutableCartesianPoint;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public abstract class SpatialObject<T extends SpatialObject<T>> extends Vector3d {
 
@@ -89,8 +90,11 @@ public abstract class SpatialObject<T extends SpatialObject<T>> extends Vector3d
 
     @Override
     public int hashCode() {
-        // use id as hashcode to store only one VehicleObject per vehicle id in perception index (e.q. quadtree)
-        return this.id.hashCode();
+        return new HashCodeBuilder(5, 11)
+                .appendSuper(super.hashCode())
+                .append(id)
+                .append(cartesianPosition)
+                .toHashCode();
     }
 
     /**

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/SpatialObjectAdapter.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/SpatialObjectAdapter.java
@@ -18,6 +18,12 @@ package org.eclipse.mosaic.fed.application.ambassador.simulation.perception.inde
 import org.eclipse.mosaic.lib.spatial.SpatialItemAdapter;
 
 public class SpatialObjectAdapter<T extends SpatialObject> implements SpatialItemAdapter<T> {
+
+    @Override
+    public int getItemHash(T item) {
+        return item.getId().hashCode();
+    }
+
     @Override
     public double getCenterX(T item) {
         return item.getProjectedPosition().getX();

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/VehicleObject.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/perception/index/objects/VehicleObject.java
@@ -58,7 +58,7 @@ public class VehicleObject extends SpatialObject<VehicleObject> {
     /**
      * The 2D bounding box of a vehicle from birds eye view.
      */
-    private VehicleBoundingBox boundingBox = null;
+    private transient VehicleBoundingBox boundingBox = null;
 
     public VehicleObject(String id) {
         super(id);
@@ -159,7 +159,6 @@ public class VehicleObject extends SpatialObject<VehicleObject> {
                 .append(length, that.length)
                 .append(width, that.width)
                 .append(height, that.height)
-                .append(boundingBox, that.boundingBox)
                 .isEquals();
     }
 
@@ -174,7 +173,6 @@ public class VehicleObject extends SpatialObject<VehicleObject> {
                 .append(length)
                 .append(width)
                 .append(height)
-                .append(boundingBox)
                 .toHashCode();
     }
 

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/Grid.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/Grid.java
@@ -119,7 +119,7 @@ public class Grid<T> {
     public boolean addItem(T item) {
         synchronized (tmpIndexA) {
             CellIndex newCellIndex = toCellIndex(adapter.getCenterX(item), adapter.getCenterZ(item), new CellIndex());
-            CellIndex oldCellIndex = items.put(new ItemKey<>(adapter.getItemHash(item), item), newCellIndex);
+            CellIndex oldCellIndex = items.put(getItemKey(item), newCellIndex);
             if (oldCellIndex != null) {
                 getGridCell(oldCellIndex).remove(item);
                 return false;
@@ -146,7 +146,7 @@ public class Grid<T> {
 
     public void removeItem(T item) {
         synchronized (tmpIndexA) {
-            CellIndex cellIndex = items.remove(new ItemKey<>(adapter.getItemHash(item), item));
+            CellIndex cellIndex = items.remove(getItemKey(item));
             if (cellIndex != null) {
                 getGridCell(cellIndex).remove(item);
             }
@@ -166,6 +166,10 @@ public class Grid<T> {
 
     private GridCell<T> getGridCell(int col, int row) {
         return grid.get(col).get(row);
+    }
+
+    private ItemKey<T> getItemKey(T item) {
+        return new ItemKey<>(adapter.getItemHash(item), item);
     }
 
     private static class GridCell<T> extends ArrayList<T> {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/QuadTree.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/QuadTree.java
@@ -18,7 +18,6 @@ package org.eclipse.mosaic.lib.spatial;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,7 @@ public class QuadTree<T> {
 
     private final TreeNode root;
 
-    private final Map<T, ObjectAndNode> objects = new HashMap<>();
+    private final Map<Integer, ObjectAndNode> objects = new HashMap<>();
     private final SpatialItemAdapter<T> adapter;
 
     /**
@@ -164,14 +163,10 @@ public class QuadTree<T> {
         return root.objectsCount;
     }
 
-    public Collection<T> getAllObjects() {
-        return objects.keySet();
-    }
-
     public boolean addItem(T item) {
         ObjectAndNode oan = new ObjectAndNode(item);
         if (root.isInBounds(oan.objectPos)) {
-            objects.put(item, oan);
+            objects.put(adapter.getItemHash(item), oan);
             root.addObjectNode(oan);
             return true;
         }
@@ -179,7 +174,7 @@ public class QuadTree<T> {
     }
 
     public void removeObject(T object) {
-        ObjectAndNode oan = objects.remove(object);
+        ObjectAndNode oan = objects.remove(adapter.getItemHash(object));
         if (oan != null) {
             root.removeObjectNode(oan);
         }

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/SpatialItemAdapter.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/spatial/SpatialItemAdapter.java
@@ -19,6 +19,11 @@ import org.eclipse.mosaic.lib.geo.Area;
 import org.eclipse.mosaic.lib.math.Vector3d;
 
 public interface SpatialItemAdapter<T> {
+
+    default int getItemHash(T item) {
+        return item.hashCode();
+    }
+
     double getMinX(T item);
 
     double getMinY(T item);
@@ -65,6 +70,7 @@ public interface SpatialItemAdapter<T> {
     }
 
     class PointAdapter<T extends Vector3d> implements SpatialItemAdapter<T> {
+
         @Override
         public double getMinX(T item) {
             return item.x;


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* When storing `VehicleObject` items in the `Grid` or `QuadTree`, they were stored as a key within a HashMap. When doing so, the hashCode of the object is used to store it in the map. However, when updating the object (e.g. adjusting its speed value), the object cannot be found anymore since its hashCode has changed and differs from the one stored in the map. This resulted in odd behavior and `VehicleObject`s could not be removed from the `Grid` or `QuadTree` and were therefore returned by the perception module,
* With this PR the behavior is fixed. Now, internal maps in `Grid` and `QuadTree` do not store the `VehicleObject` items as a key for HashMaps, but only their hash value. This hash value is furthermore generated by the `SpatialItemAdapter`. The adapter implementation responsible for the `VehicleObject` now returns only the hashcode of its id which is immutable.  This refactoring required in the `Grid` implementation a new wrapper class `ItemKey` to be used as a key for the internal HashMap, since direct access to the stored item was required.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 708
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

