### PR TITLE
fix(sumo): allow all utf-8 characters via traci

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/writer/StringTraciWriter.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/traci/writer/StringTraciWriter.java
@@ -31,18 +31,20 @@ public class StringTraciWriter extends AbstractTraciParameterWriter<String> {
 
     @Override
     public int getVariableLength(String argument) {
-        return getLength() + argument.length();
+        return getLength() + argument.getBytes(StandardCharsets.UTF_8).length;
     }
 
     @Override
     public void write(DataOutputStream out) throws IOException {
-        out.writeInt(value.length());
-        out.write(value.getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        out.writeInt(bytes.length);
+        out.write(bytes);
     }
 
     @Override
     public void writeVariableArgument(DataOutputStream out, String argument) throws IOException {
-        out.writeInt(argument.length());
-        out.write(argument.getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = argument.getBytes(StandardCharsets.UTF_8);
+        out.writeInt(bytes.length);
+        out.write(bytes);
     }
 }


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

This PR fixes a bug in the `StringTraciWriter` class which failed to send a string if it contained at least one UTF-8 character which is represented by more than one byte. To support all characters of the UTF-8 standard, which include characters of Arabic, Chinese, Hebrew, Japanese, Turkish, but also emoji characters, a simple fix in `StringTraciWriter` has been made, which now sends the length of the encoded byte array rather than the number of characters in the String via TraCI.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

