### PR TITLE
feat: various changes required for ride-hailing 

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassador.java
@@ -336,11 +336,13 @@ public class ApplicationAmbassador extends AbstractFederateAmbassador implements
     }
 
     private void process(final VehicleRoutesInitialization vehicleRoutesInitialization) {
-        SimulationKernel.SimulationKernel.getRoutes().putAll(vehicleRoutesInitialization.getRoutes());
+        for (var routeEntry : vehicleRoutesInitialization.getRoutes().entrySet()) {
+            SimulationKernel.SimulationKernel.registerRoute(routeEntry.getKey(), routeEntry.getValue());
+        }
     }
 
     private void process(final VehicleRouteRegistration vehicleRouteRegistration) {
-        SimulationKernel.SimulationKernel.getRoutes().put(vehicleRouteRegistration.getRoute().getId(), vehicleRouteRegistration.getRoute());
+        SimulationKernel.SimulationKernel.registerRoute(vehicleRouteRegistration.getRoute().getId(), vehicleRouteRegistration.getRoute());
     }
 
     private void process(final RsuRegistration rsuRegistration) {

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/SimulationKernel.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/SimulationKernel.java
@@ -36,6 +36,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.FileAppender;
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -270,17 +271,17 @@ public enum SimulationKernel {
      */
     @Nonnull
     public Map<String, VehicleRoute> getRoutes() {
-        return routes;
+        return Collections.unmodifiableMap(routes);
     }
 
     /**
-     * Returns a view for the {@link #routes}.
+     * Registers a new route to the simulation kernel.
      *
-     * @return a view for the {@link #routes}.
+     * @param id the id of the route
+     * @param route the {@link VehicleRoute} to register
      */
-    @Nonnull
-    public Map<String, VehicleRoute> getRoutesView() {
-        return routesView;
+    public void registerRoute(String id, VehicleRoute route) {
+        routes.put(id, Validate.notNull(route, "The given route must not be null."));
     }
 
     /**

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
@@ -52,7 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -148,7 +147,12 @@ public class CentralNavigationComponent {
         }
     }
 
-    private Map<String, VehicleRoute> getAllRoutes() {
+    /**
+     * Returns an unmodifiable view of all routes known to the {@link SimulationKernel}.
+     *
+     * @return unmodifiable view of all routes known to the {@link SimulationKernel}
+     */
+    public Map<String, VehicleRoute> getAllRoutes() {
         return SimulationKernel.SimulationKernel.getRoutes();
     }
 
@@ -503,15 +507,6 @@ public class CentralNavigationComponent {
         }
 
         return null;
-    }
-
-    /**
-     * Returns an unmodifiable view of {@link #getAllRoutes()}.
-     *
-     * @return unmodifiable view of {@link #getAllRoutes()}
-     */
-    Map<String, VehicleRoute> getRouteMap() {
-        return Collections.unmodifiableMap(getAllRoutes());
     }
 
     /**

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
@@ -128,8 +128,10 @@ public class CentralNavigationComponent {
             this.log.info("CNC - Navigation-System initialized");
 
             try {
-                var routeMap = routing.getRoutesFromDatabaseForMessage();
-                SimulationKernel.SimulationKernel.getRoutes().putAll(routeMap);
+                final Map<String, VehicleRoute> routeMap = routing.getRoutesFromDatabaseForMessage();
+                for (var routeEntry: routeMap.entrySet()) {
+                    SimulationKernel.SimulationKernel.registerRoute(routeEntry.getKey(), routeEntry.getValue());
+                }
 
                 // generate VehicleRoutesInitialization to inform other simulators
                 VehicleRoutesInitialization interaction = new VehicleRoutesInitialization(0, routeMap);
@@ -330,7 +332,7 @@ public class CentralNavigationComponent {
         try {
             this.rtiAmbassador.triggerInteraction(interaction);
             // store route in local map
-            getAllRoutes().put(newRoute.getId(), newRoute);
+            SimulationKernel.SimulationKernel.registerRoute(newRoute.getId(), newRoute);
         } catch (IllegalValueException e) {
             throw new InternalFederateException(e);
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/CentralNavigationComponent.java
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -84,11 +83,6 @@ public class CentralNavigationComponent {
      * The IRoutingApi.
      */
     private Routing routing;
-
-    /**
-     * Map storing all known route IDs with the belonging route.
-     */
-    private Map<String, VehicleRoute> routeMap = new HashMap<>();
 
     /**
      * The configuration for routingAPI.
@@ -134,7 +128,8 @@ public class CentralNavigationComponent {
             this.log.info("CNC - Navigation-System initialized");
 
             try {
-                routeMap = routing.getRoutesFromDatabaseForMessage();
+                var routeMap = routing.getRoutesFromDatabaseForMessage();
+                SimulationKernel.SimulationKernel.getRoutes().putAll(routeMap);
 
                 // generate VehicleRoutesInitialization to inform other simulators
                 VehicleRoutesInitialization interaction = new VehicleRoutesInitialization(0, routeMap);
@@ -149,6 +144,10 @@ public class CentralNavigationComponent {
             log.error("Exception", ex);
             throw ex;
         }
+    }
+
+    private Map<String, VehicleRoute> getAllRoutes() {
+        return SimulationKernel.SimulationKernel.getRoutes();
     }
 
     Routing createFromType(String type) throws InternalFederateException {
@@ -202,8 +201,8 @@ public class CentralNavigationComponent {
             // — first check if already a route exists
             //  — generate a complete route with an ID and propagate it
             VehicleRoute knownRoute = null;
-            for (VehicleRoute route : routeMap.values()) {
-                newRouteOnOriginalRoute = isNewRouteOnOriginalRoute(rawRoute.getConnectionIds(), routeMap.get(route.getId()).getConnectionIds());
+            for (VehicleRoute route : getAllRoutes().values()) {
+                newRouteOnOriginalRoute = isNewRouteOnOriginalRoute(rawRoute.getConnectionIds(), getAllRoutes().get(route.getId()).getConnectionIds());
                 if (newRouteOnOriginalRoute) {
                     knownRoute = route;
                     break;
@@ -261,9 +260,9 @@ public class CentralNavigationComponent {
      * @return {@link GeoPoint}-target of the given route, {@code null} if route doesn't exist.
      */
     GeoPoint getTargetPositionOfRoute(String routeId) {
-        if (routeMap.containsKey(routeId)) {
-            String lastNodeId = Iterables.getLast(routeMap.get(routeId).getNodeIds(), null);
-            return getPositionOfNode(lastNodeId);
+        if (getAllRoutes().containsKey(routeId)) {
+            String lastConnectionId = Iterables.getLast(getAllRoutes().get(routeId).getConnectionIds(), null);
+            return routing.getConnection(lastConnectionId).getEndNode().getPosition();
         } else {
             return null;
         }
@@ -276,9 +275,9 @@ public class CentralNavigationComponent {
      * @return {@link GeoPoint}-target of the given route, {@code null} if route doesn't exist.
      */
     public GeoPoint getSourcePositionOfRoute(String routeId) {
-        if (routeMap.containsKey(routeId)) {
-            String firstNodeId = Iterables.getFirst(routeMap.get(routeId).getNodeIds(), null);
-            return getPositionOfNode(firstNodeId);
+        if (getAllRoutes().containsKey(routeId)) {
+            String firstConnectionId = Iterables.getFirst(getAllRoutes().get(routeId).getConnectionIds(), null);
+            return routing.getConnection(firstConnectionId).getStartNode().getPosition();
         } else {
             return null;
         }
@@ -321,7 +320,7 @@ public class CentralNavigationComponent {
      * @throws InternalFederateException If the {@link Interaction} could not be send.
      */
     private void propagateRoute(VehicleRoute newRoute, long time) throws InternalFederateException {
-        if (routeMap.containsKey(newRoute.getId())) {
+        if (getAllRoutes().containsKey(newRoute.getId())) {
             throw new InternalFederateException(
                     String.format("Route %s is already known but is tried to be propagated, which is not allowed.", newRoute.getId())
             );
@@ -331,7 +330,7 @@ public class CentralNavigationComponent {
         try {
             this.rtiAmbassador.triggerInteraction(interaction);
             // store route in local map
-            routeMap.put(newRoute.getId(), newRoute);
+            getAllRoutes().put(newRoute.getId(), newRoute);
         } catch (IllegalValueException e) {
             throw new InternalFederateException(e);
         }
@@ -385,7 +384,7 @@ public class CentralNavigationComponent {
             // check if best route, matches one of the existing routes and if so choose that existing route
             if (response.getBestRoute() != null) {
                 VehicleRoute route = null;
-                for (VehicleRoute existingRoute : routeMap.values()) {
+                for (VehicleRoute existingRoute : getAllRoutes().values()) {
                     if (isNewRouteOnOriginalRoute(response.getBestRoute().getConnectionIds(), existingRoute.getConnectionIds())) {
                         route = existingRoute;
                         break;
@@ -456,7 +455,7 @@ public class CentralNavigationComponent {
         if (finalNode == null) {
             throw new IllegalArgumentException("finalNode is null.");
         }
-        List<String> currentRouteNodes = routeMap.get(routeId).getNodeIds();
+        List<String> currentRouteNodes = getAllRoutes().get(routeId).getNodeIds();
 
         if (!currentRouteNodes.contains(finalNode)) {
             return Double.POSITIVE_INFINITY;
@@ -485,7 +484,7 @@ public class CentralNavigationComponent {
      * @return A node if a valid one is found, otherwise {@code null}.
      */
     INode getNextNodeOnRoute(String routeId, IRoadPosition roadPosition, Predicate<INode> nodeCondition) {
-        VehicleRoute currentRoute = routeMap.get(routeId);
+        VehicleRoute currentRoute = getAllRoutes().get(routeId);
 
         int indexOfUpcomingNode = currentRoute.getNodeIds().indexOf(roadPosition.getUpcomingNode().getId());
         // check if there is an upcoming node
@@ -505,12 +504,12 @@ public class CentralNavigationComponent {
     }
 
     /**
-     * Returns an unmodifiable view of {@link #routeMap}.
+     * Returns an unmodifiable view of {@link #getAllRoutes()}.
      *
-     * @return unmodifiable view of {@link #routeMap}
+     * @return unmodifiable view of {@link #getAllRoutes()}
      */
     Map<String, VehicleRoute> getRouteMap() {
-        return Collections.unmodifiableMap(routeMap);
+        return Collections.unmodifiableMap(getAllRoutes());
     }
 
     /**

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/INavigationModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/INavigationModule.java
@@ -16,6 +16,7 @@
 package org.eclipse.mosaic.fed.application.ambassador.navigation;
 
 import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.objects.road.IConnection;
 import org.eclipse.mosaic.lib.objects.road.INode;
 import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
@@ -139,6 +140,14 @@ public interface INavigationModule {
      * @return the {@link INode} containing data for the specified node id.
      */
     INode getNode(String node);
+
+    /**
+     * Returns data for the specified connection id.
+     *
+     * @param connection the id of the node
+     * @return the {@link IConnection} containing data for the specified connection id.
+     */
+    IConnection getConnection(String connection);
 
     /**
      * Returns the node which is closest to specified {@link GeoPoint}.

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/IRoutingModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/IRoutingModule.java
@@ -16,6 +16,7 @@
 package org.eclipse.mosaic.fed.application.ambassador.navigation;
 
 import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.objects.road.IConnection;
 import org.eclipse.mosaic.lib.objects.road.INode;
 import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
 import org.eclipse.mosaic.lib.routing.RoutingParameters;
@@ -44,6 +45,14 @@ public interface IRoutingModule {
      * @return The node object identified by the given nodeId.
      */
     INode getNode(String nodeId);
+
+    /**
+     * Returns data for the specified connection id.
+     *
+     * @param connection the id of the node
+     * @return the {@link IConnection} containing data for the specified connection id.
+     */
+    IConnection getConnection(String connection);
 
     /**
      * Returns the node object, which is closest to the given {@link GeoPoint}.

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModule.java
@@ -18,6 +18,7 @@ package org.eclipse.mosaic.fed.application.ambassador.navigation;
 import org.eclipse.mosaic.fed.application.ambassador.SimulationKernel;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.AbstractSimulationUnit;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.objects.road.IConnection;
 import org.eclipse.mosaic.lib.objects.road.INode;
 import org.eclipse.mosaic.lib.objects.road.IRoadPosition;
 import org.eclipse.mosaic.lib.objects.vehicle.VehicleData;
@@ -268,6 +269,11 @@ public class NavigationModule implements INavigationModule, IRoutingModule {
     @Override
     public INode getNode(String nodeId) {
         return SimulationKernel.SimulationKernel.getCentralNavigationComponent().getRouting().getNode(nodeId);
+    }
+
+    @Override
+    public IConnection getConnection(String connectionId) {
+        return SimulationKernel.SimulationKernel.getCentralNavigationComponent().getRouting().getConnection(connectionId);
     }
 
     @Override

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModule.java
@@ -196,7 +196,7 @@ public class NavigationModule implements INavigationModule, IRoutingModule {
     private Collection<CandidateRoute> retrieveAllValidExistingRoutesToTargetHelper(RoutingPosition targetPosition) {
         CentralNavigationComponent centNavComp = SimulationKernel.SimulationKernel.getCentralNavigationComponent();
         ArrayList<CandidateRoute> candidateRoutes = new ArrayList<>();
-        for (Map.Entry<String, VehicleRoute> entry : centNavComp.getRouteMap().entrySet()) {
+        for (Map.Entry<String, VehicleRoute> entry : centNavComp.getAllRoutes().entrySet()) {
             VehicleRoute route = entry.getValue();
             if (targetQuery(targetPosition, route, centNavComp.getTargetPositionOfRoute(route.getId())) && onRouteQuery(route)) {
                 // length and time are no valid values at this point

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModule.java
@@ -123,6 +123,7 @@ public class NavigationModule implements INavigationModule, IRoutingModule {
                     "NavigationModule#switchRoute: Could not switch to candidate route[{}]",
                     StringUtils.join(newRoute.getConnectionIds(), ",")
             );
+            belongingUnit.getOsLog().error("Reason", e);
             return false;
         }
     }

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassadorTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassadorTest.java
@@ -687,8 +687,8 @@ public class ApplicationAmbassadorTest {
         ambassador.processInteraction(vehicleRoutesInitialization);
 
         // ASSERT: vehicles routes have been propagated
-        assertEquals(routes.get("0"), SimulationKernel.SimulationKernel.getRoutesView().get("0"));
-        assertEquals(routes.get("1"), SimulationKernel.SimulationKernel.getRoutesView().get("1"));
+        assertEquals(routes.get("0"), SimulationKernel.SimulationKernel.getRoutes().get("0"));
+        assertEquals(routes.get("1"), SimulationKernel.SimulationKernel.getRoutes().get("1"));
 
         // finish simulation
         ambassador.processTimeAdvanceGrant(recentAdvanceTime);

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModuleTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/navigation/NavigationModuleTest.java
@@ -109,7 +109,7 @@ public class NavigationModuleTest {
         }).when(cncMock).findRoutes(isA(RoutingRequest.class));
         HashMap<String, VehicleRoute> routeMap = new HashMap<>();
         routeMap.put("123", new VehicleRoute("123", Collections.singletonList("edgeID"), Collections.singletonList("nodeID"), 0.0));
-        when(cncMock.getRouteMap()).thenReturn(routeMap);
+        when(cncMock.getAllRoutes()).thenReturn(routeMap);
         when(cncMock.getTargetPositionOfRoute(ArgumentMatchers.anyString())).thenReturn(GeoPoint.latLon(30, 40));
     }
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/SumoAmbassador.java
@@ -301,11 +301,13 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
 
                     bridge.getSimulationControl().addVehicle(vehicleId, routeId, vehicleType, laneId, departPos, departSpeed);
 
-                    applyChangesInVehicleTypeForVehicle(
-                            vehicleId,
-                            vehicleRegistration.getMapping().getVehicleType(),
-                            cachedVehicleTypesInitialization.getTypes().get(vehicleType)
-                    );
+                    final VehicleType cachedType = cachedVehicleTypesInitialization.getTypes().get(vehicleType);
+                    if (cachedType != null) {
+                        applyChangesInVehicleTypeForVehicle(vehicleId, vehicleRegistration.getMapping().getVehicleType(), cachedType);
+                    } else {
+                        log.warn("Unknown vehicle type {}. Ensure that a suitable vType is configured in the SUMO configuration.", vehicleType);
+                    }
+
                     if (externalVehicleState != null) {
                         externalVehicleState.setAdded(true);
                     }
@@ -359,7 +361,6 @@ public class SumoAmbassador extends AbstractSumoAmbassador {
                 iterator.remove();
             }
         }
-
     }
 
     private void applyChangesInVehicleTypeForVehicle(String vehicleId, VehicleType actualVehicleType, VehicleType baseVehicleType) throws InternalFederateException {

--- a/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Aggregator.java
+++ b/lib/mosaic-geomath/src/main/java/org/eclipse/mosaic/lib/math/Aggregator.java
@@ -27,6 +27,10 @@ public class Aggregator {
     }
 
     public Aggregator add(double value) {
+        if (Double.isNaN(value)) {
+            return this;
+        }
+
         min = Math.min(min, value);
         max = Math.max(max, value);
         sum += value;

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/VehicleDeparture.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/vehicle/VehicleDeparture.java
@@ -24,7 +24,7 @@ public class VehicleDeparture implements Serializable {
     private static final long serialVersionUID = 1L;
 
     public enum DepartureSpeedMode {
-        /* the vehicle departs with the speed given in the mapping definiton of the spawner */
+        /* the vehicle departs with the speed given in the mapping definition of the spawner */
         PRECISE,
         /* the vehicle departs with a random speed */
         RANDOM,
@@ -139,8 +139,8 @@ public class VehicleDeparture implements Serializable {
         private int departureConnectionIndex;
         private double departurePos;
         private double departureSpeed;
-        private DepartureSpeedMode departureSpeedMode;
-        private LaneSelectionMode laneSelectionMode;
+        private DepartureSpeedMode departureSpeedMode = DepartureSpeedMode.MAXIMUM;
+        private LaneSelectionMode laneSelectionMode = LaneSelectionMode.DEFAULT;
 
         public Builder(String routeId) {
             this.routeId = routeId;

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/database/DatabaseRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/database/DatabaseRouting.java
@@ -121,7 +121,7 @@ public class DatabaseRouting implements Routing {
     public IConnection getConnection(String connectionId) {
         Connection c = scenarioDatabase.getConnection(connectionId);
         if (c == null) {
-            throw new IllegalArgumentException(String.format("No such (%s) connetion existing.", connectionId));
+            throw new IllegalArgumentException(String.format("No such (%s) connection existing.", connectionId));
         }
         return new LazyLoadingConnection(c);
     }

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/database/DatabaseRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/database/DatabaseRouting.java
@@ -118,10 +118,10 @@ public class DatabaseRouting implements Routing {
     }
 
     @Override
-    public IConnection getConnection(String nodeId) {
-        Connection c = scenarioDatabase.getConnection(nodeId);
+    public IConnection getConnection(String connectionId) {
+        Connection c = scenarioDatabase.getConnection(connectionId);
         if (c == null) {
-            throw new IllegalArgumentException(String.format("No such (%s) connetion existing.", nodeId));
+            throw new IllegalArgumentException(String.format("No such (%s) connetion existing.", connectionId));
         }
         return new LazyLoadingConnection(c);
     }

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
@@ -15,11 +15,15 @@
 
 package org.eclipse.mosaic.lib.routing.graphhopper;
 
+import static java.util.Objects.requireNonNull;
+
 import org.eclipse.mosaic.lib.database.Database;
 import org.eclipse.mosaic.lib.database.DatabaseUtils;
 import org.eclipse.mosaic.lib.database.road.Connection;
 import org.eclipse.mosaic.lib.database.road.Node;
 import org.eclipse.mosaic.lib.enums.VehicleClass;
+import org.eclipse.mosaic.lib.geo.GeoPoint;
+import org.eclipse.mosaic.lib.geo.GeoUtils;
 import org.eclipse.mosaic.lib.routing.CandidateRoute;
 import org.eclipse.mosaic.lib.routing.RoutingCostFunction;
 import org.eclipse.mosaic.lib.routing.RoutingPosition;
@@ -167,11 +171,11 @@ public class GraphHopperRouting {
 
         // convert paths to routes
         for (final Path path : paths) {
-            final CandidateRoute route = convertPath(path, queryGraph, querySource, queryTarget, target);
+            final CandidateRoute route = convertPath(path, queryGraph, querySource, queryTarget, source, target);
             if (route != null
                     && !route.getConnectionIds().isEmpty()
-                    && checkForDuplicate(route, duplicateSet)
-                    && checkRouteOnRequiredSourceConnection(route, source)) {
+                    && checkRouteOnRequiredSourceConnection(route, source)
+                    && checkForDuplicate(route, duplicateSet)) {
                 result.add(route);
             } else if (route != null && log.isDebugEnabled()) {
                 log.debug("Path is invalid and will be ignored [" + StringUtils.join(route.getConnectionIds(), ",") + "]");
@@ -225,19 +229,24 @@ public class GraphHopperRouting {
     }
 
     private QueryResult fixQueryResultIfSnappedPointIsTowerNode(QueryResult queryResult, RoutingPosition routingPosition, EdgeFilter fromEdgeFilter) {
+        if (queryResult.getSnappedPosition() != QueryResult.Position.TOWER) {
+            return queryResult;
+        }
         /* If the requested position is in front or behind the edge it is mapped either on the start or end of the edge (one of the tower nodes).
          * As a result, the resulting route can bypass turn restrictions in very rare cases. To avoid this, we choose an alternative
-         * node based on the queried connection.*/
-        if (queryResult.getSnappedPosition() == QueryResult.Position.TOWER) {
-            // use the node before target node (index -2) as the alternative query node to find a QueryResult _on_ the connection.
-            Node alternativeQueryNode = DatabaseUtils.getNodeByIndex(db.getConnection(routingPosition.getConnectionId()), -2);
-            if (alternativeQueryNode != null) {
-                return ghApi.getLocationIndex().findClosest(
-                        alternativeQueryNode.getPosition().getLatitude(), alternativeQueryNode.getPosition().getLongitude(), fromEdgeFilter
-                );
-            }
+         * position which is located somewhere _on_ the queried connection.*/
+        final Connection queryConnection = db.getConnection(routingPosition.getConnectionId());
+        final GeoPoint alternativeQueryPosition;
+        if (queryConnection.getNodes().size() > 2) {
+            alternativeQueryPosition = requireNonNull(DatabaseUtils.getNodeByIndex(queryConnection, -2)).getPosition();
+        } else {
+            alternativeQueryPosition = GeoUtils.getPointBetween(
+                    queryConnection.getFrom().getPosition(), queryConnection.getTo().getPosition()
+            );
         }
-        return queryResult;
+        return ghApi.getLocationIndex().findClosest(
+                alternativeQueryPosition.getLatitude(), alternativeQueryPosition.getLongitude(), fromEdgeFilter
+        );
     }
 
     /**
@@ -263,7 +272,7 @@ public class GraphHopperRouting {
         return edgeState -> edgeState.getEdge() == forcedEdge;
     }
 
-    private CandidateRoute convertPath(Path newPath, QueryGraph queryGraph, QueryResult source, QueryResult target, RoutingPosition targetPosition) {
+    private CandidateRoute convertPath(Path newPath, QueryGraph queryGraph, QueryResult source, QueryResult target, RoutingPosition sourcePosition, RoutingPosition targetPosition) {
         PointList pointList = newPath.calcPoints();
         if (pointList.isEmpty()) {
             return null;
@@ -326,8 +335,26 @@ public class GraphHopperRouting {
                 log.debug(String.format("A connection could be resolved by internal ID %d.", ghEdge.getEdge()));
             }
         }
-
+        fixFirstConnectionOfPathIfNotAsQueried(sourcePosition, pathConnections);
         return new CandidateRoute(pathConnections, newPath.getDistance(), newPath.getTime() / (double) 1000);
+    }
+
+    /**
+     * In some very rare cases, if a source connection is given, the path returned by GraphHopper omits this first connection
+     * and continues on the subsequent one. As a workaround, this code checks if the outgoing connections of the queried source connection
+     * contains the first connection of the calculated path, and then adds the source connection to the beginning of the new path.
+     */
+    private void fixFirstConnectionOfPathIfNotAsQueried(RoutingPosition sourcePosition, List<String> pathConnections) {
+        String firstConnectionId = Iterables.getFirst(pathConnections, null);
+        if (sourcePosition.getConnectionId() != null && firstConnectionId != null
+                && !sourcePosition.getConnectionId().equals(firstConnectionId)
+        ) {
+            Connection sourceConnection = db.getConnection(sourcePosition.getConnectionId());
+            Connection firstConnection = db.getConnection(firstConnectionId);
+            if (sourceConnection.getOutgoingConnections().contains(firstConnection)) {
+                pathConnections.add(0, sourceConnection.getId());
+            }
+        }
     }
 
     private boolean checkRouteOnRequiredSourceConnection(CandidateRoute route, RoutingPosition source) {

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/graphhopper/GraphHopperRouting.java
@@ -265,6 +265,9 @@ public class GraphHopperRouting {
 
     private CandidateRoute convertPath(Path newPath, QueryGraph queryGraph, QueryResult source, QueryResult target, RoutingPosition targetPosition) {
         PointList pointList = newPath.calcPoints();
+        if (pointList.isEmpty()) {
+            return null;
+        }
         GHPoint pathTarget = Iterables.getLast(pointList);
         GHPoint origTarget = new GHPoint(targetPosition.getPosition().getLatitude(), targetPosition.getPosition().getLongitude());
         double distanceToOriginalTarget = distanceCalculation.calcDist(pathTarget.lat, pathTarget.lon, origTarget.lat, origTarget.lon);

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/scheduling/Event.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/scheduling/Event.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -139,12 +138,12 @@ public class Event implements Comparable<Event> {
 
         this.time = time;
 
-        Validate.isTrue(processors.size() > 0, "The processor list must contain at minimum one processor.");
+        Validate.isTrue(!processors.isEmpty(), "The processor list must contain at minimum one processor.");
         for (EventProcessor processor : processors) {
             Objects.requireNonNull(processor, "All event processors must not be null.");
         }
 
-        this.processors = Collections.unmodifiableList(new ArrayList<>(processors));
+        this.processors = List.copyOf(processors);
         this.resource = resource;
         this.nice = nice;
     }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/mosaicandsumovehicles/SumoVehicle.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/mosaicandsumovehicles/SumoVehicle.java
@@ -48,7 +48,7 @@ public class SumoVehicle extends AbstractApplication<VehicleOperatingSystem> imp
     public void onShutdown() {
         getLog().infoSimTime(this, "Shutdown: I'm a vehicle defined in SUMO route file.");
         getLog().infoSimTime(this, "{} routes are known to the SimulationKernel.",
-                SimulationKernel.SimulationKernel.getRoutesView().size());
+                SimulationKernel.SimulationKernel.getRoutes().size());
     }
 
     @Override


### PR DESCRIPTION
## Description

Various minor improvements/fixes required by recent applications related to ride-hailing.

#### `mosaic-application`

* Routes have been stored twice in `SimulationKernel` and `CentralNavigationComponent`, but have been updated only in `SimulationKernel`. This leads to buggy behavior when working with routes in applications. Now, routes are stored and updated only in `SimulationKernel`.
* Applications can now request information about connections. This was done by adding `getConnection(id)` to `INavigationModule`.

#### `mosaic-sumo`

* When a vehicle type is not used by any spawner in `mapping_config.json`, it is not propagated to `mosaic-sumo`, thus it is unknown and results in an NPE when processing a `VehicleRegistration` interaction with a vehicle type not configured in mapping. Now you may ask: "how can a VehicleRegistration contain a vehicle type which was not used by spawner in mapping configuration?". Well, this can happen when a `VehicleRegistration` is triggered from any other ambassador (e.g., from inside an application). To allow processing this, we now catch the NPE from happening and write a `log.warn` that the user has to be sure, that the referred vehicle type must be at least known to SUMO (e.g., by adding them to any `rou.xml`).

#### `mosaic-routing`

* Added a fallback when a calculated route does not contain any points.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 724
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

