### PR TITLE
feat(utils): add utility function to move vehicle reference position

### DIFF
--- a/legal/templates/license-header-2024.txt
+++ b/legal/templates/license-header-2024.txt
@@ -1,0 +1,12 @@
+Copyright (c) 2024 Fraunhofer FOKUS and others. All rights reserved.
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0
+
+SPDX-License-Identifier: EPL-2.0
+
+Contact: mosaic@fokus.fraunhofer.de

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/VehicleReferenceUtils.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/VehicleReferenceUtils.java
@@ -16,23 +16,21 @@
 package org.eclipse.mosaic.lib.util;
 
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
+import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.math.Vector3d;
 import org.eclipse.mosaic.lib.math.VectorUtils;
 
-public class VehicleUtils {
+/**
+ * Utility class collecting methods to work with vehicle positions, such
+ * as converting the reference point from center to front bumper and vice versa.
+ */
+public class VehicleReferenceUtils {
 
     /**
      * Moves the position reference of a vehicle from its center to the center of the front bumper.
      */
     public static Vector3d fromCenterToFrontBumper(Vector3d pos, double heading, double length) {
         return VectorUtils.getDirectionVectorFromHeading(heading, new Vector3d()).multiply(length / 2).add(pos);
-    }
-
-    /**
-     * Moves the position reference of a vehicle from the center of the front bumper to its bounding box center.
-     */
-    public static Vector3d fromFrontBumperToCenter(Vector3d pos, double heading, double length) {
-        return VectorUtils.getDirectionVectorFromHeading(heading, new Vector3d()).multiply(-length / 2).add(pos);
     }
 
     /**
@@ -43,10 +41,30 @@ public class VehicleUtils {
     }
 
     /**
+     * Moves the position reference of a vehicle from its center to the center of the front bumper.
+     */
+    public static GeoPoint fromCenterToFrontBumper(GeoPoint pos, double heading, double length) {
+        return fromCenterToFrontBumper(pos.toVector3d(), heading, length).toGeo();
+    }
+    /**
+     * Moves the position reference of a vehicle from the center of the front bumper to its bounding box center.
+     */
+    public static Vector3d fromFrontBumperToCenter(Vector3d pos, double heading, double length) {
+        return VectorUtils.getDirectionVectorFromHeading(heading, new Vector3d()).multiply(-length / 2).add(pos);
+    }
+
+    /**
      * Moves the position reference of a vehicle from the center of the front bumper to its bounding box center.
      */
     public static CartesianPoint fromFrontBumperToCenter(CartesianPoint pos, double heading, double length) {
         return fromFrontBumperToCenter(pos.toVector3d(), heading, length).toCartesian();
+    }
+
+    /**
+     * Moves the position reference of a vehicle from the center of the front bumper to its bounding box center.
+     */
+    public static GeoPoint fromFrontBumperToCenter(GeoPoint pos, double heading, double length) {
+        return fromFrontBumperToCenter(pos.toVector3d(), heading, length).toGeo();
     }
 
 }

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/VehicleUtils.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/VehicleUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.util;
+
+import org.eclipse.mosaic.lib.geo.CartesianPoint;
+import org.eclipse.mosaic.lib.math.Vector3d;
+import org.eclipse.mosaic.lib.math.VectorUtils;
+
+public class VehicleUtils {
+
+    /**
+     * Moves the position reference of a vehicle from its center to the center of the front bumper.
+     */
+    public static Vector3d fromCenterToFrontBumper(Vector3d pos, double heading, double length) {
+        return VectorUtils.getDirectionVectorFromHeading(heading, new Vector3d()).multiply(length / 2).add(pos);
+    }
+
+    /**
+     * Moves the position reference of a vehicle from the center of the front bumper to its bounding box center.
+     */
+    public static Vector3d fromFrontBumperToCenter(Vector3d pos, double heading, double length) {
+        return VectorUtils.getDirectionVectorFromHeading(heading, new Vector3d()).multiply(-length / 2).add(pos);
+    }
+
+    /**
+     * Moves the position reference of a vehicle from its center to the center of the front bumper.
+     */
+    public static CartesianPoint fromCenterToFrontBumper(CartesianPoint pos, double heading, double length) {
+        return fromCenterToFrontBumper(pos.toVector3d(), heading, length).toCartesian();
+    }
+
+    /**
+     * Moves the position reference of a vehicle from the center of the front bumper to its bounding box center.
+     */
+    public static CartesianPoint fromFrontBumperToCenter(CartesianPoint pos, double heading, double length) {
+        return fromFrontBumperToCenter(pos.toVector3d(), heading, length).toCartesian();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,7 @@
                             <header>${parent.dir}/legal/templates/license-header-2021.txt</header>
                             <header>${parent.dir}/legal/templates/license-header-2022.txt</header>
                             <header>${parent.dir}/legal/templates/license-header-2023.txt</header>
+                            <header>${parent.dir}/legal/templates/license-header-2024.txt</header>
                         </validHeaders>
                         <headerDefinitions>
                         </headerDefinitions>

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicStarter.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicStarter.java
@@ -143,7 +143,7 @@ public class MosaicStarter {
 
     protected void printVersionAndCopyrightInfo() {
         System.out.println("Eclipse MOSAIC [Version " + MosaicVersion.get().toString() + "]");
-        System.out.println("Copyright (c) 2023 Fraunhofer FOKUS and others. All rights reserved.");
+        System.out.println("Copyright (c) 2024 Fraunhofer FOKUS and others. All rights reserved.");
         System.out.println("License EPL-2.0: Eclipse Public License Version 2 [https://eclipse.org/legal/epl-v20.html].");
         System.out.println();
     }


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* Simulators may have different reference positions of vehicles, e.g. SUMO points on center of front bumper, while Carla and PHABMACS refer to the center of the vehicle's bounding box.
* A later goal should be to generalize this across MOSAIC, so simulators may have to adjust the positions they put into `VehicleData` objects.
* As a first step, this MR provides utility functions to conveniently convert from "front bumper" to "bb center" and vice versa for the 2D-case.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 767
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

Not yet

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

