### PR TITLE
feat(sumo): LaneChangeMode.OFF should do no lane changes at all

### DIFF
--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/AbstractSumoAmbassador.java
@@ -739,7 +739,7 @@ public abstract class AbstractSumoAmbassador extends AbstractFederateAmbassador 
                     log.warn("VehicleLaneChange failed: unsupported lane change mode.");
                     return;
             }
-            bridge.getVehicleControl().changeLane(vehicleLaneChange.getVehicleId(), targetLaneId, vehicleLaneChange.getDuration());
+            bridge.getVehicleControl().changeLane(vehicleLaneChange.getVehicleId(), Math.max(0, targetLaneId), vehicleLaneChange.getDuration());
 
             if (sumoConfig.highlights.contains(CSumo.HIGHLIGHT_CHANGE_LANE)) {
                 VehicleData vehicleData = bridge.getSimulationControl().getLastKnownVehicleData(vehicleLaneChange.getVehicleId());

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeMode.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeMode.java
@@ -38,32 +38,28 @@ public class SumoLaneChangeMode {
         switch (laneChangeMode) {
             case OFF:
                 mode.setSublaneChanges(false, false);
-                mode.setStrategicChanges(true, true);
                 mode.setRespectOtherDrivers(RESPECT_SPEED_GAPS_OF_OTHER_DRIVERS_ADAPT_SPEED);
                 break;
-            // For strategic lane changes (change lanes to continue the route),
-            // we always let SUMO overwrite requested lane changes (overrideTraci = true)
+            case FOLLOW_ROUTE:
+                mode.setSublaneChanges(false, false);
+                mode.setStrategicChanges(true, false);
+                mode.setRespectOtherDrivers(RESPECT_SPEED_GAPS_OF_OTHER_DRIVERS_ADAPT_SPEED);
+                break;
             case AGGRESSIVE:
-                mode.setStrategicChanges(true, true);
+                mode.setStrategicChanges(true, false);
                 mode.setSpeedChanges(true, false);
                 break;
             case CAUTIOUS:
-                mode.setStrategicChanges(true, true);
+                mode.setStrategicChanges(true, false);
                 mode.setCooperativeChanges(true, false);
                 mode.setSpeedChanges(true, false);
-                mode.setRightDriveChanges(true, true);
+                mode.setRightDriveChanges(true, false);
                 mode.setRespectOtherDrivers(RESPECT_SPEED_GAPS_OF_OTHER_DRIVERS_DO_NOT_ADAPT_SPEED);
                 break;
             case PASSIVE:
-                mode.setStrategicChanges(true, true);
-                mode.setCooperativeChanges(true, false);
-                mode.setSpeedChanges(true, false);
-                mode.setRightDriveChanges(true, true);
-                mode.setRespectOtherDrivers(RESPECT_SPEED_GAPS_OF_OTHER_DRIVERS_ADAPT_SPEED);
-                break;
             case COOPERATIVE:
             case DEFAULT:
-                mode.setStrategicChanges(true, true);
+                mode.setStrategicChanges(true, false);
                 mode.setCooperativeChanges(true, false);
                 mode.setSpeedChanges(true, false);
                 mode.setRightDriveChanges(true, false);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeMode.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeMode.java
@@ -40,17 +40,19 @@ public class SumoLaneChangeMode {
                 mode.setSublaneChanges(false, false);
                 mode.setRespectOtherDrivers(RESPECT_SPEED_GAPS_OF_OTHER_DRIVERS_ADAPT_SPEED);
                 break;
+            // For strategic lane changes (change lanes to continue the route),
+            // we always let SUMO overwrite requested lane changes (overrideTraci = true)
             case FOLLOW_ROUTE:
                 mode.setSublaneChanges(false, false);
-                mode.setStrategicChanges(true, false);
+                mode.setStrategicChanges(true, true);
                 mode.setRespectOtherDrivers(RESPECT_SPEED_GAPS_OF_OTHER_DRIVERS_ADAPT_SPEED);
                 break;
             case AGGRESSIVE:
-                mode.setStrategicChanges(true, false);
+                mode.setStrategicChanges(true, true);
                 mode.setSpeedChanges(true, false);
                 break;
             case CAUTIOUS:
-                mode.setStrategicChanges(true, false);
+                mode.setStrategicChanges(true, true);
                 mode.setCooperativeChanges(true, false);
                 mode.setSpeedChanges(true, false);
                 mode.setRightDriveChanges(true, false);
@@ -59,7 +61,7 @@ public class SumoLaneChangeMode {
             case PASSIVE:
             case COOPERATIVE:
             case DEFAULT:
-                mode.setStrategicChanges(true, false);
+                mode.setStrategicChanges(true, true);
                 mode.setCooperativeChanges(true, false);
                 mode.setSpeedChanges(true, false);
                 mode.setRightDriveChanges(true, false);

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeModeTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeModeTest.java
@@ -90,12 +90,13 @@ public class SumoLaneChangeModeTest {
 
     @Test
     public void testTranslateFromEnum() {
-        assertEquals(1622, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.DEFAULT).getAsInteger());
-        assertEquals(514, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.OFF).getAsInteger());
-        assertEquals(1042, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.AGGRESSIVE).getAsInteger());
-        assertEquals(1622, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.COOPERATIVE).getAsInteger());
-        assertEquals(1942, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.CAUTIOUS).getAsInteger());
-        assertEquals(1686, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.PASSIVE).getAsInteger());
+        assertEquals(1621, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.DEFAULT).getAsInteger());
+        assertEquals(512, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.OFF).getAsInteger());
+        assertEquals(513, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.FOLLOW_ROUTE).getAsInteger());
+        assertEquals(1041, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.AGGRESSIVE).getAsInteger());
+        assertEquals(1621, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.COOPERATIVE).getAsInteger());
+        assertEquals(1877, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.CAUTIOUS).getAsInteger());
+        assertEquals(1621, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.PASSIVE).getAsInteger());
     }
 
 }

--- a/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeModeTest.java
+++ b/fed/mosaic-sumo/src/test/java/org/eclipse/mosaic/fed/sumo/bridge/api/complex/SumoLaneChangeModeTest.java
@@ -90,13 +90,13 @@ public class SumoLaneChangeModeTest {
 
     @Test
     public void testTranslateFromEnum() {
-        assertEquals(1621, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.DEFAULT).getAsInteger());
+        assertEquals(1622, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.DEFAULT).getAsInteger());
         assertEquals(512, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.OFF).getAsInteger());
-        assertEquals(513, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.FOLLOW_ROUTE).getAsInteger());
-        assertEquals(1041, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.AGGRESSIVE).getAsInteger());
-        assertEquals(1621, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.COOPERATIVE).getAsInteger());
-        assertEquals(1877, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.CAUTIOUS).getAsInteger());
-        assertEquals(1621, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.PASSIVE).getAsInteger());
+        assertEquals(514, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.FOLLOW_ROUTE).getAsInteger());
+        assertEquals(1042, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.AGGRESSIVE).getAsInteger());
+        assertEquals(1622, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.COOPERATIVE).getAsInteger());
+        assertEquals(1878, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.CAUTIOUS).getAsInteger());
+        assertEquals(1622, SumoLaneChangeMode.translateFromEnum(LaneChangeMode.PASSIVE).getAsInteger());
     }
 
 }

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/enums/LaneChangeMode.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/enums/LaneChangeMode.java
@@ -17,9 +17,10 @@ package org.eclipse.mosaic.lib.enums;
 
 public enum LaneChangeMode {
     DEFAULT, // == COOPERATIVE
-    OFF, // no lane changes except strategic (514 in SUMO)
-    CAUTIOUS, //strategic, cooperative, speed changes, keep right, no speed adaption when changing lanes (917 in SUMO)
-    COOPERATIVE, //strategic, cooperative, speed changes, keep right, avoid collisions (597 in SUMO)
-    AGGRESSIVE, //strategic, no cooperative, speed changes, stay left, do not respect other drivers (17 in SUMO)
-    PASSIVE //strategic, no cooperative, speed changes, stay right, do not respect other drivers (661 in SUMO)
+    OFF, // no lane changes at all, only by explicit calls of changeLane
+    FOLLOW_ROUTE, // no lane changes except strategic
+    CAUTIOUS, //strategic, cooperative, speed changes, keep right, no speed adaption when changing lanes
+    COOPERATIVE, //strategic, cooperative, speed changes, keep right, avoid collisions
+    AGGRESSIVE, //strategic, no cooperative, speed changes, stay left, do not respect other drivers
+    PASSIVE //strategic, no cooperative, speed changes, stay right, do not respect other drivers
 }

--- a/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/RingBuffer.java
+++ b/lib/mosaic-utils/src/main/java/org/eclipse/mosaic/lib/util/RingBuffer.java
@@ -103,6 +103,7 @@ public class RingBuffer<T> implements Iterable<T> {
     }
 
     public void clear() {
+        Arrays.fill(elements, null);
         ringMode = false;
         head = 0;
     }

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/time/RealtimeSynchronisation.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/time/RealtimeSynchronisation.java
@@ -52,13 +52,14 @@ public class RealtimeSynchronisation {
     public void sync(long timestamp) {
 
         if (realtimeFactor > 0d && realNanoTimeLastSync > 0) {
-            long realTimeSinceLastSync = System.nanoTime() - realNanoTimeLastSync;
+            // Consider real time difference of 1s at maximum, to prevent "catching up" behavior when pausing a simulator on purpose
+            long realTimeSinceLastSync = Math.min(TIME.SECOND, System.nanoTime() - realNanoTimeLastSync);
             long simTimeSinceLastSync = timestamp - simNanoTimeLastSync;
 
             // Conversion from simulation to wanted realtime according to the given realtime factor 
             long realTimeSinceLastSyncWanted = (long) (simTimeSinceLastSync * (1 / realtimeFactor));
 
-            // The real nano seconds we now have to wait to fulfill the requirement above
+            // The real nanoseconds we now have to wait to fulfill the requirement above
             long nanoTimeToWait = realTimeSinceLastSyncWanted - realTimeSinceLastSync + waitOffset;
 
             // The actual waiting


### PR DESCRIPTION
## Description

* Previously, `LaneChangeMode.OFF` still did strategic lane changes, e.g. to follow a route.
* Now, `LaneChangeMode.OFF` disables all lane changes in SUMO, an additional `LaneChangeMode.FOLLOW_ROUTE` reprises the previous behavior, with all lane change reasons turned off, except strategic lane changes for route-following.
* Furthermore, disallow negative numbers when calculating the target lane for a lane change.

Offtopic:
* RTI real time synchronization (`-b`) now works much better when pausing the simulation. Then it will not try to catch up to meet the configured real-time requirement. Instead, it will only do real-time sync for the last 1 second.

What is this PR about?

 
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

Not really, but https://eclipse.dev/mosaic/docs/develop_applications/operating_system/ is apparently broken (there is still milliseconds passed to `changeLane(..)` instead of nanoseconds.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [ ] `origin/main` has been merged into your Fork.
- [ ] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

