### PR TITLE
feat(sumo): support for SUMO 1.20.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ kind: Pod
 spec:
   containers:
   - name: maven-sumo
-    image: eclipsemosaic/mosaic-ci:jdk11-sumo-1.19.0
+    image: eclipsemosaic/mosaic-ci:jdk11-sumo-1.20.0
     command:
     - cat
     tty: true

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ IEEE Transactions on Intelligent Transportation Systems, pp. 1 - 11, Print ISSN:
 
 View our website at **[eclipse.dev/mosaic](https://eclipse.dev/mosaic)** for detailed documentation and many tutorials to get started with Eclipse MOSAIC. For a quick start on building and running the code in this repository, just jump to the bottom section of this README file.
 
-## The Essential edition of Eclipse MOSAIC
+## The Essential Edition of Eclipse MOSAIC
 
-This repository contains the *Essential* edition of Eclipse MOSAIC, that is, the runtime infrastructure, 
+This repository contains the *Essential* edition of Eclipse MOSAIC, which includes the runtime infrastructure, 
 the core libraries, and various implementations of simulators or couplings to existing ones. All features 
 included in this version of Eclipse MOSAIC are sufficient for most use-cases in the field of smart and connected mobility.
 Additional simulators and assessment features are provided by [Fraunhofer FOKUS](https://www.fokus.fraunhofer.de/go/asct) on a commercial basis.
 
-## Related repositories
+## Related Repositories
 
-* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.18.0`.
+* [Eclipse SUMO](https://github.com/eclipse/sumo) is coupled directly using the TraCI interface. We recommend using the SUMO release `1.20.0`.
 * The coupling to [ns-3](https://www.nsnam.org) is realized by a federate implementation which can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/ns3-federate). 
   We currently support ns-3 version `3.36.1`. 
 * The coupling to [OMNeT++](https://omnetpp.org) is implemented in a very similar manner. The corresponding federate implementation can be found [in our MOSAIC Addons repository](https://github.com/mosaic-addons/omnetpp-federate). 
@@ -69,7 +69,7 @@ For a successful build you need the following software to be installed:
 
 * **Maven 3.1.x** or higher.
 * **Java 11**, 17, or 21 - We recommend using the [Adoptium OpenJDK (aka Eclipse Temurin)](https://adoptium.net/?variant=openjdk11).
-* **SUMO 1.19.0** - Older versions > 1.2.0 are most probably supported, but not tested. The environment variable `SUMO_HOME` should be configured properly.
+* **SUMO 1.20.0** - Older versions > 1.2.0 are most probably supported, but not tested. The environment variable `SUMO_HOME` should be configured properly.
 
 ## Build
 

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/LibSumoAmbassador.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/ambassador/LibSumoAmbassador.java
@@ -34,7 +34,7 @@ import java.nio.file.Paths;
  */
 public class LibSumoAmbassador extends SumoAmbassador {
 
-    private static final String VALID_LIBSUMO_VERSIONS = "1\\.1[78]\\.";
+    private static final String VALID_LIBSUMO_VERSIONS = "1\\.(19|20)\\.";
 
     public LibSumoAmbassador(AmbassadorParameter ambassadorParameter) {
         super(ambassadorParameter);

--- a/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
+++ b/fed/mosaic-sumo/src/main/java/org/eclipse/mosaic/fed/sumo/bridge/SumoVersion.java
@@ -44,6 +44,7 @@ public enum SumoVersion {
     SUMO_1_17_x("1.17.*", TraciVersion.API_20),
     SUMO_1_18_x("1.18.*", TraciVersion.API_20),
     SUMO_1_19_x("1.19.*", TraciVersion.API_21),
+    SUMO_1_20_x("1.20.*", TraciVersion.API_21),
 
     /**
      * the lowest version supported by this client.
@@ -53,7 +54,7 @@ public enum SumoVersion {
     /**
      * the highest version supported by this client.
      */
-    HIGHEST(SUMO_1_19_x.sumoVersion, SUMO_1_19_x.traciVersion);
+    HIGHEST(SUMO_1_20_x.sumoVersion, SUMO_1_20_x.traciVersion);
 
     private final String sumoVersion;
     private final TraciVersion traciVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.slf4j>2.0.12</version.slf4j><!-- 2.0.12 is approved #13344 -->
         <version.sqlite-jdbc>3.42.0.0</version.sqlite-jdbc><!-- 3.42.0.0 is approved in #9089 -->
         <!-- note, when upgrading, the field LibSumoAmbassador#VALID_LIBSUMO_VERSIONS needs to be changed too -->
-        <version.libsumo>1.19.0</version.libsumo>
+        <version.libsumo>1.20.0</version.libsumo>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.slf4j>2.0.12</version.slf4j><!-- 2.0.12 is approved #13344 -->
         <version.sqlite-jdbc>3.42.0.0</version.sqlite-jdbc><!-- 3.42.0.0 is approved in #9089 -->
         <!-- note, when upgrading, the field LibSumoAmbassador#VALID_LIBSUMO_VERSIONS needs to be changed too -->
-        <version.libsumo>1.18.0</version.libsumo>
+        <version.libsumo>1.19.0</version.libsumo>
     </properties>
 
     <dependencies>

--- a/test/ci/ci-image-mvn-sumo/Dockerfile
+++ b/test/ci/ci-image-mvn-sumo/Dockerfile
@@ -9,6 +9,6 @@ WORKDIR /home/jenkins
 RUN apt-get update &&  \
     apt-get install -y --allow-unauthenticated software-properties-common && \
     # adjust this output string to bypass potential caches
-    echo "Installing SUMO 1.19.0" && \
+    echo "Installing SUMO 1.20.0" && \
     add-apt-repository ppa:sumo/stable && \
     apt-get install -y sumo

--- a/test/ci/ci-image-mvn-sumo/README.md
+++ b/test/ci/ci-image-mvn-sumo/README.md
@@ -10,9 +10,9 @@ build and tag the docker image with the latest SUMO version. This image should b
 and available in the PPA.
 
 ```shell script
-docker build . -t eclipsemosaic/mosaic-ci:jdk11-sumo-1.18.0
+docker build . -t eclipsemosaic/mosaic-ci:jdk11-sumo-1.20.0
 docker login
-docker push eclipsemosaic/mosaic-ci:jdk11-sumo-1.18.0
+docker push eclipsemosaic/mosaic-ci:jdk11-sumo-1.20.0
 ```  
 
 Afterwards, the image should be available here: https://hub.docker.com/r/eclipsemosaic/mosaic-ci/tags


### PR DESCRIPTION
## Description

* Adds support for SUMO 1.20.0
* Updated version in README
* SUMO 1.20.0 libsumojni.jar is not yet available, therefore currently only upgrade `LibSumoAmbassador` to 1.19.0, but tested already with 1.20.0-SNAPSHOT.
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

Yes, but only on next MOSAIC release.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

