### PR TITLE
introduced duplicatable V2XMessage functionality

### DIFF
--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/DuplicatableMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/DuplicatableMessage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Fraunhofer FOKUS and others. All rights reserved.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contact: mosaic@fokus.fraunhofer.de
+ */
+
+package org.eclipse.mosaic.lib.objects;
+
+import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
+
+/**
+ * Creates a copy of the message
+ * @param <MessageT>
+ */
+public interface DuplicatableMessage<T extends DuplicatableMessage<T>> {
+
+    /**
+     * Creates a copy of the V2xMessage.
+     * The message gets a new ID and routing (to use current vehicle position).
+     * Only its contents (e.g. payload, type, ...) are copied.
+     *
+     * @param routing contains current vehicle position
+     * @return cloned message
+     */
+    T duplicate(MessageRouting routing);
+}

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/DuplicatableMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/DuplicatableMessage.java
@@ -17,7 +17,7 @@ package org.eclipse.mosaic.lib.objects.v2x;
 
 /**
  * A message that can duplicate itself.
- * @param <T> a class that extends {@link org.eclipse.mosaic.lib.objects.v2x.V2xMessage}
+ * @param <T> a class that extends {@link V2xMessage}
  */
 public interface DuplicatableMessage<T extends V2xMessage> {
 

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/DuplicatableMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/DuplicatableMessage.java
@@ -19,7 +19,7 @@ package org.eclipse.mosaic.lib.objects.v2x;
  * A message that can duplicate itself.
  * @param <T> a class that extends {@link org.eclipse.mosaic.lib.objects.v2x.V2xMessage}
  */
-public interface DuplicatableMessage<T extends DuplicatableMessage<T>> {
+public interface DuplicatableMessage<T extends V2xMessage> {
 
     /**
      * Creates a copy of the V2xMessage.

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/DuplicatableMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/DuplicatableMessage.java
@@ -13,13 +13,11 @@
  * Contact: mosaic@fokus.fraunhofer.de
  */
 
-package org.eclipse.mosaic.lib.objects;
-
-import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
+package org.eclipse.mosaic.lib.objects.v2x;
 
 /**
- * Creates a copy of the message
- * @param <MessageT>
+ * A message that can duplicate itself.
+ * @param <T> a class that extends {@link org.eclipse.mosaic.lib.objects.v2x.V2xMessage}
  */
 public interface DuplicatableMessage<T extends DuplicatableMessage<T>> {
 

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/GenericV2xMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/GenericV2xMessage.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
 /**
  * This {@link V2xMessage} implementation can be used for simple message exchange between entities.
  */
-public final class GenericV2xMessage extends V2xMessage implements DuplicatableMessage {
+public final class GenericV2xMessage extends V2xMessage implements DuplicatableMessage<GenericV2xMessage> {
 
     private static final long serialVersionUID = 1L;
 

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/GenericV2xMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/GenericV2xMessage.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.mosaic.lib.objects.v2x;
 
+import org.eclipse.mosaic.lib.objects.DuplicatableMessage;
 import org.eclipse.mosaic.lib.objects.ToDataOutput;
 import org.eclipse.mosaic.lib.util.ClassUtils;
 
@@ -23,7 +24,7 @@ import javax.annotation.Nonnull;
 /**
  * This {@link V2xMessage} implementation can be used for simple message exchange between entities.
  */
-public final class GenericV2xMessage extends V2xMessage {
+public final class GenericV2xMessage extends V2xMessage implements DuplicatableMessage {
 
     private static final long serialVersionUID = 1L;
 
@@ -63,6 +64,12 @@ public final class GenericV2xMessage extends V2xMessage {
         this.payload = new EncodedPayload(messagePayload, minimalMessageSize);
     }
 
+    public GenericV2xMessage(GenericV2xMessage message) {
+        super(message.getRouting());
+        this.messageType = message.getMessageType();
+        this.payload = message.getPayload();
+    }
+
 
     @Override
     @Nonnull
@@ -80,6 +87,10 @@ public final class GenericV2xMessage extends V2xMessage {
         return "GenericV2xMessage{"
                 + "classSimpleName=" + messageType
                 + ", encodedPayload=" + payload + '}';
+    }
+
+    public GenericV2xMessage duplicate(MessageRouting routing) {
+        return new GenericV2xMessage(routing, messageType, payload.getEffectiveLength());
     }
 
 }

--- a/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/GenericV2xMessage.java
+++ b/lib/mosaic-objects/src/main/java/org/eclipse/mosaic/lib/objects/v2x/GenericV2xMessage.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.mosaic.lib.objects.v2x;
 
-import org.eclipse.mosaic.lib.objects.DuplicatableMessage;
 import org.eclipse.mosaic.lib.objects.ToDataOutput;
 import org.eclipse.mosaic.lib.util.ClassUtils;
 
@@ -64,12 +63,6 @@ public final class GenericV2xMessage extends V2xMessage implements DuplicatableM
         this.payload = new EncodedPayload(messagePayload, minimalMessageSize);
     }
 
-    public GenericV2xMessage(GenericV2xMessage message) {
-        super(message.getRouting());
-        this.messageType = message.getMessageType();
-        this.payload = message.getPayload();
-    }
-
 
     @Override
     @Nonnull
@@ -89,6 +82,7 @@ public final class GenericV2xMessage extends V2xMessage implements DuplicatableM
                 + ", encodedPayload=" + payload + '}';
     }
 
+    @Override
     public GenericV2xMessage duplicate(MessageRouting routing) {
         return new GenericV2xMessage(routing, messageType, payload.getEffectiveLength());
     }


### PR DESCRIPTION
## Description

- introducing "DuplicatableMessage" interface for V2xMessage inheritors
- allows duplicating a specialised V2XMessage without importing it 
- used by `VariableRetransmissionApp.java` when retransmitting a message 

## Issue(s) related to this PR

* Resolves issue: internal issue mosaic-extended#834
  
## Affected parts of the online documentation

none

## Definition of Done


**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

- more code changes in mosaic-extended (same branch name) 
