### PR TITLE
feat(rti): pass JVM options to JAVA based federates

### DIFF
--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/JavaFederateExecutor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/JavaFederateExecutor.java
@@ -109,10 +109,10 @@ public class JavaFederateExecutor implements FederateExecutor {
             throw new FederateStarterException("Federate has been already started");
         }
 
-        final String sep = File.separator;
-        final String fileSep = host.operatingSystem == CLocalHost.OperatingSystem.WINDOWS ? ";" : ":";
+        final String fileSeparator = File.separator;
+        final String pathSeparator = host.operatingSystem == CLocalHost.OperatingSystem.WINDOWS ? ";" : ":";
 
-        List<String> args = Lists.newArrayList("-cp", createClasspath(sep, fileSep), mainClass);
+        List<String> args = Lists.newArrayList("-cp", createClasspath(fileSeparator, pathSeparator), mainClass);
         args.addAll(Arrays.asList(programArguments.split(" ")));
 
         delegateExecFederateStarter = new ExecutableFederateExecutor(this.handle, "java", args);

--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/JavaFederateExecutor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/JavaFederateExecutor.java
@@ -134,8 +134,9 @@ public class JavaFederateExecutor implements FederateExecutor {
 
     private String createClasspath(String fileSeparator, String pathSeparator) {
         final StringBuilder classPath = new StringBuilder();
-        classPath.append("./*");
-        classPath.append(pathSeparator).append("lib/*");
+        classPath.append("."); // access to root directory
+        classPath.append(pathSeparator).append("./*"); // includes all jars in root directory
+        classPath.append(pathSeparator).append("lib/*"); //  includes all jars in lib directory
         for (String classpathEntry : handle.getJavaFederateParameters().getJavaClasspathEntries()) {
             classPath.append(pathSeparator);
             classPath.append(classpathEntry);

--- a/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/JavaFederateExecutor.java
+++ b/rti/mosaic-rti-api/src/main/java/org/eclipse/mosaic/rti/api/federatestarter/JavaFederateExecutor.java
@@ -109,7 +109,7 @@ public class JavaFederateExecutor implements FederateExecutor {
             throw new FederateStarterException("Federate has been already started");
         }
 
-        final String fileSeparator = File.separator;
+        final String fileSeparator = host.operatingSystem == CLocalHost.OperatingSystem.WINDOWS ? "\\" : "/";
         final String pathSeparator = host.operatingSystem == CLocalHost.OperatingSystem.WINDOWS ? ";" : ":";
 
         List<String> args = Lists.newArrayList("-cp", createClasspath(fileSeparator, pathSeparator), mainClass);

--- a/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/WatchDogThread.java
+++ b/rti/mosaic-rti-core/src/main/java/org/eclipse/mosaic/rti/WatchDogThread.java
@@ -62,6 +62,7 @@ public class WatchDogThread extends Thread implements WatchDog {
     @SuppressWarnings(value = "DM_EXIT", justification = "That's the purpose of the Watchdog")
     @Override
     public void run() {
+        updateCurrentTime();
         while (watching) {
             try {
                 Thread.sleep(1000L);

--- a/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
+++ b/rti/mosaic-starter/src/main/java/org/eclipse/mosaic/starter/MosaicSimulation.java
@@ -191,7 +191,6 @@ public class MosaicSimulation {
             );
             addFederates(federation, federates);
 
-
             federation.getTimeManagement().runSimulation();
 
             stopFederation(federation);
@@ -211,14 +210,6 @@ public class MosaicSimulation {
             simulationResult.exception = e;
         }
         return simulationResult;
-    }
-
-    private void addFederates(ComponentProvider federation, List<FederateDescriptor> federates) throws Exception {
-        for (FederateDescriptor descriptor : federates) {
-            federation.getFederationManagement().addFederate(descriptor);
-            federation.getInteractionManagement().subscribeInteractions(descriptor.getId(), descriptor.getInteractions());
-            federation.getTimeManagement().updateWatchDog();
-        }
     }
 
     private void initializeSingletons(CScenario scenarioConfiguration) {
@@ -457,6 +448,17 @@ public class MosaicSimulation {
             time.startExternalWatchDog(federationId, externalWatchdogPort);
         }
         return componentProvider;
+    }
+
+    /**
+     * Adds the list of {@link FederateDescriptor}s to the given federation.
+     */
+    private void addFederates(ComponentProvider federation, List<FederateDescriptor> federates) throws Exception {
+        for (FederateDescriptor descriptor : federates) {
+            federation.getFederationManagement().addFederate(descriptor);
+            federation.getInteractionManagement().subscribeInteractions(descriptor.getId(), descriptor.getInteractions());
+            federation.getTimeManagement().updateWatchDog();
+        }
     }
 
     private void stopFederation(ComponentProvider federation) {


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

* This extends the JavaFederateExecutor to be able to pass JVM options.
* Furthermore, the RTI initialization now creates the `ComponentProvider` _before_ building the `FederateExecutors`.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Part of internal issue 861
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [ ] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

