### PR TITLE
feat(file-output): add Message as an extended method for V2xMessageReception

### DIFF
--- a/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
@@ -51,6 +51,7 @@
                     <entry>MessageId</entry>
                     <entry>ReceiverName</entry>
                     <entry>ReceiverInformation.ReceiveSignalStrength</entry>
+                    <entry>Payload.EffectiveLength</entry>
                 </entries>
             </subscription>
             <subscription id="V2xMessageTransmission">
@@ -66,6 +67,7 @@
                     <entry>Message.Routing.Destination.Type</entry>
                     <entry>Message.Routing.Destination.Address.IPv4Address</entry>
                     <entry>Message.Routing.Destination.AdhocChannelId</entry>
+                    <entry>Payload.EffectiveLength</entry>
                 </entries>
             </subscription>
             <subscription id="VehicleRegistration" enabled="true">

--- a/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
+++ b/bundle/src/assembly/resources/scenarios/Barnim/output/output_config.xml
@@ -51,7 +51,7 @@
                     <entry>MessageId</entry>
                     <entry>ReceiverName</entry>
                     <entry>ReceiverInformation.ReceiveSignalStrength</entry>
-                    <entry>Payload.EffectiveLength</entry>
+                    <entry>Message.Payload.EffectiveLength</entry>
                 </entries>
             </subscription>
             <subscription id="V2xMessageTransmission">
@@ -67,7 +67,7 @@
                     <entry>Message.Routing.Destination.Type</entry>
                     <entry>Message.Routing.Destination.Address.IPv4Address</entry>
                     <entry>Message.Routing.Destination.AdhocChannelId</entry>
-                    <entry>Payload.EffectiveLength</entry>
+                    <entry>Message.Payload.EffectiveLength</entry>
                 </entries>
             </subscription>
             <subscription id="VehicleRegistration" enabled="true">

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
@@ -38,6 +38,14 @@ public class ExtendedMethodSet {
         V2X_MESSAGES.put(message.getId(), message);
     }
 
+    static public Object getType(V2xMessageTransmission interaction) {
+        V2xMessage message = Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId()));
+        if (message instanceof GenericV2xMessage) {
+            return ((GenericV2xMessage) message).getMessageType();
+        }
+        return message.getSimpleClassName();
+    }
+
     static public Object getType(V2xMessageReception interaction) {
         V2xMessage message = Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId()));
         if (message instanceof GenericV2xMessage) {
@@ -48,14 +56,6 @@ public class ExtendedMethodSet {
 
     static public V2xMessage getMessage(V2xMessageReception interaction) {
         return Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId()));
-    }
-
-    static public Object getType(V2xMessageTransmission interaction) {
-        V2xMessage message = Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId()));
-        if (message instanceof GenericV2xMessage) {
-            return ((GenericV2xMessage) message).getMessageType();
-        }
-        return message.getSimpleClassName();
     }
 
     static public Object getTimeInSec(Interaction interaction) {

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
@@ -46,6 +46,10 @@ public class ExtendedMethodSet {
         return message.getSimpleClassName();
     }
 
+    static public Object getPayload(V2xMessageReception interaction) {
+        return Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId())).getPayload();
+    }
+
     static public Object getType(V2xMessageTransmission interaction) {
         V2xMessage message = Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId()));
         if (message instanceof GenericV2xMessage) {

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/format/ExtendedMethodSet.java
@@ -46,8 +46,8 @@ public class ExtendedMethodSet {
         return message.getSimpleClassName();
     }
 
-    static public Object getPayload(V2xMessageReception interaction) {
-        return Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId())).getPayload();
+    static public V2xMessage getMessage(V2xMessageReception interaction) {
+        return Objects.requireNonNull(V2X_MESSAGES.get(interaction.getMessageId()));
     }
 
     static public Object getType(V2xMessageTransmission interaction) {


### PR DESCRIPTION
## Description

It is now possible to print details of the `V2xMessage` via file output for `V2xMessageReception` interactions:

```xml
<subscription id="V2xMessageTransmission"/>
<subscription id="V2xMessageReception">
    <entries>
        <entry>Time</entry>
        <entry>Type</entry>
        <entry>Message.Payload.EffectiveLength</entry>
        <entry>ReceiverName</entry>
    </entries>
</subscription>
```

## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Documentation will be extended.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

