### PR TITLE
refactor(output): cleaner initialization of output generators

### DIFF
--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/OutputGeneratorLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/ambassador/OutputGeneratorLoader.java
@@ -40,25 +40,6 @@ public abstract class OutputGeneratorLoader {
     private File configurationDirectory;
 
     /**
-     * this method is called just after a new instance of a derived output generator config was created.
-     * subclasses should call this method at first, and then proceed with reading custom parameters from the configuration
-     *
-     * @param rti                    the {@link RtiAmbassador} of the federation
-     * @param config                 output generator configuration
-     * @param configurationDirectory output generator configuration directory path
-     */
-    public void initialize(RtiAmbassador rti, HierarchicalConfiguration<ImmutableNode> config, File configurationDirectory) throws Exception {
-        this.rti = rti;
-        this.id = ConfigHelper.getId(config);
-        this.updateInterval = ConfigHelper.getUpdateInterval(config);
-        this.handleStartTime = ConfigHelper.getHandleStartTime(config);
-        this.handleEndTime = ConfigHelper.getHandleEndTime(config);
-        this.interactionTypes = ConfigHelper.getSubscriptions(config);
-        this.configurationDirectory = configurationDirectory;
-    }
-
-
-    /**
      * Returns the output generator identifier.
      *
      * @return output generator identifier
@@ -122,7 +103,35 @@ public abstract class OutputGeneratorLoader {
     }
 
     /**
-     * Factory method for creating actual output generator.
+     * this method is called just after a new instance of a derived output generator config was created.
+     *
+     * @param rti                    the {@link RtiAmbassador} of the federation
+     * @param config                 output generator configuration
+     * @param configurationDirectory output generator configuration directory path
+     */
+    public final void initialize(RtiAmbassador rti, HierarchicalConfiguration<ImmutableNode> config, File configurationDirectory) throws Exception {
+        this.rti = rti;
+        this.id = ConfigHelper.getId(config);
+        this.updateInterval = ConfigHelper.getUpdateInterval(config);
+        this.handleStartTime = ConfigHelper.getHandleStartTime(config);
+        this.handleEndTime = ConfigHelper.getHandleEndTime(config);
+        this.interactionTypes = ConfigHelper.getSubscriptions(config);
+        this.configurationDirectory = configurationDirectory;
+
+        configure(config);
+    }
+
+    /**
+     * Subclasses implement this method to read additional custom configuration from the
+     * given {@link HierarchicalConfiguration} tree.
+     *
+     * @param config the configuration tree for the output generator
+     */
+    protected abstract void configure(HierarchicalConfiguration<ImmutableNode> config);
+
+    /**
+     * Factory method for creating actual output generator based on the previously
+     * read configuration ({@link #configure}).
      *
      * @return the actual output generator
      */

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/file/FileOutputLoader.java
@@ -23,7 +23,6 @@ import org.eclipse.mosaic.fed.output.generator.file.write.Write;
 import org.eclipse.mosaic.fed.output.generator.file.write.WriteByFile;
 import org.eclipse.mosaic.fed.output.generator.file.write.WriteByFileCompress;
 import org.eclipse.mosaic.fed.output.generator.file.write.WriteByLog;
-import org.eclipse.mosaic.rti.api.RtiAmbassador;
 
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
@@ -70,6 +69,17 @@ public class FileOutputLoader extends OutputGeneratorLoader {
 
     public InteractionFormatter getInteractionFormatter() {
         return this.interactionFormatter;
+    }
+
+    @Override
+    public void configure(HierarchicalConfiguration<ImmutableNode> config) {
+        try {
+            this.writer = this.getWrite(config);
+            this.interactionFormatter = this.createInteractionFormatter(config);
+        } catch (Exception e) {
+            log.error("Exception", e);
+            throw new RuntimeException("Caused by OutputGenerator " + getId(), e);
+        }
     }
 
     private InteractionFormatter createInteractionFormatter(HierarchicalConfiguration<ImmutableNode> sub)
@@ -144,18 +154,6 @@ public class FileOutputLoader extends OutputGeneratorLoader {
                 throw new IllegalArgumentException("No such write method '" + write + "'");
         }
         return ret;
-    }
-
-    @Override
-    public void initialize(RtiAmbassador rti, HierarchicalConfiguration<ImmutableNode> config, File configurationDirectory) throws Exception {
-        super.initialize(rti, config, configurationDirectory);
-        try {
-            this.writer = this.getWrite(config);
-            this.interactionFormatter = this.createInteractionFormatter(config);
-        } catch (Exception e) {
-            log.error("Exception", e);
-            throw new Exception("Caused by OutputGenerator " + getId(), e);
-        }
     }
 
     @Override

--- a/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/websocket/WebsocketVisualizerLoader.java
+++ b/fed/mosaic-output/src/main/java/org/eclipse/mosaic/fed/output/generator/websocket/WebsocketVisualizerLoader.java
@@ -17,20 +17,16 @@ package org.eclipse.mosaic.fed.output.generator.websocket;
 
 import org.eclipse.mosaic.fed.output.ambassador.AbstractOutputGenerator;
 import org.eclipse.mosaic.fed.output.ambassador.OutputGeneratorLoader;
-import org.eclipse.mosaic.rti.api.RtiAmbassador;
 
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
-
-import java.io.File;
 
 public class WebsocketVisualizerLoader extends OutputGeneratorLoader {
 
     private int port;
 
     @Override
-    public void initialize(RtiAmbassador rti, HierarchicalConfiguration<ImmutableNode> config, File configurationDirectory) throws Exception {
-        super.initialize(rti, config, configurationDirectory);
+    public void configure(HierarchicalConfiguration<ImmutableNode> config) {
         port = config.getInt("port");
     }
 

--- a/fed/mosaic-output/src/test/java/org/eclipse/mosaic/fed/output/ambassador/TestOutputGeneratorLoader.java
+++ b/fed/mosaic-output/src/test/java/org/eclipse/mosaic/fed/output/ambassador/TestOutputGeneratorLoader.java
@@ -17,13 +17,18 @@ package org.eclipse.mosaic.fed.output.ambassador;
 
 import static org.mockito.Mockito.spy;
 
-import org.eclipse.mosaic.fed.output.ambassador.AbstractOutputGenerator;
-import org.eclipse.mosaic.fed.output.ambassador.OutputGeneratorLoader;
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.apache.commons.configuration2.tree.ImmutableNode;
 
 /**
  * An extension of {@link OutputGeneratorLoader} for testing purposes.
  */
 public class TestOutputGeneratorLoader extends OutputGeneratorLoader {
+
+    @Override
+    protected void configure(HierarchicalConfiguration<ImmutableNode> config) {
+        // nothing to do
+    }
 
     @Override
     public AbstractOutputGenerator createOutputGenerator() {


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->
* Previously, implementations of `OutputGenerator` had to override the `initialize` method and were required to call `super.initialize`, which is a anti-pattern to avoid. 
* This MR marks `initialize` as a `final` method and defines an additional abstract `configure` method which all subclasses need to implement to read additional parameters from the output generator configuration.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 875
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

