### PR TITLE
feat(tutorial): WeatherServerApp now relays the last received DENM

### DIFF
--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
@@ -15,12 +15,18 @@
 
 package org.eclipse.mosaic.app.tutorial;
 
+import org.eclipse.mosaic.fed.application.ambassador.simulation.communication.CamBuilder;
+import org.eclipse.mosaic.fed.application.ambassador.simulation.communication.ReceivedAcknowledgement;
+import org.eclipse.mosaic.fed.application.ambassador.simulation.communication.ReceivedV2xMessage;
 import org.eclipse.mosaic.fed.application.app.AbstractApplication;
+import org.eclipse.mosaic.fed.application.app.api.CommunicationApplication;
 import org.eclipse.mosaic.fed.application.app.api.os.ServerOperatingSystem;
+import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
 import org.eclipse.mosaic.lib.enums.SensorType;
 import org.eclipse.mosaic.lib.geo.GeoCircle;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
+import org.eclipse.mosaic.lib.objects.v2x.V2xMessage;
 import org.eclipse.mosaic.lib.objects.v2x.etsi.Denm;
 import org.eclipse.mosaic.lib.objects.v2x.etsi.DenmContent;
 import org.eclipse.mosaic.lib.util.scheduling.Event;
@@ -31,25 +37,18 @@ import org.eclipse.mosaic.rti.TIME;
  * about certain hazards on the road. The hazard is hard-coded for tutorial purposes,
  * in more realistic scenarios the location would've been updated dynamically.
  */
-public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem> {
+public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem> implements CommunicationApplication {
 
     /**
-     * Send hazard location at this interval, in seconds.
+     * Send warning at this interval, in seconds.
      */
     private final static long INTERVAL = 2 * TIME.SECOND;
 
-    /**
-     * Location of the hazard which causes the route change.
-     */
-    private final static GeoPoint HAZARD_LOCATION = GeoPoint.latLon(52.633047, 13.565314);
 
     /**
-     * Road ID where hazard is located.
+     * Save the last received DEN message for relaying.
      */
-    private final static String HAZARD_ROAD = "311964536_1313885442_2879911873";
-
-    private final static SensorType SENSOR_TYPE = SensorType.ICE;
-    private final static float SPEED = 25 / 3.6f;
+    private Denm lastMessage = null;
 
 
     /**
@@ -87,10 +86,14 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
      * and thus the DENM is sent periodically at this interval.
      */
     private void sample() {
-        final Denm denm = constructDenm(); // Construct exemplary DENM
-
-        getOs().getCellModule().sendV2xMessage(denm);
-        getLog().infoSimTime(this, "Sent DENM");
+        if (lastMessage == null) {
+            getLog().infoSimTime(this, "No warning present.");
+        } else {
+            final Denm denm = constructDenm();
+            getLog().debugSimTime(this, "{}", denm);
+            getOs().getCellModule().sendV2xMessage(denm);
+            getLog().infoSimTime(this, "Relayed last DENM");
+        }
         // Line up new event for periodic sending
         getOs().getEventManager().addEvent(
                 getOs().getSimulationTime() + INTERVAL, this
@@ -106,26 +109,57 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
      * @return The constructed DENM
      */
     private Denm constructDenm() {
-        final GeoCircle geoCircle = new GeoCircle(HAZARD_LOCATION, 3000.0D);
+        final GeoCircle geoCircle = new GeoCircle(lastMessage.getEventLocation(), 3000.0D);
         final MessageRouting routing = getOs().getCellModule().createMessageRouting().geoBroadcastBasedOnUnicast(geoCircle);
-
-        final int strength = getOs().getStateOfEnvironmentSensor(SENSOR_TYPE);
-
         return new Denm(routing,
                 new DenmContent(
-                        getOs().getSimulationTime(),
-                        null,
-                        HAZARD_ROAD,
-                        SENSOR_TYPE,
-                        strength,
-                        SPEED,
-                        0.0f,
-                        HAZARD_LOCATION,
-                        null,
-                        null
+                        lastMessage.getTime(),
+                        lastMessage.getSenderPosition(),
+                        lastMessage.getEventRoadId(),
+                        lastMessage.getWarningType(),
+                        lastMessage.getEventStrength(),
+                        lastMessage.getCausedSpeed(),
+                        lastMessage.getSenderDeceleration(),
+                        lastMessage.getEventLocation(),
+                        lastMessage.getEventArea(),
+                        lastMessage.getExtendedContainer()
                 ),
                 200
         );
+    }
+
+    @Override
+    public void onMessageReceived(ReceivedV2xMessage receivedV2xMessage) {
+        final V2xMessage msg = receivedV2xMessage.getMessage();
+        getLog().infoSimTime(this, "Received {} from {}.",
+                msg.getSimpleClassName(),
+                msg.getRouting().getSource().getSourceName()
+        );
+        // Only DEN Messages are handled
+        if (!(msg instanceof Denm)) {
+            getLog().infoSimTime(this, "Ignoring message of type: {}", msg.getSimpleClassName());
+            return;
+        }
+        lastMessage = (Denm) msg;
+        getLog().debugSimTime(this, "DENM content: Sensor Type: {}", lastMessage.getWarningType().toString());
+        getLog().debugSimTime(this, "DENM content: Event position: {}", lastMessage.getEventLocation());
+        getLog().debugSimTime(this, "DENM content: Event Strength: {}", lastMessage.getEventStrength());
+        getLog().debugSimTime(this, "DENM content: Road Id of the Sender: {}", lastMessage.getEventRoadId());
+    }
+
+    @Override
+    public void onAcknowledgementReceived(ReceivedAcknowledgement acknowledgement) {
+
+    }
+
+    @Override
+    public void onCamBuilding(CamBuilder camBuilder) {
+
+    }
+
+    @Override
+    public void onMessageTransmitted(V2xMessageTransmission v2xMessageTransmission) {
+
     }
 
     /**
@@ -133,7 +167,7 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
      */
     @Override
     public void onShutdown() {
-        getLog().infoSimTime(this, "Shutdown application");
+        getLog().infoSimTime(this, "Shutdown server.");
     }
 
 }

--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
@@ -48,7 +48,7 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
     /**
      * Save the last received DEN message for relaying.
      */
-    private Denm lastMessage = null;
+    private Denm lastReceivedMessage = null;
 
 
     /**
@@ -86,7 +86,7 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
      * and thus the DENM is sent periodically at this interval.
      */
     private void sample() {
-        if (lastMessage == null) {
+        if (lastReceivedMessage == null) {
             getLog().infoSimTime(this, "No warning present.");
         } else {
             final Denm denm = constructDenm();
@@ -109,20 +109,20 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
      * @return The constructed DENM
      */
     private Denm constructDenm() {
-        final GeoCircle geoCircle = new GeoCircle(lastMessage.getEventLocation(), 3000.0D);
+        final GeoCircle geoCircle = new GeoCircle(lastReceivedMessage.getEventLocation(), 3000.0D);
         final MessageRouting routing = getOs().getCellModule().createMessageRouting().geoBroadcastBasedOnUnicast(geoCircle);
         return new Denm(routing,
                 new DenmContent(
-                        lastMessage.getTime(),
-                        lastMessage.getSenderPosition(),
-                        lastMessage.getEventRoadId(),
-                        lastMessage.getWarningType(),
-                        lastMessage.getEventStrength(),
-                        lastMessage.getCausedSpeed(),
-                        lastMessage.getSenderDeceleration(),
-                        lastMessage.getEventLocation(),
-                        lastMessage.getEventArea(),
-                        lastMessage.getExtendedContainer()
+                        lastReceivedMessage.getTime(),
+                        lastReceivedMessage.getSenderPosition(),
+                        lastReceivedMessage.getEventRoadId(),
+                        lastReceivedMessage.getWarningType(),
+                        lastReceivedMessage.getEventStrength(),
+                        lastReceivedMessage.getCausedSpeed(),
+                        lastReceivedMessage.getSenderDeceleration(),
+                        lastReceivedMessage.getEventLocation(),
+                        lastReceivedMessage.getEventArea(),
+                        lastReceivedMessage.getExtendedContainer()
                 ),
                 200
         );
@@ -140,11 +140,11 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
             getLog().infoSimTime(this, "Ignoring message of type: {}", msg.getSimpleClassName());
             return;
         }
-        lastMessage = (Denm) msg;
-        getLog().debugSimTime(this, "DENM content: Sensor Type: {}", lastMessage.getWarningType().toString());
-        getLog().debugSimTime(this, "DENM content: Event position: {}", lastMessage.getEventLocation());
-        getLog().debugSimTime(this, "DENM content: Event Strength: {}", lastMessage.getEventStrength());
-        getLog().debugSimTime(this, "DENM content: Road Id of the Sender: {}", lastMessage.getEventRoadId());
+        lastReceivedMessage = (Denm) msg;
+        getLog().debugSimTime(this, "DENM content: Sensor Type: {}", lastReceivedMessage.getWarningType().toString());
+        getLog().debugSimTime(this, "DENM content: Event position: {}", lastReceivedMessage.getEventLocation());
+        getLog().debugSimTime(this, "DENM content: Event Strength: {}", lastReceivedMessage.getEventStrength());
+        getLog().debugSimTime(this, "DENM content: Road Id of the Sender: {}", lastReceivedMessage.getEventRoadId());
     }
 
     @Override

--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherWarningApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherWarningApp.java
@@ -108,9 +108,12 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
             return;
         }
 
-        // Message was received via cell from the WeatherServer
         if (msg.getRouting().getSource().getSourceName().equals("server_0")) {
-            getLog().infoSimTime(this, "Received message from cell from WeatherServer");
+            // Message was received via cell from the WeatherServer
+            getLog().infoSimTime(this, "Received message over cell from WeatherServer");
+        }
+        else {
+            getLog().infoSimTime(this, "Received message from {}", msg.getRouting().getSource().getSourceName());
         }
 
         getLog().infoSimTime(this, "Processing DEN message");
@@ -210,7 +213,7 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
          * with a builder and build a geoBroadCast for the circle area defined in dest.
          */
         if (useCellNetwork()) {
-            mr = getOs().getCellModule().createMessageRouting().geoBroadcastBasedOnUnicast(dest);
+            mr = getOs().getCellModule().createMessageRouting().topoCast("server_0");
         } else {
             mr = getOs().getAdHocModule().createMessageRouting().geoBroadCast(dest);
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/AbstractSimulationUnit.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/AbstractSimulationUnit.java
@@ -427,7 +427,7 @@ public abstract class AbstractSimulationUnit implements EventProcessor, Operatin
     }
 
     @Override
-    public final int getStateOfEnvironmentSensor(SensorType type) {
+    public int getStateOfEnvironmentSensor(SensorType type) {
         EnvironmentEvent event = environmentEvents.get(type);
         // If an event of this type in the map yet?
         if (event != null) {

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/ServerUnit.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/ServerUnit.java
@@ -20,6 +20,7 @@ import org.eclipse.mosaic.fed.application.ambassador.simulation.communication.Ca
 import org.eclipse.mosaic.fed.application.ambassador.simulation.navigation.IRoutingModule;
 import org.eclipse.mosaic.fed.application.ambassador.simulation.navigation.NavigationModule;
 import org.eclipse.mosaic.fed.application.app.api.os.ServerOperatingSystem;
+import org.eclipse.mosaic.lib.enums.SensorType;
 import org.eclipse.mosaic.lib.objects.mapping.ServerMapping;
 import org.eclipse.mosaic.lib.util.scheduling.Event;
 
@@ -53,8 +54,13 @@ public class ServerUnit extends AbstractSimulationUnit implements ServerOperatin
     }
 
     @Override
-    public CamBuilder assembleCamMessage(CamBuilder camBuilder) {
+    public final CamBuilder assembleCamMessage(CamBuilder camBuilder) {
         throw new UnsupportedOperationException("Servers can't send CAMs.");
+    }
+
+    @Override
+    public final int getStateOfEnvironmentSensor(SensorType type) {
+        throw new UnsupportedOperationException("Servers can't access Environment functionality.");
     }
 
     @Override

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/ReleaseBarnimIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/ReleaseBarnimIT.java
@@ -53,8 +53,8 @@ public class ReleaseBarnimIT {
         assertEquals(36,
                 LogAssert.count(simulationRule, "Navigation.log", ".*Request to switch to new route for vehicle .*")
         );
-        // 14 adhoc vehicles + 12 cell vehicles
-        assertEquals(26,
+        // 14 adhoc vehicles + 10 cell vehicles
+        assertEquals(24,
                 LogAssert.count(simulationRule, "Navigation.log", ".*Change to route [2-9] for vehicle .*")
         );
     }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/ReleaseBarnimLibsumoIT.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/ReleaseBarnimLibsumoIT.java
@@ -77,10 +77,9 @@ public class ReleaseBarnimLibsumoIT {
         assertEquals(120, LogAssert.count(simulationRule, "output.csv",
                 ".*VEHICLE_REGISTRATION;.*"
         ));
-//        //FIXME currently, libsumo.TrafficLightGetPrograms returns an empty list in any case
-//        assertEquals(53, LogAssert.count(simulationRule, "output.csv",
-//                ".*TRAFFICLIGHT_REGISTRATION;.*"
-//        ));
+        assertEquals(42, LogAssert.count(simulationRule, "output.csv",
+                ".*TRAFFICLIGHT_REGISTRATION;.*"
+        ));
         LogAssert.contains(simulationRule, "output.csv", "SERVER_REGISTRATION;0;server_0;WeatherServer;\\[.*\\]");
     }
 


### PR DESCRIPTION
## Description

The all-knowing weather server sends out warnings from second one. So any cell device will omit the icy region from the beginning on, and not a single cell-car will go towards the icy region.
I think it's more realistic, that the server can just relay the warnings that it received by cars.
For simplicity of the tutorial, the server will just memorize the last warning, and relay this last warning, independent from which car and from where it was sent.

## Issue(s) related to this PR

* Resolves internal issue 887
  
## Affected parts of the online documentation

- [ ] Changes in the documentation required!

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [x] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

