### PR TITLE
feat(sns): support multi-hop unicast for topological and geographical routing

### DIFF
--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/TransmissionSimulator.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/TransmissionSimulator.java
@@ -143,7 +143,7 @@ public class TransmissionSimulator {
         final NetworkAddress destinationAddress = dac.getAddress();
 
         if (destinationAddress.isBroadcast() && dac.getTimeToLive() != SINGLE_HOP_TTL) {
-            log.debug("SNS only supports single hop broadcasts. TTL {} will be dismissed and 1 will be used instead.", dac.getTimeToLive());
+            log.warn("SNS only supports single hop broadcasts. TTL {} will be dismissed and 1 will be used instead.", dac.getTimeToLive());
         }
 
         final TransmissionParameter transmissionParameter = new TransmissionParameter(
@@ -161,7 +161,7 @@ public class TransmissionSimulator {
             allPotentialReceivers.remove(senderName);
             log.debug("Addressed nodes in destination area={}", allPotentialReceivers);
             // transmission via singlehop broadcast
-            return transmissionModel.simulateSinglehop(
+            return transmissionModel.simulateTopologicalSinglehop(
                     senderName, allPotentialReceivers, transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
             );
         } else if (destinationAddress.isUnicast()) {
@@ -170,7 +170,7 @@ public class TransmissionSimulator {
 
             final boolean isInAreaOfSender = isNodeInArea(destination.getPosition(), getTopocastDestinationArea(sender));
             if (isInAreaOfSender) {
-                return transmissionModel.simulateSinglehop(
+                return transmissionModel.simulateTopologicalSinglehop(
                         senderName, Map.of(destinationNodeId, destination), transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
                 );
             } else {
@@ -179,13 +179,13 @@ public class TransmissionSimulator {
                 );
                 return Map.of(destinationNodeId, result);
             }
-        }
-
-        log.warn("""
+        } else {
+            log.warn("""
                 The SNS only supports SingleHop BroadCasts or MultiHop UniCasts when using Topological routing."
                 The given destination address {} is not valid. No message will be send.""", destinationAddress
-        );
-        return Map.of();
+            );
+            return Map.of();
+        }
     }
 
     /**

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/TransmissionSimulator.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/ambassador/TransmissionSimulator.java
@@ -35,7 +35,6 @@ import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -93,23 +92,20 @@ public class TransmissionSimulator {
         switch (dac.getType()) {
             case AD_HOC_TOPOCAST:
                 if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Send v2xMessage.id={} from node={} as Topocast (singlehop) @time={}",
+                    log.debug("Send v2xMessage.id={} from node={} as Topocast (singlehop) @time={}",
                             interaction.getMessage().getId(), senderName, TIME.format(interaction.getTime())
                     );
                 }
                 return sendMessageAsTopocast(senderName, dac);
             case AD_HOC_GEOCAST:
                 if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Send v2xMessage.id={} from={} as Geocast (geo routing) @time={}",
+                    log.debug( "Send v2xMessage.id={} from={} as Geocast (geo routing) @time={}",
                             interaction.getMessage().getId(), senderName, TIME.format(interaction.getTime())
                     );
                 }
                 return sendMessageAsGeocast(senderName, dac);
             default:
-                log.debug(
-                        "V2XMessage is not an ad hoc message. Skip this message. V2XMessage.id={}",
+                log.debug("V2XMessage is not an ad hoc message. Skip this message. V2XMessage.id={}",
                         interaction.getMessage().getId()
                 );
                 return null;
@@ -137,69 +133,63 @@ public class TransmissionSimulator {
     }
 
     /**
-     * Simulates topolocically-scoped Unicast or Broadcast as direct singlehop transmission.
-     * (NO multi-hops are implemented by now)
-     * <ol>
-     * <li>Verify if configured transmission can be send using the topocast logic
-     * <li>Differentiate between Unicast and Broadcast
-     * <li>Simulate transmission with one hop
-     * </ol>
+     * Simulates topolocically-scoped Unicast (singlehop or multihop transmissions) or Broadcast (only singlehop).
      *
      * @param senderName The Sender of the message.
      * @param dac        {@link DestinationAddressContainer} containing information about the destination for the message.
      * @return a Map containing the summarized transmission results
      */
     protected Map<String, TransmissionResult> sendMessageAsTopocast(String senderName, DestinationAddressContainer dac) {
-        NetworkAddress destinationAddress = dac.getAddress();
-        if (destinationAddress.isAnycast()) { // check for valid destination address
-            log.warn(
-                    "The SNS only supports SingleHopBroadCasts or SingleHopUniCasts when using TopoCasts."
-                            + " The given destination address {} is not valid. No message will be send.",
-                    destinationAddress
-            );
-            return null;
-        }
-        if (dac.getTimeToLive() != SINGLE_HOP_TTL) { // inform about dismissed TTL
-            log.debug("TTL {} will be dismissed and 1 will be used instead. For Topocast, SNS only supports SingleHopBroadCasts.", dac.getTimeToLive());
+        final NetworkAddress destinationAddress = dac.getAddress();
+
+        if (destinationAddress.isBroadcast() && dac.getTimeToLive() != SINGLE_HOP_TTL) {
+            log.debug("SNS only supports single hop broadcasts. TTL {} will be dismissed and 1 will be used instead.", dac.getTimeToLive());
         }
 
-        // accumulate all potential receivers in direct communication range
-        SimulationNode sender = SimulationEntities.INSTANCE.getOnlineNode(senderName);
-        Map<String, SimulationNode> allPotentialReceivers;
-        if (destinationAddress.isBroadcast()) { // SingleHopBroadCast
-            allPotentialReceivers = getPotentialBroadcastReceivers(getTopocastDestinationArea(sender));
-            // remove sender as single radios could not transmit and receive at the same time
-            allPotentialReceivers.remove(senderName);
-        } else { // SingleHopUniCast
-            allPotentialReceivers = getAddressedReceiver(destinationAddress, getTopocastDestinationArea(sender));
-        }
-        log.debug("Addressed nodes in destination area={}", allPotentialReceivers);
-
-        // perform actual transmission
-        TransmissionParameter transmissionParameter = new TransmissionParameter(
+        final TransmissionParameter transmissionParameter = new TransmissionParameter(
                 randomNumberGenerator,
                 config.singlehopDelay,
                 config.singlehopTransmission,
-                SINGLE_HOP_TTL
+                getTtl(dac)
         );
-        return transmissionModel.simulateTopocast(
-                senderName, allPotentialReceivers, transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
+        // accumulate all potential receivers in direct communication range
+        final SimulationNode sender = SimulationEntities.INSTANCE.getOnlineNode(senderName);
+
+        if (destinationAddress.isBroadcast()) { // SingleHopBroadCast
+            final var allPotentialReceivers = getPotentialBroadcastReceivers(getTopocastDestinationArea(sender));
+            // remove sender as single radios could not transmit and receive at the same time
+            allPotentialReceivers.remove(senderName);
+            log.debug("Addressed nodes in destination area={}", allPotentialReceivers);
+            // transmission via singlehop broadcast
+            return transmissionModel.simulateSinglehop(
+                    senderName, allPotentialReceivers, transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
+            );
+        } else if (destinationAddress.isUnicast()) {
+            final String destinationNodeId = IpResolver.getSingleton().reverseLookup(destinationAddress.getIPv4Address());
+            final SimulationNode destination = SimulationEntities.INSTANCE.getOnlineNode(destinationNodeId);
+
+            final boolean isInAreaOfSender = isNodeInArea(destination.getPosition(), getTopocastDestinationArea(sender));
+            if (isInAreaOfSender) {
+                return transmissionModel.simulateSinglehop(
+                        senderName, Map.of(destinationNodeId, destination), transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
+                );
+            } else {
+                final TransmissionResult result = transmissionModel.simulateTopologicalUnicast(
+                        senderName, destinationNodeId, destination, transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
+                );
+                return Map.of(destinationNodeId, result);
+            }
+        }
+
+        log.warn("""
+                The SNS only supports SingleHop BroadCasts or MultiHop UniCasts when using Topological routing."
+                The given destination address {} is not valid. No message will be send.""", destinationAddress
         );
+        return Map.of();
     }
 
     /**
-     * Simulates geocast routing transmission.
-     * (ONLY Broadcasts are implemented by now)
-     * <ol>
-     * <li>Verify if configured transmission can be send using the topocast logic
-     * <li>determine all potential receiver nodes in the destination area
-     * (including original sender due to re-broadcasting in geocast)</li>
-     * <li>simulate message transmission via
-     * <ol type="a">
-     * <li>simplified Multihop mode (possibly needed hops to reach destination not regarded)
-     * <li>with more elaborated approaching and flooding modes
-     * </ol>
-     * </ol>
+     * Simulates geocast routing transmission, either broadcast or unicast.
      *
      * @param senderName The Sender of the message.
      * @param dac        {@link DestinationAddressContainer} containing information about the destination for the message.
@@ -207,29 +197,49 @@ public class TransmissionSimulator {
      */
     protected Map<String, TransmissionResult> sendMessageAsGeocast(String senderName, DestinationAddressContainer dac) {
         if (dac.getGeoArea() == null) {
-            return Collections.EMPTY_MAP;
+            log.error("No target area given for Geographic routing. No message will be send.");
+            return Map.of();
         }
+        final NetworkAddress destinationAddress = dac.getAddress();
+        final Area<CartesianPoint> destinationArea = dac.getGeoArea().toCartesian();
 
-        Area<CartesianPoint> destinationArea = dac.getGeoArea().toCartesian();
-        Map<String, SimulationNode> allReceivers = getPotentialBroadcastReceivers(destinationArea);
-        log.debug("Addressed nodes in destination area={}", allReceivers);
+        final Map<String, SimulationNode> allReceivers;
+        if (destinationAddress.isUnicast()) {
+            final String destinationNodeId = IpResolver.getSingleton().reverseLookup(destinationAddress.getIPv4Address());
+            if (getPotentialBroadcastReceivers(destinationArea).containsKey(destinationNodeId)) {
+                allReceivers = Map.of(destinationNodeId, SimulationEntities.INSTANCE.getOnlineNode(destinationNodeId));
+            } else {
+                return Map.of();
+            }
+        } else if (destinationAddress.isBroadcast()){
+            allReceivers = getPotentialBroadcastReceivers(destinationArea);
+            log.debug("Addressed nodes in destination area={}", allReceivers);
+        } else {
+            log.warn("""
+                The SNS only supports BroadCasts or UniCasts when using geograpical routing."
+                The given destination address {} is not valid. No message will be send.""", destinationAddress
+            );
+            return Map.of();
+        }
 
         // get ttl value, this will be ignored for the simple transmission model
-        int ttl;
-        if (dac.getTimeToLive() == -1) {
-            ttl = config.maximumTtl; // ttl was null, which is interpreted as maximum
-        } else {
-            ttl = Math.min(dac.getTimeToLive(), config.maximumTtl); // ttl can't be higher than maximumTtl
-        }
-        TransmissionParameter transmissionParameter = new TransmissionParameter(
+        final TransmissionParameter transmissionParameter = new TransmissionParameter(
                 randomNumberGenerator,
                 config.singlehopDelay,
                 config.singlehopTransmission,
-                ttl
+                getTtl(dac)
         );
         return transmissionModel.simulateGeocast(
                 senderName, allReceivers, transmissionParameter, SimulationEntities.INSTANCE.getAllOnlineNodes()
         );
+    }
+
+    private int getTtl(DestinationAddressContainer dac) {
+        if (dac.getTimeToLive() == -1) {
+            return config.maximumTtl;
+        } else {
+            return Math.min(dac.getTimeToLive(), config.maximumTtl);
+        }
     }
 
     private Area<CartesianPoint> getTopocastDestinationArea(SimulationNode nodeData) {
@@ -242,7 +252,7 @@ public class TransmissionSimulator {
      * @param destinationArea destination area for transmission
      * @return a map containing the
      */
-    private Map<String, SimulationNode> getPotentialBroadcastReceivers(Area<CartesianPoint> destinationArea) {
+    private static Map<String, SimulationNode> getPotentialBroadcastReceivers(Area<CartesianPoint> destinationArea) {
         return getEntitiesInArea(SimulationEntities.INSTANCE.getAllOnlineNodes(), destinationArea);
     }
 
@@ -255,35 +265,14 @@ public class TransmissionSimulator {
      *                         It is called "range" because it reflects the communication range
      * @return A map of the given entities, which are in the destination area.
      */
-    public static Map<String, SimulationNode> getEntitiesInArea(
-            Map<String, SimulationNode> relevantEntities, Area<CartesianPoint> range) {
-        Map<String, SimulationNode> results = new HashMap<>();
-
-        for (Map.Entry<String, SimulationNode> entityEntry : relevantEntities.entrySet()) {
+    public static Map<String, SimulationNode> getEntitiesInArea(Map<String, SimulationNode> relevantEntities, Area<CartesianPoint> range) {
+        final Map<String, SimulationNode> results = new HashMap<>();
+        for (var entityEntry : relevantEntities.entrySet()) {
             if (range.contains(entityEntry.getValue().getPosition())) {
                 results.put(entityEntry.getKey(), entityEntry.getValue());
             }
         }
         return results;
-    }
-
-    /**
-     * Returns the addressed receiver, if it is known inside the destination area (more specific check compared to broadcast).
-     * Note: The resulting Map will always contain 0 or 1 elements.
-     *
-     * @param destinationAddress address of the potential receiver
-     * @param reachableArea      area, that can be reached with one hop by the sender
-     * @return if receiver was found single element map, else empty map
-     */
-    private Map<String, SimulationNode> getAddressedReceiver(NetworkAddress destinationAddress, Area<CartesianPoint> reachableArea) {
-        final Map<String, SimulationNode> receiver = new HashMap<>();
-
-        final String destinationNodeId = IpResolver.getSingleton().reverseLookup(destinationAddress.getIPv4Address());
-        SimulationNode entity = SimulationEntities.INSTANCE.getOnlineNode(destinationNodeId);
-        if (entity != null && isNodeInArea(entity.getPosition(), reachableArea)) {
-            receiver.put(destinationNodeId, entity);
-        }
-        return receiver;
     }
 
     private boolean isNodeInArea(CartesianPoint nodePosition, Area<CartesianPoint> destinationArea) {

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModel.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModel.java
@@ -50,7 +50,8 @@ public abstract class AdhocTransmissionModel {
     }
 
     /**
-     * Method to be implemented by extensions of {@link AdhocTransmissionModel}, calculating transmissions using topocast.
+     * Method to be implemented by extensions of {@link AdhocTransmissionModel}, calculating transmissions using topocast with
+     * only one single hop, either broadcast or unicast.
      *
      * @param senderName            The sender of the transmission.
      * @param receivers             The receivers of the transmission.
@@ -58,8 +59,24 @@ public abstract class AdhocTransmissionModel {
      * @param currentNodes          a reference to all currently online nodes
      * @return Map of the receivers and their transmission results.
      */
-    public abstract Map<String, TransmissionResult> simulateTopocast(
+    public abstract Map<String, TransmissionResult> simulateSinglehop(
             String senderName, Map<String, SimulationNode> receivers,
+            TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes
+    );
+
+    /**
+     * Method to be implemented by extensions of {@link AdhocTransmissionModel}, calculating transmissions using topocast
+     * with multiple hops, only unicast.
+     *
+     * @param senderName            The sender of the transmission.
+     * @param receiverName          The receivers of the unicast transmission.
+     * @param receiver              The receiver node information of the unicast transmission.
+     * @param transmissionParameter Data class holding the maximumTtl, the {@link Delay} and the current map of simulated entities
+     * @param currentNodes          a reference to all currently online nodes
+     * @return The transmission result to the single receiver.
+     */
+    public abstract TransmissionResult simulateTopologicalUnicast(
+            String senderName, String receiverName, SimulationNode receiver,
             TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes
     );
 

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModel.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModel.java
@@ -42,8 +42,9 @@ public abstract class AdhocTransmissionModel {
      * @return A {@link TransmissionResult} calculated using the given parameters
      */
     TransmissionResult simulateTransmission(RandomNumberGenerator randomNumberGenerator, Delay delay, CTransmission transmission) {
-        TransmissionResult result =
-                TransmissionModel.simulateTransmission(randomNumberGenerator, transmission.lossProbability, transmission.maxRetries);
+        TransmissionResult result = TransmissionModel.simulateTransmission(
+                randomNumberGenerator, transmission.lossProbability, transmission.maxRetries
+        );
         result.delay = delay.generateDelay(randomNumberGenerator, 0); // speed of node is only relevant for not-supported GammaSpeedDelay
         result.numberOfHops += 1;
         return result;
@@ -59,7 +60,7 @@ public abstract class AdhocTransmissionModel {
      * @param currentNodes          a reference to all currently online nodes
      * @return Map of the receivers and their transmission results.
      */
-    public abstract Map<String, TransmissionResult> simulateSinglehop(
+    public abstract Map<String, TransmissionResult> simulateTopologicalSinglehop(
             String senderName, Map<String, SimulationNode> receivers,
             TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes
     );

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/SimpleAdhocTransmissionModel.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/SimpleAdhocTransmissionModel.java
@@ -46,24 +46,42 @@ public class SimpleAdhocTransmissionModel extends AdhocTransmissionModel {
      */
     public CTransmission simpleMultihopTransmission = new CTransmission();
 
+
     /**
-     * Simulates a direct transmission between the sender and receivers. Note: If a single addressed receiver is used
-     * the 'receivers' map will only contain one entry as well as the results.
+     * Simulates a direct transmission between the sender and receivers.
      *
      * @param senderName            The sender of the transmission.
-     * @param receivers             The receivers of the transmission.
+     * @param receivers             The receivers of the unicast transmission.
      * @param transmissionParameter Data class holding the maximumTtl, the {@link Delay} and the current map of simulated entities
      * @param currentNodes          a reference to all currently online nodes
-     * @return Map of the receivers and their transmission results.
+     * @return The transmission result to the single receiver.
      */
     @Override
-    public Map<String, TransmissionResult> simulateTopocast(
+    public Map<String, TransmissionResult> simulateSinglehop(
             String senderName, Map<String, SimulationNode> receivers,
             TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes) {
         return calculateTransmissions(
                 transmissionParameter.randomNumberGenerator,
                 receivers, transmissionParameter.delay, transmissionParameter.transmission
         );
+    }
+
+    /**
+     * Simulates a multi-hop transmission between the sender and a single receiver. Uses the configured multi-hop delay as a simplification.
+     * No actual multi-hop is simulated (use {@link SophisticatedAdhocTransmissionModel} instead).
+     *
+     * @param senderName            The sender of the transmission.
+     * @param receiverName          The receiver name of the unicast transmission.
+     * @param receiver              The receiver node information of the unicast transmission.
+     * @param transmissionParameter Data class holding the maximumTtl, the {@link Delay} and the current map of simulated entities
+     * @param currentNodes          a reference to all currently online nodes
+     * @return The transmission result to the single receiver.
+     */
+    @Override
+    public TransmissionResult simulateTopologicalUnicast(
+            String senderName, String receiverName, SimulationNode receiver,
+            TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes) {
+        return simulateTransmission(transmissionParameter.randomNumberGenerator, simpleMultihopDelay, simpleMultihopTransmission);
     }
 
     /**

--- a/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/SimpleAdhocTransmissionModel.java
+++ b/fed/mosaic-sns/src/main/java/org/eclipse/mosaic/fed/sns/model/SimpleAdhocTransmissionModel.java
@@ -57,10 +57,10 @@ public class SimpleAdhocTransmissionModel extends AdhocTransmissionModel {
      * @return The transmission result to the single receiver.
      */
     @Override
-    public Map<String, TransmissionResult> simulateSinglehop(
+    public Map<String, TransmissionResult> simulateTopologicalSinglehop(
             String senderName, Map<String, SimulationNode> receivers,
             TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes) {
-        return calculateTransmissions(
+        return simulateMultipleTransmissions(
                 transmissionParameter.randomNumberGenerator,
                 receivers, transmissionParameter.delay, transmissionParameter.transmission
         );
@@ -81,7 +81,9 @@ public class SimpleAdhocTransmissionModel extends AdhocTransmissionModel {
     public TransmissionResult simulateTopologicalUnicast(
             String senderName, String receiverName, SimulationNode receiver,
             TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes) {
-        return simulateTransmission(transmissionParameter.randomNumberGenerator, simpleMultihopDelay, simpleMultihopTransmission);
+        return simulateTransmission(
+                transmissionParameter.randomNumberGenerator, simpleMultihopDelay, simpleMultihopTransmission
+        );
     }
 
     /**
@@ -98,14 +100,14 @@ public class SimpleAdhocTransmissionModel extends AdhocTransmissionModel {
     public Map<String, TransmissionResult> simulateGeocast(
             String senderName, Map<String, SimulationNode> receivers,
             TransmissionParameter transmissionParameter, Map<String, SimulationNode> currentNodes) {
-        return calculateTransmissions(
+        return simulateMultipleTransmissions(
                 transmissionParameter.randomNumberGenerator, receivers, simpleMultihopDelay, simpleMultihopTransmission
         );
     }
 
     /**
      * This is a helper method to avoid duplicated code, it takes transmission parameters from
-     * the {@link #simulateGeocast} and {@link #simulateTopocast} methods and calculates the
+     * the {@link #simulateGeocast} and {@link #simulateTopologicalSinglehop} methods and calculates the
      * {@link TransmissionResult}s for all receivers.
      *
      * @param rng       {@link RandomNumberGenerator} for the evaluation of delays and transmission success
@@ -113,7 +115,7 @@ public class SimpleAdhocTransmissionModel extends AdhocTransmissionModel {
      * @param delay     the delay specification from the configuration
      * @return a map containing the {@link TransmissionResult}s for all receivers
      */
-    private Map<String, TransmissionResult> calculateTransmissions(
+    private Map<String, TransmissionResult> simulateMultipleTransmissions(
             RandomNumberGenerator rng, Map<String, SimulationNode> receivers, Delay delay, CTransmission transmission) {
         Map<String, TransmissionResult> results = new HashMap<>();
         receivers.forEach((receiverName, receiver) -> results

--- a/fed/mosaic-sns/src/test/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModelTest.java
+++ b/fed/mosaic-sns/src/test/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModelTest.java
@@ -42,9 +42,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 public class AdhocTransmissionModelTest {
 
@@ -54,7 +52,6 @@ public class AdhocTransmissionModelTest {
     private final RandomNumberGenerator rng = new DefaultRandomNumberGenerator(82937858189209L);
 
     private final Map<String, SimulationNode> allNodes = new HashMap<>();
-    private final Set<String> nodesInRow = new HashSet<>();
     private final Map<String, SimulationNode> nodesRandomlyDistributed = new HashMap<>();
 
     @Rule
@@ -62,7 +59,6 @@ public class AdhocTransmissionModelTest {
 
     @Before
     public void setup() {
-
         simpleTransmissionModel = new SimpleAdhocTransmissionModel();
         ConstantDelay constantDelay = new ConstantDelay();
         constantDelay.delay = 1; // used to obtain single valued delays
@@ -81,7 +77,6 @@ public class AdhocTransmissionModelTest {
             when(newNode.getPosition()).thenReturn(GeoPoint.latLon(currentLatitude, currentLongitude).toCartesian());
             when(newNode.getRadius()).thenReturn(adhocRadius);
             allNodes.put("" + i, newNode);
-            nodesInRow.add("" + i);
         }
 
         double randomLatitude;
@@ -115,8 +110,9 @@ public class AdhocTransmissionModelTest {
 
         // RUN
         // use all entities as receivers
-        Map<String, TransmissionResult> directTransmissionResults =
-                simpleTransmissionModel.simulateTopocast("0", allNodes, transmissionParameter, allNodes);
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+                "0", allNodes, transmissionParameter, allNodes
+        );
 
         // ASSERT
         // unit without wifi capabilities can't receive transmission
@@ -133,16 +129,16 @@ public class AdhocTransmissionModelTest {
         CTransmission transmission = new CTransmission();
 
         // Note: ttl parameter doesn't matter for direct transmission, the SNS would log a warning if TTL is != 1
-        TransmissionParameter transmissionParameter = new TransmissionParameter(rng, simpleRandomDelay, transmission, 1
-        );
+        TransmissionParameter transmissionParameter = new TransmissionParameter(rng, simpleRandomDelay, transmission, 1);
 
         // RUN
         // increase range of sender
         when(allNodes.get("0").getRadius()).thenReturn(300d);
         // only use Receivers in range, this will be enforced by the transmission simulator
         Map<String, SimulationNode> receivers = getAllReceiversInRange("0");
-        Map<String, TransmissionResult> directTransmissionResults =
-                simpleTransmissionModel.simulateTopocast("0", receivers, transmissionParameter, allNodes);
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+                "0", receivers, transmissionParameter, allNodes
+        );
 
         // ASSERT
 
@@ -169,9 +165,9 @@ public class AdhocTransmissionModelTest {
 
         // RUN
         // use all randomly distributed nodes as receiver except sender
-        Map<String, TransmissionResult> floodingTransmissionResults =
-                sophisticatedTransmissionModel
-                        .simulateGeocast("30", getAllRandomlyDistributedEntitiesRemoveSender("30"), transmissionParameter, allNodes);
+        Map<String, TransmissionResult> floodingTransmissionResults = sophisticatedTransmissionModel.simulateGeocast(
+                "30", getAllRandomlyDistributedEntitiesRemoveSender("30"), transmissionParameter, allNodes
+        );
 
         // ASSERT
         // there should be results for every anticipated receiver
@@ -207,9 +203,9 @@ public class AdhocTransmissionModelTest {
         // RUN
 
         // use all randomly distributed nodes as receiver
-        Map<String, TransmissionResult> floodingTransmissionResults =
-                sophisticatedTransmissionModel
-                        .simulateGeocast("30", getAllRandomlyDistributedEntitiesRemoveSender("30"), transmissionParameter, allNodes);
+        Map<String, TransmissionResult> floodingTransmissionResults = sophisticatedTransmissionModel.simulateGeocast(
+                "30", getAllRandomlyDistributedEntitiesRemoveSender("30"), transmissionParameter, allNodes
+        );
 
         // ASSERT
         // there should be results for every anticipated receiver
@@ -243,10 +239,7 @@ public class AdhocTransmissionModelTest {
         // RUN
         // use all randomly distributed nodes as receiver
         Map<String, TransmissionResult> floodingTransmissionResults = sophisticatedTransmissionModel.simulateGeocast(
-                "30",
-                getAllRandomlyDistributedEntitiesRemoveSender("30"),
-                transmissionParameter,
-                allNodes
+                "30", getAllRandomlyDistributedEntitiesRemoveSender("30"), transmissionParameter, allNodes
         );
 
         // ASSERT
@@ -277,8 +270,9 @@ public class AdhocTransmissionModelTest {
 
         // RUN
         try {
-            sophisticatedTransmissionModel
-                    .simulateGeocast("0", getAllRandomlyDistributedEntitiesRemoveSender("0"), transmissionParameter, allNodes);
+            sophisticatedTransmissionModel.simulateGeocast(
+                    "0", getAllRandomlyDistributedEntitiesRemoveSender("0"), transmissionParameter, allNodes
+            );
         } catch (RuntimeException e) {
             assertEquals("Sender has to be in destination area to use flooding as transmission model.", e.getMessage());
         }
@@ -296,10 +290,7 @@ public class AdhocTransmissionModelTest {
         // RUN
         // use randomly distributed entities as receivers
         Map<String, TransmissionResult> transmissionResult = sophisticatedTransmissionModel.simulateGeocast(
-                "0",
-                getAllRandomlyDistributedEntitiesRemoveSender("0"),
-                transmissionParameter,
-                allNodes
+                "0", getAllRandomlyDistributedEntitiesRemoveSender("0"), transmissionParameter, allNodes
         );
         // ASSERT
         assertNotNull(transmissionResult);
@@ -324,8 +315,9 @@ public class AdhocTransmissionModelTest {
 
         // RUN
         // use all entities as receivers
-        Map<String, TransmissionResult> directTransmissionResults =
-                simpleTransmissionModel.simulateTopocast("0", allNodes, transmissionParameter, allNodes);
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+                "0", allNodes, transmissionParameter, allNodes
+        );
 
         // ASSERT
         // for the entity without wifi module there won't be any transmission attempts
@@ -337,18 +329,63 @@ public class AdhocTransmissionModelTest {
     }
 
     @Test
-    public void simulateTopocast_addressingSingleReceiver() {
+    public void simulateSingleHopUnicast_success() {
         // SETUP
         TransmissionParameter transmissionParameter = generateTransmissionParameter_NoLoss(1);
         Map<String, SimulationNode> receiver = new HashMap<>();
         receiver.put("1", allNodes.get("1"));
 
         // RUN
-        Map<String, TransmissionResult> directTransmissionResults =
-                simpleTransmissionModel.simulateTopocast("0", receiver, transmissionParameter, allNodes);
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+                "0", receiver, transmissionParameter, allNodes
+        );
 
         // ASSERT
         assertTrue(directTransmissionResults.get("1").success);
+    }
+
+    @Test
+    public void simulateMultiHopTopoUnicast_success() {
+        // SETUP
+        TransmissionParameter transmissionParameter = generateTransmissionParameter_NoLoss(10);
+
+        // RUN
+        TransmissionResult transmissionResult = sophisticatedTransmissionModel.simulateTopologicalUnicast(
+                "0", "5", allNodes.get("5"), transmissionParameter, allNodes
+        );
+
+        // ASSERT
+        assertTrue(transmissionResult.success);
+        assertEquals(5, transmissionResult.numberOfHops);
+    }
+
+    @Test
+    public void simulateMultiHopTopoUnicast_tooManyHopsRequired() {
+        // SETUP
+        TransmissionParameter transmissionParameter = generateTransmissionParameter_NoLoss(4); // max 4 hops, but target is 5 hops away
+
+        // RUN
+        TransmissionResult transmissionResult = sophisticatedTransmissionModel.simulateTopologicalUnicast(
+                "0", "5", allNodes.get("5"), transmissionParameter, allNodes
+        );
+
+        // ASSERT
+        assertFalse(transmissionResult.success);
+    }
+
+    @Test
+    public void simulateGeoUnicast_success() {
+        // SETUP
+        TransmissionParameter transmissionParameter = generateTransmissionParameter_NoLoss(10);
+
+        // RUN
+        Map<String, TransmissionResult> transmissionResult = sophisticatedTransmissionModel.simulateGeocast(
+                "0", Map.of("5", allNodes.get("5")), transmissionParameter, allNodes
+        );
+
+        // ASSERT
+        assertTrue(transmissionResult.get("5").success);
+        assertEquals(5, transmissionResult.get("5").numberOfHops);
     }
 
     @Test
@@ -359,10 +396,7 @@ public class AdhocTransmissionModelTest {
         // RUN
         // use all randomly distributed nodes as receiver
         Map<String, TransmissionResult> floodingTransmissionResults = sophisticatedTransmissionModel.simulateGeocast(
-                "30",
-                getAllRandomlyDistributedEntitiesRemoveSender("30"),
-                transmissionParameter,
-                allNodes
+                "30", getAllRandomlyDistributedEntitiesRemoveSender("30"), transmissionParameter, allNodes
         );
 
         // ASSERT
@@ -407,8 +441,7 @@ public class AdhocTransmissionModelTest {
         receiver.put("1", allNodes.get("1"));
         int totalAttempts = 0;
         for (int i = 0; i < iterations; i++) {
-            tr = simpleTransmissionModel
-                    .simulateTopocast("0", receiver, transmissionParameter, allNodes).entrySet().iterator().next().getValue();
+            tr = simpleTransmissionModel.simulateSinglehop("0", receiver, transmissionParameter, allNodes).entrySet().iterator().next().getValue();
             totalAttempts += tr.attempts;
 
             assertTrue(tr.success);

--- a/fed/mosaic-sns/src/test/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModelTest.java
+++ b/fed/mosaic-sns/src/test/java/org/eclipse/mosaic/fed/sns/model/AdhocTransmissionModelTest.java
@@ -110,7 +110,7 @@ public class AdhocTransmissionModelTest {
 
         // RUN
         // use all entities as receivers
-        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateTopologicalSinglehop(
                 "0", allNodes, transmissionParameter, allNodes
         );
 
@@ -136,7 +136,7 @@ public class AdhocTransmissionModelTest {
         when(allNodes.get("0").getRadius()).thenReturn(300d);
         // only use Receivers in range, this will be enforced by the transmission simulator
         Map<String, SimulationNode> receivers = getAllReceiversInRange("0");
-        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateTopologicalSinglehop(
                 "0", receivers, transmissionParameter, allNodes
         );
 
@@ -315,7 +315,7 @@ public class AdhocTransmissionModelTest {
 
         // RUN
         // use all entities as receivers
-        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateTopologicalSinglehop(
                 "0", allNodes, transmissionParameter, allNodes
         );
 
@@ -336,7 +336,7 @@ public class AdhocTransmissionModelTest {
         receiver.put("1", allNodes.get("1"));
 
         // RUN
-        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateSinglehop(
+        Map<String, TransmissionResult> directTransmissionResults = simpleTransmissionModel.simulateTopologicalSinglehop(
                 "0", receiver, transmissionParameter, allNodes
         );
 
@@ -441,7 +441,7 @@ public class AdhocTransmissionModelTest {
         receiver.put("1", allNodes.get("1"));
         int totalAttempts = 0;
         for (int i = 0; i < iterations; i++) {
-            tr = simpleTransmissionModel.simulateSinglehop("0", receiver, transmissionParameter, allNodes).entrySet().iterator().next().getValue();
+            tr = simpleTransmissionModel.simulateTopologicalSinglehop("0", receiver, transmissionParameter, allNodes).entrySet().iterator().next().getValue();
             totalAttempts += tr.attempts;
 
             assertTrue(tr.success);


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

SNS covers already various addressing/routing modes. With this MR, multihop unicast for both topoligic or geographic routing are added by re-using existing methods. Multi-hop Broadcast is still missing.

|Addressing|Routing|Support|
|--|--|--|
|Unicast|Topologic|✅Singlehop<br>✅**Multihop (new)**|
|Broadcast|Topologic|✅Singlehop<br>❌Multihop|
||||
|Unicast|Geographic|✅**Singlehop (new)**<br>✅**Multihop (new)**|
|Broadcast|Geographic|✅Singlehop<br>✅Multihop|

The `SimpleAdHocTransmissionModel` does not really count hops between single vehicles, but instead uses a configured multi-hop delay which is applied as soon as more than hop is required.

The `SophisticatedAdHocTransmissionModel` uses existing method `forward` (which was initially used by the Geographic routing) to send the message to a specific vehicle in the unicast mode via multiple hops. 

The geographic unicast was implemented by simply reducing the list of potential receivers in the target geo area to the one destination vehicle. 

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 918
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

Kind of, we should add supported features (such as the table above) to our website documentation.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [ ] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

