### PR TITLE
feat: refactored CellMessageRoutingBuilder

### DIFF
--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherServerApp.java
@@ -22,9 +22,7 @@ import org.eclipse.mosaic.fed.application.app.AbstractApplication;
 import org.eclipse.mosaic.fed.application.app.api.CommunicationApplication;
 import org.eclipse.mosaic.fed.application.app.api.os.ServerOperatingSystem;
 import org.eclipse.mosaic.interactions.communication.V2xMessageTransmission;
-import org.eclipse.mosaic.lib.enums.SensorType;
 import org.eclipse.mosaic.lib.geo.GeoCircle;
-import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
 import org.eclipse.mosaic.lib.objects.v2x.V2xMessage;
 import org.eclipse.mosaic.lib.objects.v2x.etsi.Denm;
@@ -110,7 +108,7 @@ public class WeatherServerApp extends AbstractApplication<ServerOperatingSystem>
      */
     private Denm constructDenm() {
         final GeoCircle geoCircle = new GeoCircle(lastReceivedMessage.getEventLocation(), 3000.0D);
-        final MessageRouting routing = getOs().getCellModule().createMessageRouting().geoBroadcastBasedOnUnicast(geoCircle);
+        final MessageRouting routing = getOs().getCellModule().createMessageRouting().broadcast().geographical(geoCircle).build();
         return new Denm(routing,
                 new DenmContent(
                         lastReceivedMessage.getTime(),

--- a/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherWarningApp.java
+++ b/app/tutorials/weather-warning/src/main/java/org/eclipse/mosaic/app/tutorial/WeatherWarningApp.java
@@ -206,7 +206,7 @@ public class WeatherWarningApp extends AbstractApplication<VehicleOperatingSyste
          * with a builder and build a geoBroadCast for the circle area defined in dest.
          */
         if (useCellNetwork()) {
-            mr = getOs().getCellModule().createMessageRouting().topoCast("server_0");
+            mr = getOs().getCellModule().createMessageRouting().destination("server_0").topological().build();
         } else {
             mr = getOs().getAdHocModule().createMessageRouting().broadcast().geographical(dest).build();
         }

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/CellModule.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/communication/CellModule.java
@@ -126,7 +126,7 @@ public class CellModule extends AbstractCommunicationModule<CellModuleConfigurat
     }
 
     private Integer sendCamViaTopocast(CellModuleConfiguration.CellCamConfiguration camConfiguration) {
-        return super.sendCam(createMessageRouting().topoCast(camConfiguration.getTopocastReceiver()));
+        return super.sendCam(createMessageRouting().destination(camConfiguration.getTopocastReceiver()).topological().build());
     }
 
     private Integer sendCamViaGeoBroadcast(CellModuleConfiguration.CellCamConfiguration camConfiguration) {
@@ -134,7 +134,7 @@ public class CellModule extends AbstractCommunicationModule<CellModuleConfigurat
             throw new UnsupportedOperationException("Cannot send CAM for entities without a location.");
         }
         final GeoCircle destination = new GeoCircle(locatable.getPosition(), camConfiguration.getGeoRadius());
-        return super.sendCam(createMessageRouting().geoBroadcastBasedOnUnicast(destination));
+        return super.sendCam(createMessageRouting().broadcast().geographical(destination).build());
     }
 
     private Integer sendCamViaGeoBroadcastMbms(CellModuleConfiguration.CellCamConfiguration camConfiguration) {
@@ -142,7 +142,7 @@ public class CellModule extends AbstractCommunicationModule<CellModuleConfigurat
             throw new UnsupportedOperationException("Cannot send CAM for entities without a location.");
         }
         final GeoCircle destination = new GeoCircle(locatable.getPosition(), camConfiguration.getGeoRadius());
-        return super.sendCam(createMessageRouting().geoBroadcastMbms(destination));
+        return super.sendCam(createMessageRouting().broadcast().geographical(destination).mbs().build());
     }
 
     /**

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/chain/ChainManagerTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/chain/ChainManagerTest.java
@@ -112,7 +112,10 @@ public class ChainManagerTest {
     @Test
     public void testStartEvent_cellRouting() {
         //SETUP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
 
         V2xMessageTransmission sendV2xMsg = new V2xMessageTransmission(12 * TIME.SECOND, v2XMessage);
 
@@ -127,7 +130,7 @@ public class ChainManagerTest {
     @Test
     public void testStartEvent_adhocRouting() {
         //SETUP
-        routing.set(new AdHocMessageRoutingBuilder("veh_0", null).singlehop().broadcast().topological().build());
+        routing.set(new AdHocMessageRoutingBuilder("veh_0", null).broadcast().topological().build());
 
         V2xMessageTransmission sendV2xMsg = new V2xMessageTransmission(12 * TIME.SECOND, v2XMessage);
 

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleStreamingTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleStreamingTest.java
@@ -172,8 +172,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
@@ -211,8 +210,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
@@ -252,7 +250,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
@@ -289,8 +287,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
@@ -353,9 +350,8 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        ))
-        ;
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
+        );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
@@ -381,8 +377,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -411,8 +406,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -441,8 +435,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -485,8 +478,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -513,7 +505,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -551,8 +543,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -589,8 +580,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -622,8 +612,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -657,8 +646,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -689,8 +677,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -724,8 +711,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         String receiverName = "veh_0";
@@ -756,8 +742,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
         String receiverName = "veh_0";
@@ -782,8 +767,7 @@ public class DownstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
         Event event = createEvent("rsu_4", sampleV2XMessage);
@@ -809,8 +793,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         Event event = createEvent("rsu_4", sampleV2XMessage);
@@ -835,8 +818,7 @@ public class DownstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EVENT_BANDWIDTH)
-                        .topoCast(new byte[]{1, 2, 3, 4}
-                        )
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
         StreamResult streamResult =

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/DownstreamModuleTest.java
@@ -162,7 +162,10 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageMulticast() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
         String[] receivers = {"veh_0", "veh_1", "veh_2"};
@@ -199,7 +202,10 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageMulticast_NodeLimited() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
         String[] receivers = {"veh_0", "veh_1", "veh_2"};
@@ -236,7 +242,10 @@ public class DownstreamModuleTest {
         ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 1120 * DATA.BIT;
         ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 1120 * DATA.BIT;
 
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
         String[] receivers = {"veh_0", "veh_1", "veh_2"};
@@ -277,7 +286,10 @@ public class DownstreamModuleTest {
         ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = 1120 * DATA.BIT;
         ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.maxCapacity = 1120 * DATA.BIT;
 
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         final Multimap<CNetworkProperties, String> receiverMap = ArrayListMultimap.create();
         String[] receivers = {"veh_0", "veh_1", "veh_2"};
@@ -335,7 +347,10 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageNodeLimited() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
@@ -362,7 +377,10 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageNodeLimitedRegionLessLimited() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
@@ -391,7 +409,10 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageNodeLimitedRegionMoreLimited() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
@@ -423,7 +444,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         String receiverName = "veh_0";
@@ -452,7 +473,7 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageNodeUnlimited_plusFreeBandwidth() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).destination(new byte[]{1, 2, 3, 4}).topological().build());
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
         String receiverName = "veh_0";
@@ -501,7 +522,10 @@ public class DownstreamModuleTest {
     public void testProcessMessage_regularMessageNodeUnlimitedRegionLimited() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
         String receiverName = "veh_0";
@@ -538,7 +562,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
@@ -576,7 +600,7 @@ public class DownstreamModuleTest {
     public void testProcessMessage_packetLossUdp() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).destination(new byte[]{1, 2, 3, 4}).topological().build());
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
         String receiverName = "veh_0";
@@ -612,7 +636,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
@@ -644,7 +668,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         String receiverName = "veh_0";
@@ -677,7 +701,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         String receiverName = "veh_0";
@@ -707,7 +731,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         String receiverName = "veh_0";
@@ -741,7 +765,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         String receiverName = "veh_0";
@@ -769,7 +793,7 @@ public class DownstreamModuleTest {
     public void testProcessMessage_nodeDeactivatedUdp() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).destination(new byte[]{1, 2, 3, 4}).topological().build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         String receiverName = "veh_0";
         Event event = createEvent(receiverName, sampleV2XMessage);
@@ -792,7 +816,7 @@ public class DownstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{1, 2, 3, 4})
+                        .destination(new byte[]{1, 2, 3, 4}).topological().build()
         );
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         Event event = createEvent("rsu_4", sampleV2XMessage);
@@ -815,7 +839,7 @@ public class DownstreamModuleTest {
     public void testProcessMessage_nodeNotRegisteredUdp() throws Exception {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).destination(new byte[]{1, 2, 3, 4}).topological().build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         Event event = createEvent("rsu_4", sampleV2XMessage);
 
@@ -835,7 +859,7 @@ public class DownstreamModuleTest {
         NodeCapacityUtility.consumeCapacityDown(cellConfiguration, 200 * DATA.BIT);
         SimulationData.INSTANCE.setCellConfigurationOfNode(receiverName, cellConfiguration);
         ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.downlink.capacity = (42000 - 200) * DATA.BIT;
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).destination(new byte[]{1, 2, 3, 4}).topological().build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         StreamResult streamResult =
                 new StreamResult(GLOBAL_NETWORK_ID, 200 * DATA.BIT, TransmissionMode.DownlinkUnicast, receiverName, sampleV2XMessage);

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/GeocasterModuleTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/GeocasterModuleTest.java
@@ -19,8 +19,6 @@ import static org.eclipse.mosaic.fed.cell.config.model.CNetworkProperties.GLOBAL
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.when;
 
 import org.eclipse.mosaic.fed.cell.chain.ChainManager;
 import org.eclipse.mosaic.fed.cell.chain.SampleV2xMessage;
@@ -34,7 +32,6 @@ import org.eclipse.mosaic.fed.cell.message.CellModuleMessage;
 import org.eclipse.mosaic.fed.cell.message.GeocasterResult;
 import org.eclipse.mosaic.fed.cell.message.StreamResult;
 import org.eclipse.mosaic.fed.cell.utility.RegionUtility;
-import org.eclipse.mosaic.lib.enums.ProtocolType;
 import org.eclipse.mosaic.lib.geo.GeoPoint;
 import org.eclipse.mosaic.lib.geo.GeoRectangle;
 import org.eclipse.mosaic.lib.geo.UtmPoint;
@@ -44,18 +41,12 @@ import org.eclipse.mosaic.lib.junit.IpResolverRule;
 import org.eclipse.mosaic.lib.math.DefaultRandomNumberGenerator;
 import org.eclipse.mosaic.lib.math.RandomNumberGenerator;
 import org.eclipse.mosaic.lib.objects.addressing.CellMessageRoutingBuilder;
-import org.eclipse.mosaic.lib.objects.addressing.DestinationAddressContainer;
 import org.eclipse.mosaic.lib.objects.addressing.IpResolver;
-import org.eclipse.mosaic.lib.objects.addressing.SourceAddressContainer;
 import org.eclipse.mosaic.lib.objects.communication.CellConfiguration;
 import org.eclipse.mosaic.lib.objects.v2x.MessageRouting;
-import org.eclipse.mosaic.lib.objects.v2x.V2xMessage;
 import org.eclipse.mosaic.lib.util.scheduling.Event;
 import org.eclipse.mosaic.rti.DATA;
 import org.eclipse.mosaic.rti.TIME;
-import org.eclipse.mosaic.rti.api.IllegalValueException;
-import org.eclipse.mosaic.rti.api.Interaction;
-import org.eclipse.mosaic.rti.api.InternalFederateException;
 import org.eclipse.mosaic.rti.api.RtiAmbassador;
 import org.eclipse.mosaic.rti.api.parameters.AmbassadorParameter;
 
@@ -65,7 +56,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -141,7 +131,10 @@ public class GeocasterModuleTest {
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_2", cellModuleConfiguration);
         IpResolver.getSingleton().registerHost("veh_2");
 
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 0, 0, 2}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 0, 0, 2})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         StreamResult streamResult =
                 new StreamResult(GLOBAL_NETWORK_ID, 200 * DATA.BIT, TransmissionMode.UplinkUnicast, "rsu_0", sampleV2XMessage);
@@ -175,7 +168,7 @@ public class GeocasterModuleTest {
         GeoPoint nw = GeoPoint.lonLat(13.333625793457031, 52.51563064800963);
         GeoPoint se = GeoPoint.lonLat(13.421859741210938, 52.5053554452214);
         GeoRectangle geoRectangle = new GeoRectangle(nw, se);
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).geoBroadcastBasedOnUnicast(geoRectangle));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).broadcast().geographical(geoRectangle).build());
         GeoPoint inRectangleKreuzberg = GeoPoint.lonLat(13.404693603515625, 52.50838549553871);
         GeoPoint inRectangleGrosserStern = GeoPoint.lonLat(13.349933624267578, 52.51388868388495);
         GeoPoint offRectangleKreuzberg = GeoPoint.lonLat(13.404006958007812, 52.498111211481216);
@@ -230,7 +223,7 @@ public class GeocasterModuleTest {
         GeoPoint nw = GeoPoint.lonLat(13.333625793457031, 52.51563064800963);
         GeoPoint se = GeoPoint.lonLat(13.421859741210938, 52.5053554452214);
         GeoRectangle geoRectangle = new GeoRectangle(nw, se);
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).geoBroadcastMbms(geoRectangle));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null).broadcast().mbs().geographical(geoRectangle).build());
         GeoPoint inRectangleKreuzberg = GeoPoint.lonLat(13.404693603515625, 52.50838549553871);
         GeoPoint inRectangleGrosserStern = GeoPoint.lonLat(13.349933624267578, 52.51388868388495);
         GeoPoint offRectangleKreuzberg = GeoPoint.lonLat(13.404006958007812, 52.498111211481216);

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleStreamingTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleStreamingTest.java
@@ -168,7 +168,7 @@ public class UpstreamModuleStreamingTest {
         // UDP
         routing.set(new CellMessageRoutingBuilder("veh_0", null)
                 .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                .topoCast(new byte[]{10, 2, 0, 0})
+                .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -193,7 +193,7 @@ public class UpstreamModuleStreamingTest {
         // UDP
         routing.set(new CellMessageRoutingBuilder("veh_0", null)
                 .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                .topoCast(new byte[]{10, 2, 0, 0})
+                .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 400L, 400L);
@@ -220,7 +220,7 @@ public class UpstreamModuleStreamingTest {
         // UDP
         routing.set(new CellMessageRoutingBuilder("veh_0", null)
                 .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                .topoCast(new byte[]{10, 2, 0, 0})
+                .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 400L, 400L);
@@ -252,7 +252,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 10)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         int smallerStreamSize = 10;
@@ -287,7 +287,8 @@ public class UpstreamModuleStreamingTest {
         // SETUP
         // UDP
         MessageRouting messageRouting = new CellMessageRoutingBuilder("veh_0", null)
-                .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH).topoCast(new byte[]{10, 2, 0, 0});
+                .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
+                .destination(new byte[]{10, 2, 0, 0}).topological().build();
         routing.set(messageRouting);
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -331,7 +332,7 @@ public class UpstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -362,7 +363,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 1000)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -395,7 +396,7 @@ public class UpstreamModuleStreamingTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), MESSAGE_SIZE);
@@ -430,7 +431,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 10)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
@@ -461,7 +462,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 10)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         CellConfiguration cellConfiguration = SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0");
@@ -494,7 +495,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 10)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
@@ -524,7 +525,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 10)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
@@ -558,7 +559,7 @@ public class UpstreamModuleStreamingTest {
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
                         .streaming(EVENT_DURATION, 10)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
@@ -588,7 +589,7 @@ public class UpstreamModuleStreamingTest {
         // UDP
         routing.set(new CellMessageRoutingBuilder("veh_0", null)
                 .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                .topoCast(new byte[]{10, 2, 0, 0})
+                .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);
@@ -643,7 +644,7 @@ public class UpstreamModuleStreamingTest {
         IpResolver.getSingleton().registerHost("veh_1");
         routing.set(new CellMessageRoutingBuilder("veh_1", null)
                 .streaming(EVENT_DURATION, EXPECTED_BANDWIDTH)
-                .topoCast(new byte[]{10, 2, 0, 0})
+                .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5);

--- a/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleTest.java
+++ b/fed/mosaic-cell/src/test/java/org/eclipse/mosaic/fed/cell/module/UpstreamModuleTest.java
@@ -163,7 +163,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_regularMessageNodeLimited() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
         Event event = new Event(10 * TIME.SECOND, upstreamModule, sampleV2XMessage);
@@ -190,7 +193,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_regularMessageNodeLimitedRegionLessLimited() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 2240 * DATA.BIT, 2240 * DATA.BIT);
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
@@ -220,7 +226,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_regularMessageNodeLimitedRegionMoreLimited() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         CellConfiguration cellConfiguration = new CellConfiguration("veh_0", true, 2240 * DATA.BIT, 2240 * DATA.BIT);
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
@@ -253,7 +262,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 10 * DATA.BYTE);
@@ -282,7 +291,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_regularMessageNodeUnlimited_plusFreeBandwidth() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
@@ -326,7 +338,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_regularMessageNodeUnlimitedRegionLimited() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
@@ -366,7 +381,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         long messageLength = 10 * DATA.BYTE;
@@ -404,7 +419,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_packetLossUdp() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         long messageLength = 10 * DATA.BYTE;
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), messageLength);
@@ -441,7 +459,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
@@ -471,7 +489,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         CellConfiguration cellConfiguration = SimulationData.INSTANCE.getCellConfigurationOfNode("veh_0");
@@ -504,7 +522,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
@@ -533,7 +551,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
@@ -566,7 +584,7 @@ public class UpstreamModuleTest {
         routing.set(
                 new CellMessageRoutingBuilder("veh_0", null)
                         .protocol(ProtocolType.TCP)
-                        .topoCast(new byte[]{10, 2, 0, 0})
+                        .destination(new byte[]{10, 2, 0, 0}).topological().build()
         );
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
@@ -594,7 +612,10 @@ public class UpstreamModuleTest {
     public void testProcessMessage_nodeDeactivatedUdp() throws InternalFederateException {
         // SETUP
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         Event event = new Event(10 * TIME.NANO_SECOND, upstreamModule, sampleV2XMessage);
@@ -647,7 +668,10 @@ public class UpstreamModuleTest {
         // SETUP
         IpResolver.getSingleton().registerHost("veh_1");
         // UDP
-        routing.set(new CellMessageRoutingBuilder("veh_1", null).topoCast(new byte[]{10, 2, 0, 0}));
+        routing.set(new CellMessageRoutingBuilder("veh_1", null)
+                .destination(new byte[]{10, 2, 0, 0})
+                .topological()
+                .build());
 
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         Event event = new Event(10 * TIME.NANO_SECOND, upstreamModule, sampleV2XMessage);
@@ -668,7 +692,10 @@ public class UpstreamModuleTest {
         SimulationData.INSTANCE.setCellConfigurationOfNode("veh_0", cellConfiguration);
         ConfigurationData.INSTANCE.getNetworkConfig().globalNetwork.uplink.capacity = (21000 - 200) * DATA.BIT;
 
-        routing.set(new CellMessageRoutingBuilder("veh_0", null).topoCast(new byte[]{1, 2, 3, 4}));
+        routing.set(new CellMessageRoutingBuilder("veh_0", null)
+                .destination(new byte[]{1, 2, 3, 4})
+                .topological()
+                .build());
         SampleV2xMessage sampleV2XMessage = new SampleV2xMessage(routing.get(), 5 * DATA.BYTE);
         StreamResult streamResult = new StreamResult(
                 GLOBAL_NETWORK_ID,

--- a/lib/mosaic-objects/src/test/java/org/eclipse/mosaic/lib/objects/v2x/CellMessageRoutingBuilderTest.java
+++ b/lib/mosaic-objects/src/test/java/org/eclipse/mosaic/lib/objects/v2x/CellMessageRoutingBuilderTest.java
@@ -52,7 +52,7 @@ public class CellMessageRoutingBuilderTest {
     @Test
     public void geoBroadcastCircle() {
         // run
-        MessageRouting routing = builder.geoBroadcastBasedOnUnicast(geoCircle);
+        MessageRouting routing = builder.broadcast().geographical(geoCircle).build();
 
         // assert
         assertEquals(DestinationType.CELL_GEOCAST, routing.getDestination().getType());
@@ -64,7 +64,7 @@ public class CellMessageRoutingBuilderTest {
     @Test
     public void geoBroadcastRectangle() {
         // run
-        MessageRouting routing = builder.geoBroadcastBasedOnUnicast(geoRectangle);
+        MessageRouting routing = builder.broadcast().geographical(geoRectangle).build();
 
         // assert
         assertEquals(DestinationType.CELL_GEOCAST, routing.getDestination().getType());
@@ -74,9 +74,9 @@ public class CellMessageRoutingBuilderTest {
     }
 
     @Test
-    public void geoBroadcastMbmsCircle() {
+    public void geoBroadcastMbsCircle() {
         // run
-        MessageRouting routing = builder.geoBroadcastMbms(geoCircle);
+        MessageRouting routing = builder.broadcast().mbs().geographical(geoCircle).build();
 
         // assert
         assertEquals(DestinationType.CELL_GEOCAST_MBMS, routing.getDestination().getType());
@@ -86,9 +86,9 @@ public class CellMessageRoutingBuilderTest {
     }
 
     @Test
-    public void geoBroadcastMbmsRectangle() {
+    public void geoBroadcastMbsRectangle() {
         // run
-        MessageRouting routing = builder.geoBroadcastMbms(geoRectangle);
+        MessageRouting routing = builder.broadcast().mbs().geographical(geoRectangle).build();
 
         // assert
         assertEquals(DestinationType.CELL_GEOCAST_MBMS, routing.getDestination().getType());
@@ -100,7 +100,7 @@ public class CellMessageRoutingBuilderTest {
     @Test
     public void topocast() {
         // run
-        MessageRouting routing = builder.topoCast(ipAddress);
+        MessageRouting routing = builder.destination(ipAddress).topological().build();
 
         // assert
         assertEquals(DestinationType.CELL_TOPOCAST, routing.getDestination().getType());

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendandreceive/NackReceivingServer.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendandreceive/NackReceivingServer.java
@@ -65,7 +65,11 @@ public class NackReceivingServer extends AbstractApplication<ServerOperatingSyst
     @Override
     public void processEvent(Event event) {
         if (event instanceof SendSimpleMessage sendSimpleMessage) {
-            MessageRouting routing = getOs().getCellModule().createMessageRouting().tcp().topoCast(sendSimpleMessage.receiver);
+            MessageRouting routing = getOs().getCellModule().createMessageRouting()
+                    .tcp()
+                    .destination(sendSimpleMessage.receiver)
+                    .topological()
+                    .build();
             getOs().getCellModule().sendV2xMessage(new GenericV2xMessage(routing, 8));
             getLog().infoSimTime(this, "Message sent at time {}", getOs().getSimulationTime());
         }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendandreceive/ReceiveAndReturnRoundTripMessage.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendandreceive/ReceiveAndReturnRoundTripMessage.java
@@ -55,7 +55,11 @@ public class ReceiveAndReturnRoundTripMessage extends AbstractApplication<Vehicl
                     receivedV2xMessage.getMessage().getRouting().getDestination().getProtocolType()
             );
             String roundtripReceiver = receivedV2xMessage.getMessage().getRouting().getSource().getSourceName();
-            MessageRouting routing = getOs().getCellModule().createMessageRouting().tcp().topoCast(roundtripReceiver);
+            MessageRouting routing = getOs().getCellModule().createMessageRouting()
+                    .tcp()
+                    .destination(roundtripReceiver)
+                    .topological()
+                    .build();
             getOs().getCellModule().sendV2xMessage(new GenericV2xMessage(routing, 8));
             getLog().infoSimTime(this, "Send V2xMessage to {} at time {}", roundtripReceiver, getOs().getSimulationTime());
         }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendandreceive/SendAndReceiveRoundTripMessage.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendandreceive/SendAndReceiveRoundTripMessage.java
@@ -101,7 +101,11 @@ public class SendAndReceiveRoundTripMessage extends AbstractApplication<ServerOp
     @Override
     public void processEvent(Event event) {
         if (event instanceof SendRoundTripMessageEvent) {
-            MessageRouting routing = getOs().getCellModule().createMessageRouting().tcp().topoCast(receiver);
+            MessageRouting routing = getOs().getCellModule().createMessageRouting()
+                    .tcp()
+                    .destination(receiver)
+                    .topological()
+                    .build();
             getOs().getCellModule().sendV2xMessage(new GenericV2xMessage(routing, 8));
             getLog().infoSimTime(this, "Message sent at time {}", getOs().getSimulationTime());
         }

--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendonshutdown/SendOnShutdownApp.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/app/sendonshutdown/SendOnShutdownApp.java
@@ -34,7 +34,7 @@ public class SendOnShutdownApp extends AbstractApplication<VehicleOperatingSyste
     @Override
     public void onShutdown() {
         getOs().getCellModule().sendV2xMessage(new ShutdownMessage(
-                getOs().getCellModule().createMessageRouting().topoCast("server_0")
+                getOs().getCellModule().createMessageRouting().destination("server_0").topological().build()
         ));
 
         getOs().getAdHocModule().sendV2xMessage(new ShutdownMessage(


### PR DESCRIPTION
## Description

- Refactored `CellMessageRoutingBuilder` to new standards
- Every configurable aspect now has a seperate method in the builder
  - streaming(long streamDuration, long streamBandwidthInBitPs)
  - protocol(ProtocolType type)
    - tcp()
    - udp()
  - destination(NetworkAddress networkAddress)
    - destination(String receiverName)
    - destination(byte[] ipv4Address)
    - broadcast()
  - mbs()
  - topological()
  - geographical(GeoArea area)

What is this PR about?

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves part of internal issue 917
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->
- Changes in the communication documentation on the website are required
- Addressed in internal issue 911

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [ ] You have read CONTRIBUTING.md carefully.
- [ ] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [ ] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [ ] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [ ] `origin/main` has been merged into your Fork.
- [ ] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

