### PR TITLE
feat(bundle): build path to java binary with JAVA_HOME if set

### DIFF
--- a/bundle/src/assembly/resources/bin/mosaic.bat
+++ b/bundle/src/assembly/resources/bin/mosaic.bat
@@ -7,6 +7,7 @@ set javaMemorySizeXmx=2G
 REM uncomment to activate remote debugging
 REM set javaRemoteDebugging=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000
 
+REM check if JAVA_HOME is set and define path to java binary accordingly (variable: java_bin)
 if "%JAVA_HOME%"=="" (
   set java_bin=java
 ) else (

--- a/bundle/src/assembly/resources/bin/mosaic.bat
+++ b/bundle/src/assembly/resources/bin/mosaic.bat
@@ -32,7 +32,7 @@ if not "!libs!" == "" set libs=!libs!;
 
 set libs=!libs!;
 
-%java_bin% -Xmx%javaMemorySizeXmx% %javaRemoteDebugging% -cp !libs! org.eclipse.mosaic.starter.MosaicStarter %*
+"%java_bin%" -Xmx%javaMemorySizeXmx% %javaRemoteDebugging% -cp !libs! org.eclipse.mosaic.starter.MosaicStarter %*
 
 EndLocal
 

--- a/bundle/src/assembly/resources/bin/mosaic.bat
+++ b/bundle/src/assembly/resources/bin/mosaic.bat
@@ -7,6 +7,12 @@ set javaMemorySizeXmx=2G
 REM uncomment to activate remote debugging
 REM set javaRemoteDebugging=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000
 
+if "%JAVA_HOME%"=="" (
+  set java_bin=java
+) else (
+  set java_bin=%JAVA_HOME%\bin\java
+)
+
 set libs=
 
 rem core components
@@ -25,7 +31,7 @@ if not "!libs!" == "" set libs=!libs!;
 
 set libs=!libs!;
 
-java -Xmx%javaMemorySizeXmx% %javaRemoteDebugging% -cp !libs! org.eclipse.mosaic.starter.MosaicStarter %*
+%java_bin% -Xmx%javaMemorySizeXmx% %javaRemoteDebugging% -cp !libs! org.eclipse.mosaic.starter.MosaicStarter %*
 
 EndLocal
 

--- a/bundle/src/assembly/resources/bin/mosaic.sh
+++ b/bundle/src/assembly/resources/bin/mosaic.sh
@@ -25,5 +25,5 @@ tmp=`ls ${dir_libs} | grep jar`
 libs=${dir_libs}/${tmp//[^A-Za-z0-9\-\.]/:${dir_libs}/}
 
 # create and run command
-cmd="${java_bin} -Xmx${javaMemorySizeXmx} ${javaRemoteDebugging} -cp .:${mosaic}:${libs} org.eclipse.mosaic.starter.MosaicStarter $*"
-$cmd
+cmd="\"${java_bin}\" -Xmx${javaMemorySizeXmx} ${javaRemoteDebugging} -cp .:${mosaic}:${libs} org.eclipse.mosaic.starter.MosaicStarter $*"
+eval $cmd

--- a/bundle/src/assembly/resources/bin/mosaic.sh
+++ b/bundle/src/assembly/resources/bin/mosaic.sh
@@ -7,6 +7,13 @@ javaMemorySizeXmx="2g"
 # uncomment to activate remote debugging
 # javaRemoteDebugging="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000"
 
+# check if JAVA_HOME is set and define path to java binary accordingly (variable: java_bin)
+if [ -z "${JAVA_HOME}" ]; then
+  java_bin=java
+else
+  java_bin=${JAVA_HOME}/bin/java
+fi
+
 # mosaic
 dir_mosaic=./lib/mosaic
 tmp=`ls ${dir_mosaic} | grep jar`
@@ -18,5 +25,5 @@ tmp=`ls ${dir_libs} | grep jar`
 libs=${dir_libs}/${tmp//[^A-Za-z0-9\-\.]/:${dir_libs}/}
 
 # create and run command
-cmd="java -Xmx${javaMemorySizeXmx} ${javaRemoteDebugging} -cp .:${mosaic}:${libs} org.eclipse.mosaic.starter.MosaicStarter $*"
+cmd="${java_bin} -Xmx${javaMemorySizeXmx} ${javaRemoteDebugging} -cp .:${mosaic}:${libs} org.eclipse.mosaic.starter.MosaicStarter $*"
 $cmd


### PR DESCRIPTION
## Description

In the MOSAIC starter scripts `mosaic.sh` and `mosaic.bat` the path to the Java binary is built with JAVA_HOME if set.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 768
  
## Affected parts of the online documentation

no change in the documentation is required

## Definition of Done

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [ ] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

