### PR TITLE
build: raise mockito to be compatible with JDK 23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.janino>3.1.11</version.janino><!-- 3.1.11 is approved in #13292 and #13293  -->
         <version.jsch>0.2.16</version.jsch><!-- 0.2.16 is approved in #8468 -->
         <version.logback>1.5.0</version.logback><!-- 1.5.0 is approved in #13282 and 13283 -->
-        <version.mockito>5.6.0</version.mockito><!-- approval not required, we do not ship this library -->
+        <version.mockito>5.15.2</version.mockito><!-- approval not required, we do not ship this library -->
         <version.mapdb>1.0.8</version.mapdb><!-- 1.0.8 approved in CQ8246 -->
         <version.opencsv>5.9</version.opencsv><!-- 5.9 is approved in #17586 -->
         <version.protobuf>3.23.2</version.protobuf><!-- 3.8.0 is approved in #8634 -->


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

Bump mockito to 5.15.2 to solve problems with JDK 23.

`mvn -site` still does not work with JDK23 since spotbugs plugin would need to be upgraded too. That, however, would raise too many new Spotbugs errors. When we want to upgrade spotbugs, we need to check our spotbugs-configuration.

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

