### PR TITLE
build: Added Develocity setup 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 .flattened-pom.xml
 
+# Develocity
+.mvn/.develocity/develocity-workspace-id
+
 # MOSAIC
 
 *.log

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>automotive.mosaic</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['JENKINS_URL'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['JENKINS_URL'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Size](https://img.shields.io/github/repo-size/eclipse/mosaic.svg) <br>
 [![Build](https://github.com/eclipse/mosaic/workflows/Java%20CI%20with%20Maven/badge.svg)](https://github.com/eclipse/mosaic/actions?query=branch%3Amain+workflow%3A%22Java+CI+with+Maven%22)
 [![Jenkins Build](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fmosaic%2Fjob%2Fmosaic%2Fjob%2Fmain&label=Jenkins%20build)](https://ci.eclipse.org/mosaic/job/mosaic/)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity-staging.eclipse.org/)
 
 
 [**Eclipse MOSAIC**](https://eclipse.dev/mosaic) is a multi-scale simulation framework in the field of smart and connected mobility.


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue #466.

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Local and remote caching was left disabled on this PR by design so that the build is not affected by this change.

The build scans of the Eclipse Mosaic project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Mosaic project and all other Eclipse projects.

On this Develocity instance, the Eclipse Mosaic project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. 

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**

This PR will remain a draft until the CI is configured by Eclipse Infra team.

## Issue(s) related to this PR

* Resolves issue #466 

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

Since this applies changes to the Jenkinsfile and this is coming from an untrusted fork, even after applying the CI configuration, Jenkins will not apply the changed Jenkinsfile for this PR.

