### PR TITLE
fix(application): complete VehicleRoute object if it is missing node ids or connection ids

### DIFF
--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/SimulationKernel.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/SimulationKernel.java
@@ -302,7 +302,10 @@ public enum SimulationKernel {
      * @param route the {@link VehicleRoute} to register
      */
     public void registerRoute(String id, VehicleRoute route) {
-        routes.put(id, Validate.notNull(route, "The given route must not be null."));
+        VehicleRoute completedRoute = getCentralNavigationComponent().refineRoute(
+                Validate.notNull(route, "The given route must not be null.")
+        );
+        routes.put(id, completedRoute);
     }
 
     /**

--- a/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/navigation/CentralNavigationComponent.java
+++ b/fed/mosaic-application/src/main/java/org/eclipse/mosaic/fed/application/ambassador/simulation/navigation/CentralNavigationComponent.java
@@ -492,6 +492,17 @@ public class CentralNavigationComponent {
     }
 
     /**
+     * This method completes a route definition if it is missing either
+     * a list of node ids or connection ids, but provides the other.
+     *
+     * @param route the potentially incomplete {@link VehicleRoute}
+     * @return the completed {@link VehicleRoute} with list of node ids and connection ids
+     */
+    public VehicleRoute refineRoute(VehicleRoute route) {
+        return vehicleRouting.refineRoute(route);
+    }
+
+    /**
      * Calculates the distance to a node given the current position
      * along a given route.<br><br>
      * The {@code upcomingNode} is important, so that the distance from the

--- a/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassadorTest.java
+++ b/fed/mosaic-application/src/test/java/org/eclipse/mosaic/fed/application/ambassador/ApplicationAmbassadorTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -143,6 +144,12 @@ public class ApplicationAmbassadorTest {
         Mockito.doAnswer((i) -> recentAdvanceTime).when(rtiAmbassador).getNextEventTimestamp();
 
         recentAdvanceTime = 0;
+    }
+
+    @Before
+    public void setupRouteRefinement() {
+        when(SimulationKernel.SimulationKernel.getCentralNavigationComponent().refineRoute(isA(VehicleRoute.class)))
+                .thenAnswer(c -> c.getArguments()[0]);
     }
 
     @After

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/VehicleRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/VehicleRouting.java
@@ -76,6 +76,17 @@ public interface VehicleRouting {
     IRoadPosition refineRoadPosition(IRoadPosition roadPosition);
 
     /**
+     * This method completes a route definition if it is missing either
+     * a list of node ids or connection ids, but provides the other.
+     *
+     * @param route the potentially incomplete {@link VehicleRoute}
+     * @return the completed {@link VehicleRoute} with list of node ids and connection ids
+     *
+     * @throws IllegalStateException if the route contains neither node ids nor connection ids
+     */
+    VehicleRoute refineRoute(VehicleRoute route);
+
+    /**
      * Approximates the costs of a {@link CandidateRoute}. Pass a {@link CandidateRoute}
      * and the ID of the last Node the vehicle passed on to the method and it will return a new
      * Candidate route with the approximated values in its "length" and "time" field.

--- a/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/norouting/NoRouting.java
+++ b/lib/mosaic-routing/src/main/java/org/eclipse/mosaic/lib/routing/norouting/NoRouting.java
@@ -74,6 +74,11 @@ public class NoRouting implements VehicleRouting {
     }
 
     @Override
+    public VehicleRoute refineRoute(VehicleRoute route) {
+        return route;
+    }
+
+    @Override
     public CandidateRoute approximateCostsForCandidateRoute(CandidateRoute route, String lastNodeId) {
         return route;
     }

--- a/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/database/DatabaseRoutingTest.java
+++ b/lib/mosaic-routing/src/test/java/org/eclipse/mosaic/lib/routing/database/DatabaseRoutingTest.java
@@ -35,6 +35,7 @@ import org.eclipse.mosaic.lib.routing.RoutingResponse;
 import org.eclipse.mosaic.lib.routing.config.CVehicleRouting;
 import org.eclipse.mosaic.rti.api.InternalFederateException;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -294,6 +295,32 @@ public class DatabaseRoutingTest {
         CandidateRoute approximatedCandidateRoute = spyRSDB.approximateCostsForCandidateRoute(candidateRoute, "1");
         assertEquals(1010, approximatedCandidateRoute.getLength(), 0);
         assertEquals(505, approximatedCandidateRoute.getTime(), 0);
+    }
+
+    @Test
+    public void refineRoute_fillNodeIds() throws InternalFederateException {
+        configuration.source = "tiergarten.db";
+        databaseRouting.initialize(configuration, cfgDir);
+
+        VehicleRoute route = databaseRouting.refineRoute(new VehicleRoute("0",
+                Lists.newArrayList( "4068038_423839224_26704448", "36337928_26704448_27537750", "4609244_27537750_27537749"),
+                Lists.newArrayList(), 0));
+
+        assertEquals(Lists.newArrayList("423839224", "26704448", "27537750", "27537749"), route.getNodeIds());
+        assertEquals(85.92, route.getLength(), 0.1);
+    }
+
+    @Test
+    public void refineRoute_fillConnectionIds() throws InternalFederateException {
+        configuration.source = "tiergarten.db";
+        databaseRouting.initialize(configuration, cfgDir);
+
+        VehicleRoute route = databaseRouting.refineRoute(new VehicleRoute("0",
+                Lists.newArrayList(),
+                Lists.newArrayList("423839224", "26704448", "27537750", "27537749"), 0));
+
+        assertEquals(Lists.newArrayList( "4068038_423839224_26704448", "36337928_26704448_27537750", "4609244_27537750_27537749"), route.getConnectionIds());
+        assertEquals(85.92, route.getLength(), 0.1);
     }
 
 }


### PR DESCRIPTION
## Description

If SumoAmbassador is started with a SUMO configuration which includes routes, then all routes from SUMO are read via TraCI and send to the RTI. The application ambassador stores these `VehicleRoute`s in an internal cache. If the application simulator already have a route internally with the same ID, it is overridden with the new `VehicleRoute` object coming from SUMO.

There is one major issue: All `VehicleRoute` objects created by SumoAmbassador only contain a list of connection IDs. The list of node IDs is always empty. This leads to the problem, that applications which want to use these routes cannot do stuff like `getOs().getNavigationModule().getCurrentRoute().getLastNodeId()`, which is useful for dynamic route calculation. 

This PR therefore adds the functionality, that the `VehicleRoute` object is always completed/filled with the missing list of nodes or connections, as long at least one of these properties exists. If both are already given, nothing happens. 

We still override the VehicleRoute in the internal cache of the application simulator, as this is the source of truth when coming from SUMO.

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Resolves internal issue 1006
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required?

No

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [x] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [x] `origin/main` has been merged into your Fork.
- [x] Coding guidelines have been followed (see CONTRIBUTING.md).
- [x] All checks on GitHub pass.
- [x] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [x] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [x] There are no new SpotBugs warnings.

## Special notes to reviewer

