### PR TITLE
test: use different scenario config file in integration tests

### DIFF
--- a/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/junit/MosaicSimulationRule.java
+++ b/test/mosaic-integration-tests/src/test/java/org/eclipse/mosaic/test/junit/MosaicSimulationRule.java
@@ -178,23 +178,27 @@ public class MosaicSimulationRule extends TemporaryFolder {
         return runtimeConfiguration;
     }
 
-    public MosaicSimulation.SimulationResult executeTestScenario(String name) {
-        return executeSimulation("..", "scenarios", name);
+    public MosaicSimulation.SimulationResult executeTestScenario(String folder) {
+        return executeSimulation(Paths.get("..", "scenarios", folder));
     }
 
-    public MosaicSimulation.SimulationResult executeReleaseScenario(String name) {
-        return executeSimulation("..", "..", "bundle", "src", "assembly", "resources", "scenarios", name);
+    public MosaicSimulation.SimulationResult executeTestScenario(String folder, String config) {
+        return executeSimulation(Paths.get("..", "scenarios", folder), config);
     }
 
-    public MosaicSimulation.SimulationResult executeSimulation(String first, String... other) {
-        return executeSimulation(Paths.get(first, other));
+    public MosaicSimulation.SimulationResult executeReleaseScenario(String folder) {
+        return executeSimulation(Paths.get("..", "..", "bundle", "src", "assembly", "resources", "scenarios", folder));
     }
 
     public MosaicSimulation.SimulationResult executeSimulation(Path scenarioDirectory) {
+        return executeSimulation(scenarioDirectory, "scenario_config.json");
+    }
+
+    public MosaicSimulation.SimulationResult executeSimulation(Path scenarioDirectory, String config) {
         try {
             return executeSimulation(scenarioDirectory,
                     new ObjectInstantiation<>(CScenario.class)
-                            .readFile(scenarioDirectory.resolve("scenario_config.json").toFile())
+                            .readFile(scenarioDirectory.resolve(config).toFile())
             );
         } catch (InstantiationException e) {
             LOG.error("", e);


### PR DESCRIPTION
## Description

<!--- ( write down a useful description of the problem or issue and what your solution provides ) -->

With this change, we can configure which scenario config is chosen in integration test. We can use a different file name than just always hardcoded `scenario_config.json`

## Issue(s) related to this PR

<!--- ( if no issue provided, remove this part ) -->

* Addresses internal issue 940
  
## Affected parts of the online documentation

<!--- ( write down if there is any change to be made in the online documentation at eclipse.org/mosaic, the maintainers will apply those after merging ) -->

Changes in the documentation required? No.

## Definition of Done

<!--- ( to be checked by the author ) -->

**Prerequisites**

- [x] You have read CONTRIBUTING.md carefully.
- [x] You have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] Your GitHub user id is linked with your Eclipse Account.

**Required**

- [x] The title of this merge request follows the scheme `type(scope): description`  (in the style of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary))
- [ ] You have assigned a suitable label to this pull request (e.g., `enhancement`, or `bugfix`)
- [ ] `origin/main` has been merged into your Fork.
- [ ] Coding guidelines have been followed (see CONTRIBUTING.md).
- [ ] All checks on GitHub pass.
- [ ] All tests on [Jenkins](https://ci.eclipse.org/mosaic/job/mosaic/) pass.

**Requested** (can be enforced by maintainers)

- [ ] New functionality is covered by unit tests or integration tests. Code coverage must not decrease.
- [ ] If a bug has been fixed, a new unit test has been written (beforehand) to prove misbehavior
- [ ] There are no new SpotBugs warnings.

## Special notes to reviewer

